### PR TITLE
CBL-2083: Change to official library name and version

### DIFF
--- a/CBL_C.xcodeproj/xcshareddata/xcschemes/CBL_C Dylib.xcscheme
+++ b/CBL_C.xcodeproj/xcshareddata/xcschemes/CBL_C Dylib.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27B61D6F21D6B64A0027CCDB"
-               BuildableName = "libCouchbaseLiteC.dylib"
+               BuildableName = "libcblite.dylib"
                BlueprintName = "CBL_C Dylib"
                ReferencedContainer = "container:CBL_C.xcodeproj">
             </BuildableReference>
@@ -70,7 +70,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "271C2A2221CAC8920045856E"
-            BuildableName = "libCouchbaseLiteC-static.a"
+            BuildableName = "libcblite-static.a"
             BlueprintName = "CBL_C"
             ReferencedContainer = "container:CBL_C.xcodeproj">
          </BuildableReference>

--- a/CBL_C.xcodeproj/xcshareddata/xcschemes/CBL_C.xcscheme
+++ b/CBL_C.xcodeproj/xcshareddata/xcschemes/CBL_C.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "271C2A2221CAC8920045856E"
-               BuildableName = "libCouchbaseLiteC-static.a"
+               BuildableName = "libcblite-static.a"
                BlueprintName = "CBL_C"
                ReferencedContainer = "container:CBL_C.xcodeproj">
             </BuildableReference>
@@ -49,7 +49,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "271C2A2221CAC8920045856E"
-            BuildableName = "libCouchbaseLiteC-static.a"
+            BuildableName = "libcblite-static.a"
             BlueprintName = "CBL_C"
             ReferencedContainer = "container:CBL_C.xcodeproj">
          </BuildableReference>
@@ -72,7 +72,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "271C2A2221CAC8920045856E"
-            BuildableName = "libCouchbaseLiteC-static.a"
+            BuildableName = "libcblite-static.a"
             BlueprintName = "CBL_C"
             ReferencedContainer = "container:CBL_C.xcodeproj">
          </BuildableReference>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ project (
 )
 
 set(CBL_LIB_VERSION "3.0.0")
-set(CBL_LIB_SOVERSION "6")
 
 ### BUILD SETTINGS:
 
@@ -121,9 +120,9 @@ set(
     ${PLATFORM_SRC}
 )
 
