### PR TITLE
Disable Version Vector

### DIFF
--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -315,7 +315,7 @@ private:
         }
         C4DatabaseConfig2 c4Config = {};
         c4Config.parentDirectory = effectiveDir(config->directory);
-        c4Config.flags = kC4DB_Create | kC4DB_VersionVectors;
+        c4Config.flags = kC4DB_Create;
 #ifdef COUCHBASE_ENTERPRISE
         c4Config.encryptionKey = asC4Key(&config->encryptionKey);
 #endif

--- a/test/DatabaseTest.cc
+++ b/test/DatabaseTest.cc
@@ -162,7 +162,7 @@ TEST_CASE_METHOD(CBLTest, "Save Empty Document") {
 
     doc = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
     CHECK(CBLDocument_ID(doc) == "foo"_sl);
-    CHECK(CBLDocument_RevisionID(doc) == "1@*"_sl);
+    CHECK(CBLDocument_RevisionID(doc) == "1-581ad726ee407c8376fc94aad966051d013893c4"_sl);
     CHECK(CBLDocument_Sequence(doc) == 1);
     CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{}"_sl);
     CBLDocument_Release(doc);


### PR DESCRIPTION
We will not support Version Vector in Lithium so disable version vector when creating the database.