### PR TITLE
Add Database and Document tests

### DIFF
--- a/include/cbl/CBLDocument.h
+++ b/include/cbl/CBLDocument.h
@@ -111,7 +111,7 @@ bool CBLDatabase_SaveDocumentWithConcurrencyControl(CBLDatabase* db,
     @return  True on success, false on failure. */
 bool CBLDatabase_SaveDocumentWithConflictHandler(CBLDatabase* db,
                                                  CBLDocument* doc,
-                                                 CBLConflictHandler _cbl_nullable conflictHandler,
+                                                 CBLConflictHandler conflictHandler,
                                                  void* _cbl_nullable context,
                                                  CBLError* _cbl_nullable outError) CBLAPI;
 

--- a/src/CBLDatabase_CAPI.cc
+++ b/src/CBLDatabase_CAPI.cc
@@ -247,7 +247,10 @@ bool CBLDatabase_PurgeDocument(CBLDatabase* db,
                                const CBLDocument* doc,
                                CBLError* outError) noexcept
 {
-    return CBLDatabase_PurgeDocumentByID(doc->database(), doc->docID(), outError);
+    try {
+        CBLDocument::checkDBMatches(doc->database(), db);
+        return CBLDatabase_PurgeDocumentByID(db, doc->docID(), outError);
+    } catchAndBridge(outError)
 }
 
 bool CBLDatabase_PurgeDocumentByID(CBLDatabase* db,

--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -190,7 +190,7 @@ public:
     };
 
     bool save(CBLDatabase* db, const SaveOptions &opt);
-
+    
 
 #pragma mark - Conflict resolution:
 
@@ -230,6 +230,13 @@ public:
     bool resolveConflict(Resolution resolution, const CBLDocument* _cbl_nullable mergeDoc);
 
 
+#pragma mark - Utils:
+    
+    static void checkDBMatches(CBLDatabase* _cbl_nullable myDB, CBLDatabase *dbParam) {
+        if (myDB && myDB != dbParam)
+            C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter, "Use document on a wrong database");
+    }
+
 #pragma mark - Internals:
 
 
@@ -243,11 +250,6 @@ private:
     void checkMutable() const {
         if (!_usuallyTrue(_mutable))
             C4Error::raise(LiteCoreDomain, kC4ErrorNotWriteable, "Document object is immutable");
-    }
-
-    static void checkDBMatches(CBLDatabase* _cbl_nullable myDB, CBLDatabase *dbParam) {
-        if (myDB && myDB != dbParam)
-            C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter, "Saving doc to wrong database");
     }
 
     static CBLNewBlob* _cbl_nullable findNewBlob(FLDict dict);

--- a/test/DatabaseTest.cc
+++ b/test/DatabaseTest.cc
@@ -27,6 +27,29 @@ using namespace std;
 using namespace fleece;
 
 
