### PR TITLE
CBL-2162 : Workaround for handling unitsCompleted more than unitsTotal

### DIFF
--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -46,7 +46,11 @@ static CBLReplicatorStatus external(const C4ReplicatorStatus &c4status) {
         (c4status.level == kC4Idle || c4status.level == kC4Stopped) && c4status.error.code == 0) {
         complete = 1.0; // When the replicator is idle or stopped, return as completed if having no changes to replicate
     } else {
-        complete = c4status.progress.unitsCompleted / std::max(float(c4status.progress.unitsTotal), 1.0f);
+        auto total = c4status.progress.unitsTotal > 0 ? c4status.progress.unitsTotal : 1;
+        if (c4status.progress.unitsCompleted < total)
+            complete = c4status.progress.unitsCompleted / float(total);
+        else
+            complete = 1.0;
     }
     
     return {

--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -46,11 +46,8 @@ static CBLReplicatorStatus external(const C4ReplicatorStatus &c4status) {
         (c4status.level == kC4Idle || c4status.level == kC4Stopped) && c4status.error.code == 0) {
         complete = 1.0; // When the replicator is idle or stopped, return as completed if having no changes to replicate
     } else {
-        auto total = c4status.progress.unitsTotal > 0 ? c4status.progress.unitsTotal : 1;
-        if (c4status.progress.unitsCompleted < total)
-            complete = c4status.progress.unitsCompleted / float(total);
-        else
-            complete = 1.0;
+        complete = c4status.progress.unitsCompleted / std::max(float(c4status.progress.unitsTotal), 1.0f);
+        complete = std::min(complete, 1.0f); // CBL-2610 : Workaround for unitsCompleted > unitsTotal
     }
     
     return {


### PR DESCRIPTION
From CBL-2162, it's possible that the unitsCompleted could be more than unitsTotal. To workaround the problem and return the correct range of value (0.0 - 1.0), when computing the fractional complete, return 1.0 if unitsCompleted is more than unitsTotal.