-add_library(CouchbaseLiteCStatic STATIC ${ALL_SRC_FILES})
+add_library(cblite-static STATIC ${ALL_SRC_FILES})
 target_include_directories(
-    CouchbaseLiteCStatic PUBLIC
+    cblite-static PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/generated_headers/public/cbl/>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/>
@@ -131,7 +130,7 @@ target_include_directories(
 )
 set_platform_include_directories(RESULT PLATFORM_INCLUDE)
 target_include_directories(
-    CouchbaseLiteCStatic
+    cblite-static
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/cbl
     src
@@ -141,14 +140,14 @@ target_include_directories(
 )
 
 target_link_libraries(
-    CouchbaseLiteCStatic INTERFACE
+    cblite-static INTERFACE
     LiteCoreStatic
 )
 
 file(WRITE empty.cpp)
-add_library(CouchbaseLiteC SHARED empty.cpp)
+add_library(cblite SHARED empty.cpp)
 target_include_directories(
-    CouchbaseLiteC PUBLIC
+    cblite PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/generated_headers/public/cbl/>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/>
@@ -156,7 +155,7 @@ target_include_directories(
 )
 
 target_include_directories(
-    CouchbaseLiteC
+    cblite
     PRIVATE
     src
     vendor/couchbase-lite-core/C
@@ -166,7 +165,7 @@ target_include_directories(
 
 set(CBL_LIBRARIES_PRIVATE
     ${WHOLE_LIBRARY_FLAG}
-    CouchbaseLiteCStatic
+    cblite-static
     ${NO_WHOLE_LIBRARY_FLAG}
     LiteCoreWebSocket
 )
@@ -177,7 +176,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^armv[67]")
                               atomic)
 endif()
 
-target_link_libraries(CouchbaseLiteC PRIVATE ${CBL_LIBRARIES_PRIVATE})
+target_link_libraries(cblite PRIVATE ${CBL_LIBRARIES_PRIVATE})
 
 set_dylib_properties()
 
@@ -190,7 +189,7 @@ else()
 endif()
 
 install(
-    TARGETS CouchbaseLiteC
+    TARGETS cblite
     EXPORT CouchbaseLiteTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
@@ -204,8 +203,8 @@ install(FILES ${C_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl)
 install(FILES ${PROJECT_BINARY_DIR}/generated_headers/public/cbl/CBL_Edition.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl)
 install(FILES ${FLEECE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fleece)
 
-configure_file(CouchbaseLiteC.pc.in CouchbaseLiteC.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CouchbaseLiteC.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+configure_file(cblite.pc.in cblite.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cblite.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 include(CMakePackageConfigHelpers)
 set(TARGETS_EXPORT_NAME "CouchbaseLiteTargets")
@@ -219,7 +218,7 @@ write_basic_package_version_file(
     VERSION ${CBL_LIBRARY_VERSION} COMPATIBILITY SameMajorVersion
 )
 
-install(FILES ${CMAKE_BINARY_DIR}/CouchbaseLiteConfig.cmake
+install(FILES ${CMAKE_BINARY_DIR}/cbliteonfig.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CouchbaseLite)
 
 ### TESTS:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ project (
     VERSION 3.0.0
 )
 
-set(CBL_LIB_VERSION "3.0.0")
+set(CBL_LIB_VERSION ${CouchbaseLite_C_VERSION})
+set(CBL_API_VERSION ${CouchbaseLite_C_VERSION_MAJOR})
 
 ### BUILD SETTINGS:
 
@@ -179,6 +180,7 @@ endif()
 target_link_libraries(cblite PRIVATE ${CBL_LIBRARIES_PRIVATE})
 
 set_dylib_properties()
+set_target_properties(cblite PROPERTIES VERSION "${CBL_LIB_VERSION}" SOVERSION "${CBL_API_VERSION}")
 
 ## Installation
 
@@ -218,7 +220,7 @@ write_basic_package_version_file(
     VERSION ${CBL_LIBRARY_VERSION} COMPATIBILITY SameMajorVersion
 )
 
-install(FILES ${CMAKE_BINARY_DIR}/cbliteonfig.cmake
+install(FILES ${CMAKE_BINARY_DIR}/CouchbaseLiteConfig.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CouchbaseLite)
 
 ### TESTS:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Dependencies:
 3. Run the shellscript `build.sh`
 6. Run the unit tests, with `test.sh`
 
-The library is at `build_cmake/libCouchbaseLiteC.so`. (Or `.DLL` or `.dylib`)
+The library is at `build_cmake/libcblite.so`. (Or `.DLL` or `.dylib`)
 
 ### With CMake on Windows
 

--- a/Xcode/xcconfigs/CBL_static.xcconfig
+++ b/Xcode/xcconfigs/CBL_static.xcconfig
@@ -8,7 +8,7 @@
 
 #include "vendor/couchbase-lite-core/Xcode/xcconfigs/static_lib.xcconfig"
 
-PRODUCT_NAME                = CouchbaseLiteC-static
+PRODUCT_NAME                = cblite-static
 
 DSTROOT                     = /tmp/couchbase_lite_C.dst
 HEADER_SEARCH_PATHS         = $(LITECORE)/C/include $(LITECORE)/C/Cpp_include $(LITECORE)/C  $(LITECORE)/LiteCore/Support  $(FLEECE)/API  $(FLEECE)/Fleece/Support $(SRCROOT)/include

--- a/bindings/nim/README.md
+++ b/bindings/nim/README.md
@@ -22,14 +22,14 @@ You first need to build Couchbase Lite For C (the root of this repo) with CMake,
 Symlink or copy the library into this directory.
 
     $ cd bindings/nim
-    $ ln -s ../../build_cmake/libCouchbaseLiteC.dylib .
+    $ ln -s ../../build_cmake/libcblite.dylib .
 
 After that, you can use [Nimble][NIMBLE] to build and run:
 
     $ nimble test
 
 When compiling on Linux system remember to set `LD_LIBRARY_PATH` to point to the
-directory where `libCouchbaseLiteC.so` exists. If you followed the above steps
+directory where `libcblite.so` exists. If you followed the above steps
 this would look like this:
 
     $ LD_LIBRARY_PATH=. nimble test

--- a/bindings/nim/src/CouchbaseLite/private/cbl.nim
+++ b/bindings/nim/src/CouchbaseLite/private/cbl.nim
@@ -11,11 +11,11 @@
 
 
 when defined(Linux):
-  {.push dynlib: "libCouchbaseLiteC.so".}
+  {.push dynlib: "libcblite.so".}
 elif defined(MacOS) or defined(MacOSX):
-  {.push dynlib: "libCouchbaseLiteC.dylib".}
+  {.push dynlib: "libcblite.dylib".}
 elif defined(Windows):
-  {.push dynlib: "libCouchbaseLiteC.dll".}
+  {.push dynlib: "cblite.dll".}
 
 
 ##

--- a/bindings/nim/src/CouchbaseLite/private/fl.nim
+++ b/bindings/nim/src/CouchbaseLite/private/fl.nim
@@ -11,11 +11,11 @@
 
 
 when defined(Linux):
-  {.push dynlib: "libCouchbaseLiteC.so".}
+  {.push dynlib: "libcblite.so".}
 elif defined(MacOS) or defined(MacOSX):
-  {.push dynlib: "libCouchbaseLiteC.dylib".}
+  {.push dynlib: "libcblite.dylib".}
 elif defined(Windows):
-  {.push dynlib: "CouchbaseLiteC.dll".}
+  {.push dynlib: "cblite.dll".}
 
 
 ##   FLSlice.h

--- a/bindings/python/BuildPyCBL.py
+++ b/bindings/python/BuildPyCBL.py
@@ -36,7 +36,7 @@ CBL_INCLUDE_DIR    = "/include"
 FLEECE_INCLUDE_DIR = "/vendor/couchbase-lite-core/vendor/fleece/API"
 
 # CMake settings are defaults, but overrideable on command-line
-DEFAULT_LIBRARIES = "CouchbaseLiteC z"
+DEFAULT_LIBRARIES = "cblite z"
 DEFAULT_LIBRARY_DIR  = DEFAULT_SRC_DIR + "build_cmake/"
 
 # Extra linker arguments -- platform-specific
@@ -56,7 +56,7 @@ def BuildLibrary(sourceDir, python_includedir, libdir, libraries, extra_link_arg
     libdir = os.path.relpath(libdir)
 
     # Copy the CBL library here:
-    libpath = libdir + "/libCouchbaseLiteC"
+    libpath = libdir + "/libcblite"
     if platform.system() == "Darwin":
         libpath += ".dylib"
     else:

--- a/bindings/rust/CouchbaseLite/build.rs
+++ b/bindings/rust/CouchbaseLite/build.rs
@@ -74,7 +74,7 @@ fn main() {
         .write_to_file(out_dir.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 
-    // Tell cargo to tell rustc to link the CouchbaseLiteC shared library.
+    // Tell cargo to tell rustc to link the cblite shared library.
     //TODO: Abort the build now if the library does not exist, and tell the user to run CMake.
     let root = root_dir.to_str().unwrap();
 
@@ -86,7 +86,7 @@ fn main() {
         println!("cargo:rustc-link-search={}/build_cmake/vendor/couchbase-lite-core/vendor/mbedtls/library", root);
         println!("cargo:rustc-link-search={}/build_cmake/vendor/couchbase-lite-core/vendor/sqlite3-unicodesn", root);
 
-        println!("cargo:rustc-link-lib=static=CouchbaseLiteCStatic");
+        println!("cargo:rustc-link-lib=static=cblite-static");
         println!("cargo:rustc-link-lib=static=FleeceStatic");
 
         println!("cargo:rustc-link-lib=static=liteCoreStatic");
@@ -106,13 +106,13 @@ fn main() {
         println!("cargo:rustc-link-lib=framework=SystemConfiguration");
     } else {
         // Copy the CBL dylib:
-        let src = root_dir.join("build_cmake/libCouchbaseLiteC.dylib");
-        let dst = out_dir.join("libCouchbaseLiteC.dylib");
+        let src = root_dir.join("build_cmake/libcblite.dylib");
+        let dst = out_dir.join("libcblite.dylib");
         println!("cargo:rerun-if-changed={}", src.to_str().unwrap());
         fs::copy(src, dst).expect("copy dylib");
         // Tell rustc to link it:
         println!("cargo:rustc-link-search={}", out_dir.to_str().unwrap());
-        println!("cargo:rustc-link-lib=dylib=CouchbaseLiteC");
+        println!("cargo:rustc-link-lib=dylib=cblite");
     }
 
     // Tell cargo to invalidate the built crate whenever the wrapper changes

--- a/cblite.pc.in
+++ b/cblite.pc.in
@@ -3,8 +3,8 @@ exec_prefix=${prefix}
 libdir=@CMAKE_INSTALL_LIBDIR@
 includedir=@CMAKE_INSTALL_INCLUDEDIR@
 
-Name: CouchbaseLiteC
+Name: cblite
 Description: Couchbase Lite for C
 Version: @CBL_LIB_VERSION@
-Libs: -L${libdir} -lCouchbaseLiteC
+Libs: -L${libdir} -lcblite
 Cflags: -I${includedir}

--- a/cmake/CouchbaseLiteConfig.cmake.in
+++ b/cmake/CouchbaseLiteConfig.cmake.in
@@ -1,4 +1,4 @@
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
-check_required_components(CouchbaseLiteC)
+check_required_components(cblite)

--- a/cmake/cblite.rc.in
+++ b/cmake/cblite.rc.in
@@ -1,0 +1,34 @@
+#include <winresrc.h>
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION
+@CouchbaseLite_C_VERSION_MAJOR@,@CouchbaseLite_C_VERSION_MINOR@,@CouchbaseLite_C_VERSION_PATCH@,0
+PRODUCTVERSION @CouchbaseLite_C_VERSION_MAJOR@,@CouchbaseLite_C_VERSION_MINOR@,@CouchbaseLite_C_VERSION_PATCH@,0
+FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifndef NDEBUG
+FILEFLAGS 0
+#else
+FILEFLAGS VER_DEBUG
+#endif
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+BLOCK "StringFileInfo"
+BEGIN
+BLOCK "04090000"
+BEGIN
+VALUE "FileDescription", "Couchbase Lite for C"
+VALUE "FileVersion", "@CouchbaseLite_C_VERSION@"
+VALUE "InternalName", "cblite"
+VALUE "LegalCopyright", "Copyright 2021 Couchbase"
+VALUE "OriginalFilename", "cblite.dll"
+VALUE "ProductName", "Couchbase Lite"
+VALUE "ProductVersion", "@CouchbaseLite_C_VERSION@"
+END
+END
+BLOCK "VarFileInfo"
+BEGIN
+VALUE "Translation", 0x409, 1200
+END
+END

--- a/cmake/platform_android.cmake
+++ b/cmake/platform_android.cmake
@@ -15,6 +15,6 @@ endfunction()
 function(set_dylib_properties)
     set_exported_symbols_file()
     
-    target_compile_definitions(CouchbaseLiteCStatic PRIVATE -D_CRYPTO_MBEDTLS)
-    target_link_libraries(CouchbaseLiteC PRIVATE atomic log zlibstatic)
+    target_compile_definitions(cblite-static PRIVATE -D_CRYPTO_MBEDTLS)
+    target_link_libraries(cblite PRIVATE atomic log zlibstatic)
 endfunction()

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -23,15 +23,15 @@ endfunction()
 function(set_dylib_properties)
     if(BUILD_ENTERPRISE)
         set_target_properties(
-            CouchbaseLiteC PROPERTIES LINK_FLAGS
+            cblite PROPERTIES LINK_FLAGS
             "-exported_symbols_list ${PROJECT_SOURCE_DIR}/src/exports/generated/CBL_EE.exp")
     else()
         set_target_properties(
-            CouchbaseLiteC PROPERTIES LINK_FLAGS
+            cblite PROPERTIES LINK_FLAGS
             "-exported_symbols_list ${PROJECT_SOURCE_DIR}/src/exports/generated/CBL.exp")
     endif()
     
-    target_link_libraries(CouchbaseLiteC PUBLIC
+    target_link_libraries(cblite PUBLIC
             "-framework CoreFoundation"
             "-framework Foundation"
             "-framework CFNetwork"

--- a/cmake/platform_linux.cmake
+++ b/cmake/platform_linux.cmake
@@ -6,11 +6,11 @@ endfunction()
 function(set_exported_symbols_file)
     if(BUILD_ENTERPRISE)
         set_target_properties(
-            CouchbaseLiteC PROPERTIES LINK_FLAGS
+            cblite PROPERTIES LINK_FLAGS
             "-Wl,--version-script=${PROJECT_SOURCE_DIR}/src/exports/generated/CBL_EE.gnu")
     else()
                 set_target_properties(
-            CouchbaseLiteC PROPERTIES LINK_FLAGS
+            cblite PROPERTIES LINK_FLAGS
             "-Wl,--version-script=${PROJECT_SOURCE_DIR}/src/exports/generated/CBL.gnu")
     endif()
 endfunction()

--- a/cmake/platform_linux_desktop.cmake
+++ b/cmake/platform_linux_desktop.cmake
@@ -50,6 +50,4 @@ function(set_dylib_properties)
         $<INSTALL_INTERFACE:icudata>
         $<INSTALL_INTERFACE:icui18n>
     )
-
-    set_target_properties(cblite PROPERTIES SOVERSION "${CBL_LIB_VERSION}")
 endfunction()

--- a/cmake/platform_linux_desktop.cmake
+++ b/cmake/platform_linux_desktop.cmake
@@ -40,14 +40,16 @@ function(set_dylib_properties)
     set_exported_symbols_file()
    
     foreach(LIB ${ICU_LIBS})
-        target_link_libraries(CouchbaseLiteC PUBLIC $<BUILD_INTERFACE:${LIB}>)
+        target_link_libraries(cblite PUBLIC $<BUILD_INTERFACE:${LIB}>)
     endforeach()
  
     target_link_libraries(
-        CouchbaseLiteC PUBLIC
+        cblite PUBLIC
         z
         $<INSTALL_INTERFACE:icuuc>
         $<INSTALL_INTERFACE:icudata>
         $<INSTALL_INTERFACE:icui18n>
     )
+
+    set_target_properties(cblite PROPERTIES SOVERSION "${CBL_LIB_VERSION}")
 endfunction()

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -70,4 +70,11 @@ function(set_dylib_properties)
     
     target_link_libraries(cblite PRIVATE zlibstatic Ws2_32)
     target_compile_definitions(cblite-static PRIVATE LITECORE_EXPORTS)
+
+    configure_file(
+        "${PROJECT_SOURCE_DIR}/cmake/cblite.rc.in"
+        "${PROJECT_BINARY_DIR}/cblite.rc"
+    )
+
+    target_sources(cblite PRIVATE "${PROJECT_BINARY_DIR}/cblite.rc")
 endfunction()

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -46,12 +46,12 @@ endfunction()
 
 function(set_dylib_properties)
     if(WINDOWS_STORE)
-        target_compile_definitions(CouchbaseLiteCStatic PRIVATE -DMBEDTLS_NO_PLATFORM_ENTROPY)
-        set_target_properties(CouchbaseLiteC PROPERTIES COMPILE_FLAGS /ZW)
+        target_compile_definitions(cblite-static PRIVATE -DMBEDTLS_NO_PLATFORM_ENTROPY)
+        set_target_properties(cblite PROPERTIES COMPILE_FLAGS /ZW)
 
         # Not that happy about this, but I'm too lazy right now to rework LiteCore
         target_sources(
-            CouchbaseLiteC PRIVATE
+            cblite PRIVATE
             vendor/couchbase-lite-core/MSVC/SQLiteTempDirectory.cc
         )
         
@@ -60,14 +60,14 @@ function(set_dylib_properties)
     
     if(BUILD_ENTERPRISE)
         set_target_properties(
-            CouchbaseLiteC PROPERTIES LINK_FLAGS
+            cblite PROPERTIES LINK_FLAGS
             "/def:${PROJECT_SOURCE_DIR}/src/exports/generated/CBL_EE.def")
     else()
         set_target_properties(
-            CouchbaseLiteC PROPERTIES LINK_FLAGS
+            cblite PROPERTIES LINK_FLAGS
             "/def:${PROJECT_SOURCE_DIR}/src/exports/generated/CBL.def")
     endif()
     
-    target_link_libraries(CouchbaseLiteC PRIVATE zlibstatic Ws2_32)
-    target_compile_definitions(CouchbaseLiteCStatic PRIVATE LITECORE_EXPORTS)
+    target_link_libraries(cblite PRIVATE zlibstatic Ws2_32)
+    target_compile_definitions(cblite-static PRIVATE LITECORE_EXPORTS)
 endfunction()

--- a/jenkins/server_build_unix.sh
+++ b/jenkins/server_build_unix.sh
@@ -39,7 +39,7 @@ esac
 
 project_dir=couchbase-lite-c
 strip_dir=${project_dir}
-macosx_lib="libCouchbaseLiteC.dylib"
+macosx_lib="libcblite.dylib"
 
 echo VERSION=${VERSION}
 # Global define end
@@ -54,7 +54,7 @@ if [[ ${OS} == 'linux' ]]; then
     ${WORKSPACE}/couchbase-lite-c/jenkins/strip.sh ${strip_dir}
 else
     pushd ${project_dir}
-    dsymutil ${macosx_lib} -o libCouchbaseLiteC.dylib.dSYM
+    dsymutil ${macosx_lib} -o libcblite.dylib.dSYM
     strip -x ${macosx_lib}
     popd
 fi
@@ -62,10 +62,10 @@ fi
 make install
 if [[ ${OS} == 'macosx' ]]; then
     # package up the strip symbols
-    cp -rp ${strip_dir}/libCouchbaseLiteC.dylib.dSYM  ./install/
+    cp -rp ${strip_dir}/libcblite.dylib.dSYM  ./install/
 else
     # package up the strip symbols
-    cp -rp ${strip_dir}/libCouchbaseLiteC.so.sym  ./install/
+    cp -rp ${strip_dir}/libcblite.so.sym  ./install/
 
     # copy C++ stdlib, etc to output
     libstdcpp=`g++ --print-file-name=libstdc++.so`
@@ -95,11 +95,11 @@ cd ${WORKSPACE}/build_release/install
 if [[ ${OS} == 'macosx' ]]; then
     ${PKG_CMD} ${WORKSPACE}/${PACKAGE_NAME} include lib
     SYMBOLS_RELEASE_PKG_NAME=${PRODUCT}-${OS}-${VERSION}-${BLD_NUM}-${EDITION}-'symbols'.${PKG_TYPE}
-    ${PKG_CMD} ${WORKSPACE}/${SYMBOLS_RELEASE_PKG_NAME}  libCouchbaseLiteC.dylib.dSYM
+    ${PKG_CMD} ${WORKSPACE}/${SYMBOLS_RELEASE_PKG_NAME}  libcblite.dylib.dSYM
 else # linux
     ${PKG_CMD} ${WORKSPACE}/${PACKAGE_NAME} include lib
     SYMBOLS_RELEASE_PKG_NAME=${PRODUCT}-${OS}-${VERSION}-${BLD_NUM}-${EDITION}-'symbols'.${PKG_TYPE}
-    ${PKG_CMD} ${WORKSPACE}/${SYMBOLS_RELEASE_PKG_NAME} libCouchbaseLiteC*.sym
+    ${PKG_CMD} ${WORKSPACE}/${SYMBOLS_RELEASE_PKG_NAME} libcblite*.sym
 fi
 cd ${WORKSPACE}
 

--- a/jenkins/server_cross_unix.sh
+++ b/jenkins/server_cross_unix.sh
@@ -41,7 +41,7 @@ ${WORKSPACE}/couchbase-lite-c/jenkins/strip.sh ${strip_dir} ${STRIP_PREFIX}
 make install
 
 # package up the strip symbols
-cp -rp ${strip_dir}/libCouchbaseLiteC.so.sym  ./install/
+cp -rp ${strip_dir}/libcblite.so.sym  ./install/
 
 cd ${WORKSPACE}
 
@@ -53,7 +53,7 @@ echo
 cd ${WORKSPACE}/build_release/install
 ${PKG_CMD} ${WORKSPACE}/${PACKAGE_NAME} include lib
 SYMBOLS_RELEASE_PKG_NAME=${PRODUCT}-${OS}-${VERSION}-${BLD_NUM}-${EDITION}-'symbols'.${PKG_TYPE}
-${PKG_CMD} ${WORKSPACE}/${SYMBOLS_RELEASE_PKG_NAME} libCouchbaseLiteC*.sym
+${PKG_CMD} ${WORKSPACE}/${SYMBOLS_RELEASE_PKG_NAME} libcblite*.sym
 
 cd ${WORKSPACE}
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -40,7 +40,7 @@ pushd test > /dev/null
 ./CBL_C_Tests -r list
 popd > /dev/null
 
-lcov -d CMakeFiles/CouchbaseLiteCStatic.dir -c -o CBL_C_Tests.info
+lcov -d CMakeFiles/cblite-static.dir -c -o CBL_C_Tests.info
 find . -type f -name '*.gcda' -delete
 
 lcov --remove CBL_C_Tests.info '/Applications/*' -o CBL_C_Tests_Filtered.info

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ set(TEST_SRC
 )
 add_executable(CBL_C_Tests ${TEST_SRC} )
 
-target_link_libraries(CBL_C_Tests PRIVATE  CouchbaseLiteC)
+target_link_libraries(CBL_C_Tests PRIVATE  cblite)
 
 if(MSVC)
     # For internal fleece dependencies:
@@ -52,7 +52,7 @@ if(MSVC)
     )
 
     set(BIN_TOP "${PROJECT_BINARY_DIR}/..")
-    set(FilesToCopy ${BIN_TOP}/\$\(Configuration\)/CouchbaseLiteC)
+    set(FilesToCopy ${BIN_TOP}/\$\(Configuration\)/cblite)
 
     add_custom_command(TARGET CBL_C_Tests POST_BUILD
         COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
The new library names and details are as follows:

Windows:

cblite-static.lib (static library, no version info)
cblite.dll (dynamic library, version info inserted via RC file [see cblite.rc.in])

macOS:

libcblite-static.a (static library, no version info)
libcblite.3.0.0.dylib (dynamic library, compatibility version set to 3.0.0 current version set to 3.0.0)
libcblite.3.dylib (compatibility version driven symlink to actual file)
libcblite.dylib (rolling symlink to any target)

Linux:

libcblite-static.a (static library, no version info)
libcblite.so.3.0.0 (dynamic library actual file)
libcblite.so.3 (SOVERSION driven symlink to actual file)
libcblite.so (master symlink to any version)