+static constexpr const slice kOtherDBName = "CBLTest_OtherDB";
+
+class DatabaseTest : public CBLTest {
+public:
+    CBLDatabase* otherDB = nullptr;
+    
+    DatabaseTest() {
+        CBLError error;
+        if (!CBL_DeleteDatabase(kOtherDBName, kDatabaseConfiguration.directory, &error) && error.code != 0)
+            FAIL("Can't delete otherDB database: " << error.domain << "/" << error.code);
+    }
+
+    ~DatabaseTest() {
+        if (otherDB) {
+            CBLError error;
+            if (!CBLDatabase_Close(otherDB, &error))
+                WARN("Failed to close other database: " << error.domain << "/" << error.code);
+            CBLDatabase_Release(otherDB);
+        }
+    }
+};
+
+
 static void createDocument(CBLDatabase *db, slice docID, slice property, slice value) {
     CBLDocument* doc = CBLDocument_CreateWithID(docID);
     MutableDict props = CBLDocument_MutableProperties(doc);
@@ -38,7 +61,7 @@ static void createDocument(CBLDatabase *db, slice docID, slice property, slice v
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Database") {
+TEST_CASE_METHOD(DatabaseTest, "Database") {
     CHECK(CBLDatabase_Name(db) == kDatabaseName);
     CHECK(string(CBLDatabase_Path(db)) == string(kDatabaseDir) + kPathSeparator + string(kDatabaseName) + ".cblite2" + kPathSeparator);
     CHECK(CBL_DatabaseExists(kDatabaseName, kDatabaseDir));
@@ -47,7 +70,7 @@ TEST_CASE_METHOD(CBLTest, "Database") {
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Database w/o config") {
+TEST_CASE_METHOD(DatabaseTest, "Database w/o config") {
     CBLError error;
     CBLDatabase *defaultdb = CBLDatabase_Open("unconfig"_sl, nullptr, &error);
     REQUIRE(defaultdb);
@@ -69,7 +92,7 @@ TEST_CASE_METHOD(CBLTest, "Database w/o config") {
 
 #ifdef COUCHBASE_ENTERPRISE
 
-TEST_CASE_METHOD(CBLTest, "Database Encryption") {
+TEST_CASE_METHOD(DatabaseTest, "Database Encryption") {
     // Ensure no database:
     CBL_DeleteDatabase("encdb"_sl, nullslice, nullptr);
     CHECK(!CBL_DatabaseExists("encdb"_sl, nullslice));
@@ -123,7 +146,10 @@ TEST_CASE_METHOD(CBLTest, "Database Encryption") {
 #endif
 
 
-TEST_CASE_METHOD(CBLTest, "Missing Document") {
+#pragma mark - Document:
+
+
+TEST_CASE_METHOD(DatabaseTest, "Missing Document") {
     CBLError error;
     const CBLDocument* doc = CBLDatabase_GetDocument(db, "foo"_sl, &error);
     CHECK(doc == nullptr);
@@ -139,7 +165,7 @@ TEST_CASE_METHOD(CBLTest, "Missing Document") {
 }
 
 
-TEST_CASE_METHOD(CBLTest, "New Document") {
+TEST_CASE_METHOD(DatabaseTest, "New Document") {
     CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
     CHECK(doc != nullptr);
     CHECK(CBLDocument_ID(doc) == "foo"_sl);
@@ -151,10 +177,87 @@ TEST_CASE_METHOD(CBLTest, "New Document") {
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Save Empty Document") {
+TEST_CASE_METHOD(DatabaseTest, "New Document With Auto ID") {
+    CBLDocument* doc = CBLDocument_Create();
+    CHECK(doc != nullptr);
+    CHECK(CBLDocument_ID(doc) != nullslice);
+    CHECK(CBLDocument_RevisionID(doc) == nullslice);
+    CHECK(CBLDocument_Sequence(doc) == 0);
+    CHECK(CBLDocument_CreateJSON(doc) == "{}"_sl);
+    CHECK(CBLDocument_MutableProperties(doc) == CBLDocument_Properties(doc));
+    CBLDocument_Release(doc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Mutable Copy New Document") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    CHECK(doc != nullptr);
+    MutableDict props = CBLDocument_MutableProperties(doc);
+    props["greeting"_sl] = "Howdy!"_sl;
+    
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_RevisionID(doc) == nullslice);
+    CHECK(CBLDocument_Sequence(doc) == 0);
+    CHECK(CBLDocument_CreateJSON(doc) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+    
+    CBLDocument* mDoc = CBLDocument_MutableCopy(doc);
+    CHECK(mDoc != doc);
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(mDoc) == 0);
+    CHECK(CBLDocument_CreateJSON(doc) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+    
+    CBLDocument_Release(doc);
+    CBLDocument_Release(mDoc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Mutable Copy Immutable Document") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    CHECK(doc != nullptr);
+    MutableDict props = CBLDocument_MutableProperties(doc);
+    props["greeting"_sl] = "Howdy!"_sl;
+    
+    CBLError error;
+    REQUIRE(CBLDatabase_SaveDocument(db, doc, &error));
+    
+    const CBLDocument* rDoc = CBLDatabase_GetDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(rDoc) == "foo"_sl);
+    CHECK(CBLDocument_RevisionID(rDoc) != nullslice);
+    CHECK(CBLDocument_Sequence(rDoc) == 1);
+    CHECK(CBLDocument_CreateJSON(rDoc) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(rDoc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+
+    CBLDocument* mDoc = CBLDocument_MutableCopy(rDoc);
+    CHECK(mDoc != rDoc);
+    CHECK(CBLDocument_ID(mDoc) == "foo"_sl);
+    CHECK(CBLDocument_RevisionID(mDoc) == CBLDocument_RevisionID(rDoc));
+    CHECK(CBLDocument_Sequence(mDoc) == 1);
+    CHECK(CBLDocument_CreateJSON(doc) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+    
+    CBLDocument_Release(doc);
+    CBLDocument_Release(rDoc);
+    CBLDocument_Release(mDoc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Get Non Existing Document") {
+    CBLError error;
+    const CBLDocument* doc = CBLDatabase_GetDocument(db, "foo"_sl, &error);
+    REQUIRE(doc == nullptr);
+    CHECK(error.code == 0);
+}
+
+
+#pragma mark - Save Document:
+
+
+TEST_CASE_METHOD(DatabaseTest, "Save Empty Document") {
     CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
     CBLError error;
-    REQUIRE(CBLDatabase_SaveDocumentWithConcurrencyControl(db, doc, kCBLConcurrencyControlFailOnConflict, &error));
+    REQUIRE(CBLDatabase_SaveDocument(db, doc, &error));
     CHECK(CBLDocument_ID(doc) == "foo"_sl);
     CHECK(CBLDocument_Sequence(doc) == 1);
     CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{}"_sl);
@@ -169,7 +272,7 @@ TEST_CASE_METHOD(CBLTest, "Save Empty Document") {
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Save Document With Property") {
+TEST_CASE_METHOD(DatabaseTest, "Save Document With Property") {
     CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
     MutableDict props = CBLDocument_MutableProperties(doc);
     props["greeting"_sl] = "Howdy!"_sl;
@@ -178,7 +281,7 @@ TEST_CASE_METHOD(CBLTest, "Save Document With Property") {
     CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
 
     CBLError error;
-    REQUIRE(CBLDatabase_SaveDocumentWithConcurrencyControl(db, doc, kCBLConcurrencyControlFailOnConflict, &error));
+    REQUIRE(CBLDatabase_SaveDocument(db, doc, &error));
     CHECK(CBLDocument_ID(doc) == "foo"_sl);
     CHECK(CBLDocument_Sequence(doc) == 1);
     CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\"}"_sl);
@@ -194,16 +297,546 @@ TEST_CASE_METHOD(CBLTest, "Save Document With Property") {
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Missing document") {
+TEST_CASE_METHOD(DatabaseTest, "Save Document Twice") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    MutableDict props = CBLDocument_MutableProperties(doc);
+    props["greeting"_sl] = "Howdy!"_sl;
+    
     CBLError error;
-    REQUIRE(!CBLDatabase_PurgeDocumentByID(db, "bogus"_sl, &error));
-    CHECK(error.domain == CBLDomain);
-    CHECK(error.code == CBLErrorNotFound);
-    CHECK(alloc_slice(CBLError_Message(&error)) == "not found"_sl);
+    REQUIRE(CBLDatabase_SaveDocument(db, doc, &error));
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 1);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+
+    CBLDocument* savedDoc = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(savedDoc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(savedDoc) == 1);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(savedDoc)) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(savedDoc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+    CBLDocument_Release(savedDoc);
+    
+    // Modify Again:
+    props = CBLDocument_MutableProperties(doc);
+    props["greeting"_sl] = "Hello!"_sl;
+    
+    REQUIRE(CBLDatabase_SaveDocument(db, doc, &error));
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 2);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Hello!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Hello!\"}");
+    CBLDocument_Release(doc);
+
+    savedDoc = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(savedDoc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(savedDoc) == 2);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(savedDoc)) == "{\"greeting\":\"Hello!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(savedDoc)).toJSONString() == "{\"greeting\":\"Hello!\"}");
+    CBLDocument_Release(savedDoc);
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Expiration") {
+TEST_CASE_METHOD(DatabaseTest, "Save Document with LastWriteWin") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+
+    CBLError error;
+    REQUIRE(CBLDatabase_SaveDocumentWithConcurrencyControl(db, doc, kCBLConcurrencyControlLastWriteWins, &error));
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 1);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+    CBLDocument_Release(doc);
+
+    CBLDocument* doc1 = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc1) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc1) == 1);
+    
+    CBLDocument* doc2 = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc2) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc2) == 1);
+    
+    FLMutableDict props1 = CBLDocument_MutableProperties(doc1);
+    FLMutableDict_SetString(props1, "name"_sl, "bob"_sl);
+    REQUIRE(CBLDatabase_SaveDocumentWithConcurrencyControl(db, doc1, kCBLConcurrencyControlLastWriteWins, &error));
+    CHECK(CBLDocument_Sequence(doc1) == 2);
+    CBLDocument_Release(doc1);
+    
+    FLMutableDict props2 = CBLDocument_MutableProperties(doc2);
+    FLMutableDict_SetString(props2, "name"_sl, "sally"_sl);
+    REQUIRE(CBLDatabase_SaveDocumentWithConcurrencyControl(db, doc2, kCBLConcurrencyControlLastWriteWins, &error));
+    CHECK(CBLDocument_Sequence(doc2) == 3);
+    CBLDocument_Release(doc2);
+    
+    doc = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 3);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\",\"name\":\"sally\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\",\"name\":\"sally\"}");
+    CBLDocument_Release(doc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Save Document with FailOnConflict") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+
+    CBLError error;
+    REQUIRE(CBLDatabase_SaveDocumentWithConcurrencyControl(db, doc, kCBLConcurrencyControlFailOnConflict, &error));
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 1);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+    CBLDocument_Release(doc);
+
+    CBLDocument* doc1 = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc1) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc1) == 1);
+    
+    CBLDocument* doc2 = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc2) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc2) == 1);
+    
+    FLMutableDict props1 = CBLDocument_MutableProperties(doc1);
+    FLMutableDict_SetString(props1, "name"_sl, "bob"_sl);
+    REQUIRE(CBLDatabase_SaveDocumentWithConcurrencyControl(db, doc1, kCBLConcurrencyControlFailOnConflict, &error));
+    CHECK(CBLDocument_Sequence(doc1) == 2);
+    CBLDocument_Release(doc1);
+    
+    FLMutableDict props2 = CBLDocument_MutableProperties(doc2);
+    FLMutableDict_SetString(props2, "name"_sl, "sally"_sl);
+    CHECK(!CBLDatabase_SaveDocumentWithConcurrencyControl(db, doc2, kCBLConcurrencyControlFailOnConflict, &error));
+    CBLDocument_Release(doc2);
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorConflict);
+    
+    error = {};
+    doc = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 2);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\",\"name\":\"bob\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\",\"name\":\"bob\"}");
+    CBLDocument_Release(doc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Save Document with Conflict Handler") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+    
+    CBLConflictHandler failConflict = [](void *c, CBLDocument *mine, const CBLDocument *existing) -> bool {
+        return false;
+    };
+    
+    CBLConflictHandler mergeConflict = [](void *c, CBLDocument *mine, const CBLDocument *existing) -> bool {
+        FLMutableDict mergedProps = CBLDocument_MutableProperties(mine);
+        FLValue anotherName = FLDict_Get(CBLDocument_Properties(existing),"name"_sl);
+        FLMutableDict_SetValue(mergedProps, "anotherName"_sl, anotherName);
+        return true;
+    };
+    
+    CBLError error;
+    REQUIRE(CBLDatabase_SaveDocumentWithConflictHandler(db, doc, failConflict, nullptr, &error));
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 1);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+    CBLDocument_Release(doc);
+
+    CBLDocument* doc1 = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc1) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc1) == 1);
+    
+    CBLDocument* doc2 = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc2) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc2) == 1);
+    
+    FLMutableDict props1 = CBLDocument_MutableProperties(doc1);
+    FLMutableDict_SetString(props1, "name"_sl, "bob"_sl);
+    REQUIRE(CBLDatabase_SaveDocumentWithConflictHandler(db, doc1, failConflict, nullptr, &error));
+    CHECK(CBLDocument_Sequence(doc1) == 2);
+    CBLDocument_Release(doc1);
+    
+    FLMutableDict props2 = CBLDocument_MutableProperties(doc2);
+    FLMutableDict_SetString(props2, "name"_sl, "sally"_sl);
+    CHECK(!CBLDatabase_SaveDocumentWithConflictHandler(db, doc2, failConflict, nullptr, &error));
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorConflict);
+    
+    error = {};
+    CHECK(CBLDatabase_SaveDocumentWithConflictHandler(db, doc2, mergeConflict, nullptr, &error));
+    CBLDocument_Release(doc2);
+    
+    doc = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 3);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\",\"name\":\"sally\",\"anotherName\":\"bob\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\",\"name\":\"sally\",\"anotherName\":\"bob\"}");
+    CBLDocument_Release(doc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Save Document into Different DB") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+    
+    CBLError error;
+    CHECK(CBLDatabase_SaveDocument(db, doc, &error));
+    
+    otherDB = CBLDatabase_Open(kOtherDBName, &kDatabaseConfiguration, &error);
+    REQUIRE(otherDB);
+    
+    ExpectingExceptions x;
+    CHECK(!CBLDatabase_SaveDocument(otherDB, doc, &error));
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorInvalidParameter);
+    CBLDocument_Release(doc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Save Document into Different DB Instance") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+    
+    CBLError error;
+    CHECK(CBLDatabase_SaveDocument(db, doc, &error));
+    
+    CBLDatabase* db2 = CBLDatabase_Open(kDatabaseName, &kDatabaseConfiguration, &error);
+    REQUIRE(db2);
+    
+    ExpectingExceptions x;
+    CHECK(!CBLDatabase_SaveDocument(db2, doc, &error));
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorInvalidParameter);
+    CBLDocument_Release(doc);
+    
+    error = {};
+    REQUIRE(CBLDatabase_Close(db2, &error));
+    CBLDatabase_Release(db2);
+}
+
+
+#pragma mark - Delete Document:
+
+
+TEST_CASE_METHOD(DatabaseTest, "Delete Non Existing Document") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    
+    ExpectingExceptions x;
+    CBLError error;
+    CHECK(!CBLDatabase_DeleteDocument(db, doc, &error));
+    CBLDocument_Release(doc);
+    
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorNotFound);
+    
+    error = {};
+    CHECK(!CBLDatabase_DeleteDocumentByID(db, "foo"_sl, &error));
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorNotFound);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Delete Document") {
+    createDocument(db, "doc1", "foo", "bar");
+    createDocument(db, "doc2", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLDatabase_GetDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc);
+    CHECK(CBLDocument_Sequence(doc) == 1);
+    
+    CHECK(CBLDatabase_DeleteDocument(db, doc, &error));
+    CHECK(CBLDocument_Sequence(doc) == 3);
+    CBLDocument_Release(doc);
+    CHECK(!CBLDatabase_GetDocument(db, "doc1"_sl, &error));
+    
+    CHECK(CBLDatabase_DeleteDocumentByID(db, "doc2"_sl, &error));
+    CHECK(!CBLDatabase_GetDocument(db, "doc2"_sl, &error));
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Delete Already Deleted Document") {
+    createDocument(db, "doc1", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLDatabase_GetDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc);
+    
+    CHECK(CBLDatabase_DeleteDocument(db, doc, &error));
+    CHECK(CBLDocument_Sequence(doc) == 2);
+    CHECK(!CBLDatabase_GetDocument(db, "doc1"_sl, &error));
+    
+    CHECK(CBLDatabase_DeleteDocument(db, doc, &error));
+    CHECK(CBLDocument_Sequence(doc) == 3);
+    CBLDocument_Release(doc);
+    
+    CHECK(CBLDatabase_DeleteDocumentByID(db, "doc1"_sl, &error));
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Delete Then Update Document") {
+    createDocument(db, "doc1", "foo", "bar");
+    
+    CBLError error;
+    CBLDocument* doc = CBLDatabase_GetMutableDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc);
+    
+    CHECK(CBLDatabase_DeleteDocument(db, doc, &error));
+    CHECK(CBLDocument_Sequence(doc) == 2);
+    CHECK(!CBLDatabase_GetDocument(db, "doc1"_sl, &error));
+    
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "foo"_sl, "bar1"_sl);
+    CHECK(CBLDatabase_SaveDocument(db, doc, &error));
+    
+    CHECK(CBLDocument_ID(doc) == "doc1"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 3);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"foo\":\"bar1\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"foo\":\"bar1\"}");
+    CBLDocument_Release(doc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Delete Document with LastWriteWin") {
+    createDocument(db, "doc1", "foo", "bar");
+
+    CBLError error;
+    CBLDocument* doc1 = CBLDatabase_GetMutableDocument(db, "doc1"_sl, &error);
+    CHECK(CBLDocument_ID(doc1) == "doc1"_sl);
+    CHECK(CBLDocument_Sequence(doc1) == 1);
+    
+    CBLDocument* doc2 = CBLDatabase_GetMutableDocument(db, "doc1"_sl, &error);
+    CHECK(CBLDocument_ID(doc2) == "doc1"_sl);
+    CHECK(CBLDocument_Sequence(doc2) == 1);
+    
+    FLMutableDict props1 = CBLDocument_MutableProperties(doc1);
+    FLMutableDict_SetString(props1, "foo"_sl, "bar1"_sl);
+    REQUIRE(CBLDatabase_SaveDocumentWithConcurrencyControl(db, doc1, kCBLConcurrencyControlLastWriteWins, &error));
+    CHECK(CBLDocument_Sequence(doc1) == 2);
+    CBLDocument_Release(doc1);
+    
+    REQUIRE(CBLDatabase_DeleteDocumentWithConcurrencyControl(db, doc2, kCBLConcurrencyControlLastWriteWins, &error));
+    CHECK(CBLDocument_Sequence(doc2) == 3);
+    CBLDocument_Release(doc2);
+    
+    REQUIRE(!CBLDatabase_GetDocument(db, "doc1"_sl, &error));
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Delete Document with FailOnConflict") {
+    createDocument(db, "doc1", "foo", "bar");
+
+    CBLError error;
+    CBLDocument* doc1 = CBLDatabase_GetMutableDocument(db, "doc1"_sl, &error);
+    CHECK(CBLDocument_ID(doc1) == "doc1"_sl);
+    CHECK(CBLDocument_Sequence(doc1) == 1);
+    
+    CBLDocument* doc2 = CBLDatabase_GetMutableDocument(db, "doc1"_sl, &error);
+    CHECK(CBLDocument_ID(doc2) == "doc1"_sl);
+    CHECK(CBLDocument_Sequence(doc2) == 1);
+    
+    FLMutableDict props1 = CBLDocument_MutableProperties(doc1);
+    FLMutableDict_SetString(props1, "foo"_sl, "bar1"_sl);
+    REQUIRE(CBLDatabase_SaveDocumentWithConcurrencyControl(db, doc1, kCBLConcurrencyControlFailOnConflict, &error));
+    CHECK(CBLDocument_Sequence(doc1) == 2);
+    CBLDocument_Release(doc1);
+    
+    REQUIRE(!CBLDatabase_DeleteDocumentWithConcurrencyControl(db, doc2, kCBLConcurrencyControlFailOnConflict, &error));
+    CBLDocument_Release(doc2);
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorConflict);
+    
+    error = {};
+    doc1 = CBLDatabase_GetMutableDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc1);
+    CHECK(CBLDocument_Sequence(doc1) == 2);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc1)) == "{\"foo\":\"bar1\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc1)).toJSONString() == "{\"foo\":\"bar1\"}");
+    CBLDocument_Release(doc1);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Delete Document from Different DB") {
+    createDocument(db, "doc1", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLDatabase_GetDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc);
+    
+    otherDB = CBLDatabase_Open(kOtherDBName, &kDatabaseConfiguration, &error);
+    REQUIRE(otherDB);
+    
+    ExpectingExceptions x;
+    CHECK(!CBLDatabase_DeleteDocument(otherDB, doc, &error));
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorInvalidParameter);
+    CBLDocument_Release(doc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Delete Document from Different DB Instance") {
+    createDocument(db, "doc1", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLDatabase_GetDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc);
+    
+    CBLDatabase* db2 = CBLDatabase_Open(kDatabaseName, &kDatabaseConfiguration, &error);
+    REQUIRE(db2);
+    
+    ExpectingExceptions x;
+    CHECK(!CBLDatabase_DeleteDocument(db2, doc, &error));
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorInvalidParameter);
+    CBLDocument_Release(doc);
+    
+    error = {};
+    REQUIRE(CBLDatabase_Close(db2, &error));
+    CBLDatabase_Release(db2);
+}
+
+
+#pragma mark - Purge Document:
+
+
+TEST_CASE_METHOD(DatabaseTest, "Purge Non Existing Document") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    
+    ExpectingExceptions x;
+    CBLError error;
+    CHECK(!CBLDatabase_PurgeDocument(db, doc, &error));
+    CBLDocument_Release(doc);
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorNotFound);
+    
+    error = {};
+    CHECK(!CBLDatabase_PurgeDocumentByID(db, "foo"_sl, &error));
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorNotFound);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Purge Document") {
+    createDocument(db, "doc1", "foo", "bar");
+    createDocument(db, "doc2", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLDatabase_GetDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc);
+    CHECK(CBLDocument_Sequence(doc) == 1);
+    
+    CHECK(CBLDatabase_PurgeDocument(db, doc, &error));
+    CBLDocument_Release(doc);
+    CHECK(!CBLDatabase_GetDocument(db, "doc1"_sl, &error));
+    
+    CHECK(CBLDatabase_PurgeDocumentByID(db, "doc2"_sl, &error));
+    CHECK(!CBLDatabase_GetDocument(db, "doc2"_sl, &error));
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Purge Already Purged Document") {
+    createDocument(db, "doc1", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLDatabase_GetDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc);
+    
+    CHECK(CBLDatabase_PurgeDocument(db, doc, &error));
+    CHECK(!CBLDatabase_GetDocument(db, "doc1"_sl, &error));
+    
+    CHECK(!CBLDatabase_PurgeDocument(db, doc, &error));
+    CBLDocument_Release(doc);
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorNotFound);
+    
+    error = {};
+    CHECK(!CBLDatabase_PurgeDocumentByID(db, "doc1"_sl, &error));
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorNotFound);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Purge Document from Different DB") {
+    createDocument(db, "doc1", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLDatabase_GetDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc);
+    
+    otherDB = CBLDatabase_Open(kOtherDBName, &kDatabaseConfiguration, &error);
+    REQUIRE(otherDB);
+    
+    ExpectingExceptions x;
+    CHECK(!CBLDatabase_PurgeDocument(otherDB, doc, &error));
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorInvalidParameter);
+    CBLDocument_Release(doc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Purge Document from Different DB Instance") {
+    createDocument(db, "doc1", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLDatabase_GetDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc);
+    
+    CBLDatabase* db2 = CBLDatabase_Open(kDatabaseName, &kDatabaseConfiguration, &error);
+    REQUIRE(db2);
+    
+    ExpectingExceptions x;
+    CHECK(!CBLDatabase_PurgeDocument(db2, doc, &error));
+    CHECK(error.domain == CBLDomain);
+    CHECK(error.code == CBLErrorInvalidParameter);
+    CBLDocument_Release(doc);
+    
+    error = {};
+    REQUIRE(CBLDatabase_Close(db2, &error));
+    CBLDatabase_Release(db2);
+}
+
+
+#pragma mark - File Operations:
+
+
+TEST_CASE_METHOD(DatabaseTest, "Copy Database") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+    
+    CBLError error;
+    REQUIRE(CBLDatabase_SaveDocument(db, doc, &error));
+    CBLDocument_Release(doc);
+    
+    REQUIRE(!CBL_DatabaseExists(kOtherDBName, kDatabaseConfiguration.directory));
+    
+    // Copy:
+    alloc_slice path = CBLDatabase_Path(db);
+    REQUIRE(CBL_CopyDatabase(path, kOtherDBName, &kDatabaseConfiguration, &error));
+    
+    // Check:
+    CHECK(CBL_DatabaseExists(kOtherDBName, kDatabaseConfiguration.directory));
+    otherDB = CBLDatabase_Open(kOtherDBName, &kDatabaseConfiguration, &error);
+    CHECK(otherDB != nullptr);
+    CHECK(CBLDatabase_Count(otherDB) == 1);
+    
+    doc = CBLDatabase_GetMutableDocument(otherDB, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CBLDocument_Release(doc);
+}
+
+
+#pragma mark - Document Expiry:
+
+
+TEST_CASE_METHOD(DatabaseTest, "Expiration") {
     createDocument(db, "doc1", "foo", "bar");
     createDocument(db, "doc2", "foo", "bar");
     createDocument(db, "doc3", "foo", "bar");
@@ -223,7 +856,7 @@ TEST_CASE_METHOD(CBLTest, "Expiration") {
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Expiration After Reopen") {
+TEST_CASE_METHOD(DatabaseTest, "Expiration After Reopen") {
     createDocument(db, "doc1", "foo", "bar");
     createDocument(db, "doc2", "foo", "bar");
     createDocument(db, "doc3", "foo", "bar");
@@ -245,7 +878,10 @@ TEST_CASE_METHOD(CBLTest, "Expiration After Reopen") {
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Maintenance : Compact and Integrity Check") {
+#pragma mark - Maintenance:
+
+
+TEST_CASE_METHOD(DatabaseTest, "Maintenance : Compact and Integrity Check") {
     // Create a doc with blob:
     CBLDocument* doc = CBLDocument_CreateWithID("doc1"_sl);
     FLMutableDict dict = CBLDocument_MutableProperties(doc);
@@ -285,7 +921,7 @@ TEST_CASE_METHOD(CBLTest, "Maintenance : Compact and Integrity Check") {
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Maintenance : Reindex") {
+TEST_CASE_METHOD(DatabaseTest, "Maintenance : Reindex") {
     CBLError error;
     CBLValueIndexConfiguration config = {};
     config.expressionLanguage = kCBLJSONLanguage;
@@ -303,6 +939,88 @@ TEST_CASE_METHOD(CBLTest, "Maintenance : Reindex") {
     CHECK(FLArray_Count(names) == 1);
     CHECK(FLValue_AsString(FLArray_Get(names, 0)) == "foo"_sl);
     FLArray_Release(names);
+}
+
+
+#pragma mark - Transaction:
+
+
+TEST_CASE_METHOD(DatabaseTest, "Transaction Commit") {
+    createDocument(db, "doc1", "foo", "bar1");
+    createDocument(db, "doc2", "foo", "bar2");
+
+    CHECK(CBLDatabase_Count(db) == 2);
+
+    // Begin Transaction:
+    CBLError error;
+    REQUIRE(CBLDatabase_BeginTransaction(db, &error));
+
+    // Create:
+    createDocument(db, "doc3", "foo", "bar3");
+
+    // Delete:
+    const CBLDocument* doc1 = CBLDatabase_GetDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc1);
+    REQUIRE(CBLDatabase_DeleteDocument(db, doc1, &error));
+    CBLDocument_Release(doc1);
+
+    // Purge:
+    const CBLDocument* doc2 = CBLDatabase_GetDocument(db, "doc2"_sl, &error);
+    REQUIRE(doc2);
+    REQUIRE(CBLDatabase_PurgeDocument(db, doc2, &error));
+    CBLDocument_Release(doc2);
+
+    // Commit Transaction:
+    REQUIRE(CBLDatabase_EndTransaction(db, true, &error));
+
+    // Check:
+    CHECK(CBLDatabase_Count(db) == 1);
+    const CBLDocument* doc3 = CBLDatabase_GetDocument(db, "doc3"_sl, &error);
+    CHECK(CBLDocument_ID(doc3) == "doc3"_sl);
+    CHECK(CBLDocument_Sequence(doc3) == 3);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc3)) == "{\"foo\":\"bar3\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc3)).toJSONString() == "{\"foo\":\"bar3\"}");
+    CBLDocument_Release(doc3);
+
+    CHECK(!CBLDatabase_GetDocument(db, "doc1"_sl, &error));
+    CHECK(!CBLDatabase_GetDocument(db, "doc2"_sl, &error));
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Transaction Abort") {
+    createDocument(db, "doc1", "foo", "bar1");
+    createDocument(db, "doc2", "foo", "bar2");
+    
+    // Begin Transaction:
+    CBLError error;
+    REQUIRE(CBLDatabase_BeginTransaction(db, &error));
+
+    // Create:
+    createDocument(db, "doc3", "foo", "bar3");
+
+    // Delete:
+    const CBLDocument* doc1 = CBLDatabase_GetDocument(db, "doc1"_sl, &error);
+    REQUIRE(doc1);
+    REQUIRE(CBLDatabase_DeleteDocument(db, doc1, &error));
+    CBLDocument_Release(doc1);
+
+    // Purge:
+    const CBLDocument* doc2 = CBLDatabase_GetDocument(db, "doc2"_sl, &error);
+    REQUIRE(doc2);
+    REQUIRE(CBLDatabase_PurgeDocument(db, doc2, &error));
+    CBLDocument_Release(doc2);
+
+    // Abort Transaction:
+    REQUIRE(CBLDatabase_EndTransaction(db, false, &error));
+    
+    CHECK(CBLDatabase_Count(db) == 2);
+    doc1 = CBLDatabase_GetMutableDocument(db, "doc1"_sl, &error);
+    CHECK(CBLDocument_ID(doc1) == "doc1"_sl);
+    CBLDocument_Release(doc1);
+    
+    doc2 = CBLDatabase_GetMutableDocument(db, "doc2"_sl, &error);
+    CHECK(CBLDocument_ID(doc2) == "doc2"_sl);
+    CBLDocument_Release(doc2);
 }
 
 
@@ -328,7 +1046,7 @@ static void fooListener(void *context, const CBLDatabase *db, FLString docID) {
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Database notifications") {
+TEST_CASE_METHOD(DatabaseTest, "Database notifications") {
     // Add a listener:
     dbListenerCalls = fooListenerCalls = 0;
     auto token = CBLDatabase_AddChangeListener(db, dbListener, this);
@@ -377,7 +1095,7 @@ static void barListener(void *context, const CBLDatabase *db, FLString docID) {
 }
 
 
-TEST_CASE_METHOD(CBLTest, "Scheduled database notifications") {
+TEST_CASE_METHOD(DatabaseTest, "Scheduled database notifications") {
     // Add a listener:
     dbListenerCalls = fooListenerCalls = barListenerCalls = 0;
     auto token = CBLDatabase_AddChangeListener(db, dbListener2, this);


### PR DESCRIPTION
* Added Database and Document tests.
* Fixed CBLDatabase_SaveDocumentWithConflictHandler’s conflictHandler from nullable to non-null
* Validated database matching in CBLDatabase_PurgeDocument.
* Improved code coverage (both lines and functions) about 3% (line 68.3%, function 79.4%)