### PR TITLE
Update code coverage script and CMakeList.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,10 @@ if(CODE_COVERAGE_ENABLED)
 endif()
 
 if(BUILD_ENTERPRISE)
+    message("Building Enterprise Edition")
     set(COUCHBASE_ENTERPRISE 1)                     # For generating CBL_Edition.h
+else()
+    message("Building Community Edition")
 endif()
 
 configure_file(

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -43,7 +43,7 @@ popd > /dev/null
 lcov -d CMakeFiles/cblite-static.dir -c -o CBL_C_Tests.info
 find . -type f -name '*.gcda' -delete
 
-lcov --remove CBL_C_Tests.info '/Applications/*' -o CBL_C_Tests_Filtered.info
+lcov --remove CBL_C_Tests.info '/Applications/*' '*/vendor/*' -o CBL_C_Tests_Filtered.info
 
 mkdir -p coverage_reports
 genhtml CBL_C_Tests_Filtered.info -o coverage_reports

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_SRC
     DatabaseTest_Cpp.cc
     QueryTest.cc
     ReplicatorTest.cc
+    ReplicatorEETest.cc
     ${TOP}vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/Backtrace.cc
     ${TOP}vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/LibC++Debug.cc
     ${TOP}vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/betterassert.cc


### PR DESCRIPTION
* Updated coverage.sh to filter all vendors out.
* Update test’s CMakeLists.txt to include ReplicatorEETest.cc.
* Update main’s CMakeList.txt to print the edition (EE or CE) info.