### PR TITLE
CBL-2162 : Fix Replicator’s complete progress when having no changes to replicate

### DIFF
--- a/test/ReplicatorTest.cc
+++ b/test/ReplicatorTest.cc
@@ -62,7 +62,7 @@ TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate", "[Replicator]") {
         return true;
     };
 
-    replicate();
+    replicate({CBLNetworkDomain, CBLNetErrUnknownHost});
 }
 
 
@@ -77,8 +77,8 @@ TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate with auth and proxy", "[Replica
     proxy.username = "User Name"_sl;
     proxy.password = "123456"_sl;
     config.proxy = &proxy;
-
-    replicate();
+    
+    replicate({ CBLNetworkDomain, CBLNetErrUnknownHost });
 }
 
 


### PR DESCRIPTION
* The root cause of CBL-2162 is that when there are no changes to replicate, the replicator is stopped or idle with status.progress.complete = 0.0 instead of 1.0.
* Returns a initial status which has complete status = 0.0 if the replicator hasn’t ever been started.
* Returns complete status = 1.0 if the replicator is stopped or idle but having no changes to replicate.
* Added and updated tests