### PR TITLE
CBL-2160 : Fix local win doc not being push to the server

### DIFF
--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -165,7 +165,7 @@ alloc_slice CBLDocument::encodeBody(CBLDatabase* db,
 #pragma mark - CONFLICT RESOLUTION:
 
 
-bool CBLDocument::resolveConflict(Resolution resolution, const CBLDocument * _cbl_nullable mergeDoc) {
+bool CBLDocument::resolveConflict(Resolution resolution, const CBLDocument * _cbl_nullable resolveDoc) {
     auto c4doc = _c4doc.useLocked();
 
     if (!c4doc)
@@ -174,24 +174,21 @@ bool CBLDocument::resolveConflict(Resolution resolution, const CBLDocument * _cb
     _properties = nullptr;
     _fromJSON = nullptr;
 
+    // Remote Revision always win so that the resolved revision will not conflict with the remote:
     slice winner(c4doc->selectedRev().revID), loser(c4doc->revID());
-    if (resolution != Resolution::useRemote)
-        std::swap(winner, loser);
-
+    
     return _db->useLocked<bool>([&](C4Database *c4db) {
         C4Database::Transaction t(c4db);
 
         alloc_slice mergeBody;
         C4RevisionFlags mergeFlags = 0;
-        if (resolution == Resolution::useMerge) {
-            if (mergeDoc) {
-                mergeBody = mergeDoc->encodeBody(_db, c4db, mergeFlags);
+        if (resolution != Resolution::useRemote) {
+            if (resolveDoc) {
+                mergeBody = resolveDoc->encodeBody(_db, c4db, mergeFlags);
             } else {
                 mergeBody = alloc_slice(size_t(0));
                 mergeFlags = kRevDeleted;
             }
-        } else {
-            assert(!mergeDoc);
         }
 
         try {

--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -182,6 +182,9 @@ bool CBLDocument::resolveConflict(Resolution resolution, const CBLDocument * _cb
 
         alloc_slice mergeBody;
         C4RevisionFlags mergeFlags = 0;
+        // When useLocal (local wins) or useMerge is true, the new revision will be created
+        // under the remote branch which is the winning branch. When useRemote (remote wins)
+        // is true, the remote revision will be kept as is and the losing branch will be pruned.
         if (resolution != Resolution::useRemote) {
             if (resolveDoc) {
                 mergeBody = resolveDoc->encodeBody(_db, c4db, mergeFlags);

--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -227,7 +227,12 @@ public:
         useMerge
     };
 
-    bool resolveConflict(Resolution resolution, const CBLDocument* _cbl_nullable mergeDoc);
+    
+    // Resolve conflict for pull replication; The document itself is the conflict (remote) doc.
+    // When saving the resolution, the remote branch will always win so that the saved doc
+    // will not be conflicted when it is push to the remote server. When the resolution is
+    // useRemote, the resolveDoc will be ignore.
+    bool resolveConflict(Resolution resolution, const CBLDocument* _cbl_nullable resolveDoc);
 
 
 #pragma mark - Utils:

--- a/test/ReplicatorTest.hh
+++ b/test/ReplicatorTest.hh
@@ -99,6 +99,15 @@ public:
         CBLListener_Remove(dtoken);
     }
     
+    void resetReplicator() {
+        if (!repl)
+            return;
+        
+        REQUIRE(CBLReplicator_Status(repl).activity == kCBLReplicatorStopped);
+        CBLReplicator_Release(repl);
+        repl = nullptr;
+    }
+    
     bool waitForActivityLevel(CBLReplicatorActivityLevel level, double timeout) {
         time start = clock::now();
         while (std::chrono::duration_cast<seconds>(clock::now() - start).count() < timeout) {


### PR DESCRIPTION
* Made that the remote branch will always win so that the saved resolved doc will not be conflicted when it is being push to the remote server.
* In ConflictResolver::customResolve(conflict), renamed otherDoc to remoteDoc and myDoc to localDoc to match the actual term.
* In ConflictResolver::customResolve(conflict), fixed retained count when the resolved doc is the same as local or remote doc.
* Updated Lite Core to pick up the fix in purgeRevision after resolveConflict (c25026c).
* Added tests