### PR TITLE
Reimplement CBLLog

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -86,6 +86,8 @@
 		27DBD09C246CA60E002FD7A7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 271A98AF243FDF55008C032D /* SystemConfiguration.framework */; };
 		27DBD0A9246CA667002FD7A7 /* CBLLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 277B77C6245B44BE00B222D3 /* CBLLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6938073022DE96C200727053 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 277CC9B122BC4E2E00B245CB /* Security.framework */; };
+		93965A6326A7CD50008728EE /* LogTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 93965A6226A7CD50008728EE /* LogTest.cc */; };
+		93965A6426A7CD50008728EE /* LogTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 93965A6226A7CD50008728EE /* LogTest.cc */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -372,6 +374,7 @@
 		27DBCF41246B81EE002FD7A7 /* LibC++Debug.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "LibC++Debug.cc"; sourceTree = "<group>"; };
 		27DBD096246C99AF002FD7A7 /* mergeIntoStaticLib.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = mergeIntoStaticLib.sh; sourceTree = "<group>"; };
 		27DBD097246C9DE7002FD7A7 /* CBLDatabase+Apple.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "CBLDatabase+Apple.mm"; sourceTree = "<group>"; };
+		93965A6226A7CD50008728EE /* LogTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogTest.cc; sourceTree = "<group>"; };
 		93D0AFF1262619B800777AFC /* generate_edition_header.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = generate_edition_header.sh; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -580,6 +583,7 @@
 				275BC4F32204FB1400DBE7D2 /* BlobTest_Cpp.cc */,
 				27B61DB821D6ECA70027CCDB /* DatabaseTest.cc */,
 				277FEE5221E6BCA500B60E3C /* DatabaseTest_Cpp.cc */,
+				93965A6226A7CD50008728EE /* LogTest.cc */,
 				275B359D234D064600FE9CF0 /* QueryTest.cc */,
 				2736A625242E5A07002B9D65 /* ReplicatorTest.hh */,
 				277CC99422BC23DE00B245CB /* ReplicatorTest.cc */,
@@ -1206,6 +1210,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				93965A6426A7CD50008728EE /* LogTest.cc in Sources */,
 				275B3599234C158900FE9CF0 /* CouchbaseLiteTests.mm in Sources */,
 				275B358E23481D0C00FE9CF0 /* CBLTest.c in Sources */,
 				2736A635242E5A74002B9D65 /* ReplicatorEETest.cc in Sources */,
@@ -1245,6 +1250,7 @@
 				27B61DB921D6ECA70027CCDB /* DatabaseTest.cc in Sources */,
 				277FEE5321E6BCA500B60E3C /* DatabaseTest_Cpp.cc in Sources */,
 				275BC4F42204FB1400DBE7D2 /* BlobTest_Cpp.cc in Sources */,
+				93965A6326A7CD50008728EE /* LogTest.cc in Sources */,
 				275B359E234D064600FE9CF0 /* QueryTest.cc in Sources */,
 				277CC99522BC23DE00B245CB /* ReplicatorTest.cc in Sources */,
 				2736A634242E5A74002B9D65 /* ReplicatorEETest.cc in Sources */,

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -80,7 +80,7 @@ namespace cbl {
             if (!ok) {
 #if DEBUG
                 alloc_slice message = CBLError_Message(&error);
-                CBL_Log(kCBLLogDomainAll, CBLLogError, "API returning error %d/%d: %.*s",
+                CBL_Log(kCBLLogDomainDatabase, CBLLogError, "API returning error %d/%d: %.*s",
                         error.domain, error.code, (int)message.size, (char*)message.buf);
 #endif
                 throw error;

--- a/include/cbl/CBLLog.h
+++ b/include/cbl/CBLLog.h
@@ -28,11 +28,10 @@ CBL_CAPI_BEGIN
 
 /** Subsystems that log information. */
 typedef CBL_ENUM(uint8_t, CBLLogDomain) {
-    kCBLLogDomainAll,
     kCBLLogDomainDatabase,
     kCBLLogDomainQuery,
     kCBLLogDomainReplicator,
-    kCBLLogDomainNetwork,
+    kCBLLogDomainNetwork
 };
 
 /** Levels of log messages. Higher values are more important/severe. Each level includes the lower ones. */
@@ -103,7 +102,7 @@ void CBLLog_SetCallbackLevel(CBLLogLevel) CBLAPI;
 CBLLogCallback CBLLog_Callback(void) CBLAPI;
 
 /** Sets the callback for receiving log messages. If set to NULL, no messages are logged to the console. */
-void CBLLog_SetCallback(CBLLogCallback) CBLAPI;
+void CBLLog_SetCallback(CBLLogCallback _cbl_nullable callback) CBLAPI;
 
 /** @} */
 

--- a/src/CBLLog.cc
+++ b/src/CBLLog.cc
@@ -27,6 +27,7 @@
 #include <atomic>
 #include <cstdlib>
 #include <iostream>
+#include <mutex>
 
 using namespace std;
 using namespace fleece;
@@ -59,9 +60,9 @@ static CBLLogDomain getCBLLogDomain(C4LogDomain domain);
 
 // Note: Cannot use static initializing here as the order of initializing static C4LogDomain
 // constants such as kC4DatabaseLog cannot be guaranteed to be done prior.
+static once_flag initFlag;
 static void init() {
-    static bool initialized = false;
-    if (!initialized) {
+    call_once(initFlag, [](){
         // Initialize log level of each domain to debug (lowest level):
         for (int i = 0; i < sizeof(kC4Domains)/sizeof(kC4Domains[0]); ++i) {
             C4LogDomain domain = kC4Domains[i];
@@ -70,9 +71,7 @@ static void init() {
         
         // Register log callback:
         c4log_writeToCallback(effectiveC4CallbackLogLevel(), &c4LogCallback, true /*preformatted*/);
-        
-        initialized = true;
-    }
+    });
 }
 
 

--- a/src/CBLPrivate.h
+++ b/src/CBLPrivate.h
@@ -28,10 +28,6 @@ CBL_CAPI_BEGIN
     void CBLLog_BeginExpectingExceptions() CBLAPI;
     void CBLLog_EndExpectingExceptions() CBLAPI;
 
-    void CBLLog_SetConsoleLevelOfDomain(CBLLogDomain domain, CBLLogLevel level) CBLAPI;
-
-    CBLLogLevel CBLLog_ConsoleLevelOfDomain(CBLLogDomain domain) CBLAPI;
-
     /** Returns the last sequence number assigned in the database.
         This starts at zero and increments every time a document is saved or deleted. */
     uint64_t CBLDatabase_LastSequence(const CBLDatabase*) CBLAPI;

--- a/src/exports/CBL_Exports.txt
+++ b/src/exports/CBL_Exports.txt
@@ -118,8 +118,6 @@ CBLLog_CallbackLevel
 CBLLog_SetCallbackLevel
 CBLLog_ConsoleLevel
 CBLLog_SetConsoleLevel
-CBLLog_ConsoleLevelOfDomain
-CBLLog_SetConsoleLevelOfDomain
 CBLLog_FileConfig
 CBLLog_SetFileConfig
 CBLLog_BeginExpectingExceptions

--- a/src/exports/generated/CBL.def
+++ b/src/exports/generated/CBL.def
@@ -89,8 +89,6 @@ CBLLog_CallbackLevel
 CBLLog_SetCallbackLevel
 CBLLog_ConsoleLevel
 CBLLog_SetConsoleLevel
-CBLLog_ConsoleLevelOfDomain
-CBLLog_SetConsoleLevelOfDomain
 CBLLog_FileConfig
 CBLLog_SetFileConfig
 CBLLog_BeginExpectingExceptions

--- a/src/exports/generated/CBL.exp
+++ b/src/exports/generated/CBL.exp
@@ -87,8 +87,6 @@ _CBLLog_CallbackLevel
 _CBLLog_SetCallbackLevel
 _CBLLog_ConsoleLevel
 _CBLLog_SetConsoleLevel
-_CBLLog_ConsoleLevelOfDomain
-_CBLLog_SetConsoleLevelOfDomain
 _CBLLog_FileConfig
 _CBLLog_SetFileConfig
 _CBLLog_BeginExpectingExceptions

--- a/src/exports/generated/CBL.gnu
+++ b/src/exports/generated/CBL.gnu
@@ -87,8 +87,6 @@ CBL_C {
 		CBLLog_SetCallbackLevel;
 		CBLLog_ConsoleLevel;
 		CBLLog_SetConsoleLevel;
-		CBLLog_ConsoleLevelOfDomain;
-		CBLLog_SetConsoleLevelOfDomain;
 		CBLLog_FileConfig;
 		CBLLog_SetFileConfig;
 		CBLLog_BeginExpectingExceptions;

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -92,8 +92,6 @@ CBLLog_CallbackLevel
 CBLLog_SetCallbackLevel
 CBLLog_ConsoleLevel
 CBLLog_SetConsoleLevel
-CBLLog_ConsoleLevelOfDomain
-CBLLog_SetConsoleLevelOfDomain
 CBLLog_FileConfig
 CBLLog_SetFileConfig
 CBLLog_BeginExpectingExceptions

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -90,8 +90,6 @@ _CBLLog_CallbackLevel
 _CBLLog_SetCallbackLevel
 _CBLLog_ConsoleLevel
 _CBLLog_SetConsoleLevel
-_CBLLog_ConsoleLevelOfDomain
-_CBLLog_SetConsoleLevelOfDomain
 _CBLLog_FileConfig
 _CBLLog_SetFileConfig
 _CBLLog_BeginExpectingExceptions

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -90,8 +90,6 @@ CBL_C {
 		CBLLog_SetCallbackLevel;
 		CBLLog_ConsoleLevel;
 		CBLLog_SetConsoleLevel;
-		CBLLog_ConsoleLevelOfDomain;
-		CBLLog_SetConsoleLevelOfDomain;
 		CBLLog_FileConfig;
 		CBLLog_SetFileConfig;
 		CBLLog_BeginExpectingExceptions;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_SRC
     CBLTestsMain.cpp
     DatabaseTest.cc
     DatabaseTest_Cpp.cc
+    LogTest.cc
     QueryTest.cc
     ReplicatorTest.cc
     ReplicatorEETest.cc

--- a/test/LogTest.cc
+++ b/test/LogTest.cc
@@ -1,0 +1,331 @@
+//
+// LogTest.cc
+//
+// Copyright © 2018 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "CBLTest.hh"
+#include "cbl/CouchbaseLite.h"
+#include "fleece/Fleece.hh"
+#include <array>
+#include <dirent.h>
+#include <sys/stat.h>
+
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
+
+using namespace std;
+using namespace fleece;
+
+#ifdef _MSC_VER
+    static const char  kSeparatorChar = '\\';
+    static const char  kBackupSeparatorChar = '/';
+    static const char* kCurrentDir = ".\\";
+#else
+    static const char  kSeparatorChar = '/';
+    static const char  kBackupSeparatorChar = '\\';
+    static const char* kCurrentDir = "./";
+#endif
+
+static const array<CBLLogLevel, 6> kLogLevels = {{
+    CBLLogDebug, CBLLogVerbose, CBLLogInfo, CBLLogWarning, CBLLogError, CBLLogNone
+}};
+
+static const array<string, 6> kLogLevelNames = {{
+    "Debug", "Verbose", "Info", "Warning", "Error", "None"
+}};
+
+static const array<string, 5> kLogFileNamePrefixes = {{
+    "cbl_debug_", "cbl_verbose_", "cbl_info_", "cbl_warning_", "cbl_error_"
+}};
+
+// For rotating test log directory:
+static unsigned sLogDirCount = 0;
+
+class LogTest : public CBLTest {
+public:
+    string logDir;
+    CBLLogLevel backupConsoleLogLevel;
+    
+    LogTest() {
+        backupConsoleLogLevel = CBLLog_ConsoleLevel();
+    }
+
+    ~LogTest() {
+        // Restore from backup:
+        CBLLog_SetConsoleLevel(backupConsoleLogLevel);
+        
+        // Disable file logging if there is one set up:
+        const CBLLogFileConfiguration* oldConfig = CBLLog_FileConfig();
+        if (oldConfig != nullptr) {
+            CBLLogFileConfiguration config = *oldConfig;
+            config.level = CBLLogNone;
+            REQUIRE(CBLLog_SetFileConfig(config, nullptr));
+        }
+        
+        // Reset log callback:
+        CBLLog_SetCallback(nullptr);
+        CBLLog_SetCallbackLevel(CBLLogNone);
+    }
+    
+    void prepareLogDir() {
+        // Base:
+        string dir = string(CBLTest::kDatabaseDir) + kSeparatorChar + "CBLLogTest";
+        createDir(dir);
+        
+        // Log dir:
+        dir += kSeparatorChar + to_string(++sLogDirCount);
+        createDir(dir);
+        
+        logDir = dir;
+        deleteAllLogFiles();
+    }
+    
+    void deleteAllLogFiles() {
+        auto paths = getAllLogFilePaths();
+        for (string path : paths) {
+        #ifndef WIN32
+            int result = unlink(path.c_str());
+        #else
+            int result = _unlink(path.c_str());
+        #endif
+            if (result != 0)
+                FAIL("Can't delete file at " << path <<": " << result);
+        }
+    }
+    
+    vector<string> getAllLogFilePaths() {
+        vector<string> logFiles;
+        
+        auto dir = opendir(logDir.c_str());
+        if (!dir)
+            FAIL("Can't open log directory at "<< logDir << ": errno " << errno);
+        
+        struct dirent *entry;
+        while ((entry = readdir(dir)) != NULL) {
+            string filename = string(entry->d_name);
+        #ifndef WIN32
+            string path = logDir + kSeparatorChar + filename;
+            struct stat statEntry;
+            stat(path.c_str(), &statEntry);
+        #else
+            string path = logDir + kSeparatorChar + filename;
+            struct _stat statEntry;
+            _stat(path.c_str(), &statEntry);
+        #endif
+            
+            if (S_ISDIR(statEntry.st_mode))
+                continue;
+            
+            auto split = splitExtension(filename);
+            if (split.second != ".cbllog")
+                continue;
+            
+            logFiles.push_back(path);
+        }
+        
+        return logFiles;
+    }
+    
+    vector<string> readLogFile(CBLLogLevel level) {
+        string filePath;
+        auto logFilePaths = getAllLogFilePaths();
+        for (string path : logFilePaths) {
+            auto split = splitPath(path);
+            auto fileName = split.second;
+            if (fileName.find(kLogFileNamePrefixes[level]) == 0) {
+                // Make sure there is only one
+                CHECK(filePath.empty());
+                filePath = path;
+            }
+        }
+        REQUIRE(!filePath.empty());
+        
+        vector<string> lines;
+        ReadFileByLines(filePath, [&](FLSlice line) {
+            lines.push_back(string(line));
+            return true;
+        });
+        return lines;
+    }
+    
+    void writeLogs() {
+        CBL_Log(kCBLLogDomainDatabase, CBLLogDebug, "%s ...", kLogLevelNames[CBLLogDebug].c_str());
+        CBL_Log(kCBLLogDomainDatabase, CBLLogVerbose, "%s ...", kLogLevelNames[CBLLogVerbose].c_str());
+        CBL_Log(kCBLLogDomainDatabase, CBLLogInfo, "%s ...", kLogLevelNames[CBLLogInfo].c_str());
+        CBL_Log(kCBLLogDomainDatabase, CBLLogWarning, "%s ...", kLogLevelNames[CBLLogWarning].c_str());
+        CBL_Log(kCBLLogDomainDatabase, CBLLogError, "%s ...", kLogLevelNames[CBLLogError].c_str());
+    }
+    
+    // File Utils:
+    
+    void createDir(string dir) {
+    #ifndef WIN32
+        if (mkdir(dir.c_str(), 0744) != 0 && errno != EEXIST)
+            FAIL("Can't create temp directory: errno " << errno);
+    #else
+        if (_mkdir(dir.c_str()) != 0 && errno != EEXIST)
+            FAIL("Can't create temp directory: errno " << errno);
+    #endif
+    }
+    
+    pair<string,string> splitExtension(const string &file) {
+        auto dot = file.rfind('.');
+        auto lastSlash = file.rfind(kSeparatorChar);
+        if (dot == string::npos || (lastSlash != string::npos && dot < lastSlash))
+            return {file, ""};
+        else
+            return {file.substr(0, dot), file.substr(dot)};
+    }
+    
+    pair<string,string> splitPath(const string &path) {
+        string dirname, basename;
+        auto slash = path.rfind(kSeparatorChar);
+        auto backupSlash = path.rfind(kBackupSeparatorChar);
+        if (slash == string::npos && backupSlash == string::npos) {
+            return{ kCurrentDir, string(path) };
+        }
+        
+        if (slash == string::npos) {
+            slash = backupSlash;
+        }
+        else if (backupSlash != string::npos) {
+            slash = std::max(slash, backupSlash);
+        }
+
+        return {string(path.substr(0, slash+1)), string(path.substr(slash+1))};
+    }
+};
+
+
+TEST_CASE_METHOD(LogTest, "Console Logging : Set Log Level", "[Log]") {
+    for (CBLLogLevel level : kLogLevels) {
+        CBLLog_SetConsoleLevel(level);
+        CHECK(CBLLog_ConsoleLevel() == level);
+    }
+}
+
+
+TEST_CASE_METHOD(LogTest, "File Logging : Config", "[Log][FileLog]") {
+    prepareLogDir();
+    
+    CBLLogFileConfiguration config = {};
+    config.directory = slice(logDir);
+    config.level = CBLLogVerbose;
+    config.maxRotateCount = 5;
+    config.maxSize = 10;
+    config.usePlaintext = true;
+    
+    CBLError error;
+    CHECK(CBLLog_SetFileConfig(config, &error));
+    
+    auto config2 = CBLLog_FileConfig();
+    CHECK(config2->level == config.level);
+    CHECK(config2->directory == config.directory);
+    CHECK(config2->maxRotateCount == config.maxRotateCount);
+    CHECK(config2->maxSize == config.maxSize);
+    CHECK(config2->usePlaintext == config.usePlaintext);
+}
+
+
+TEST_CASE_METHOD(LogTest, "File Logging : Set Log Level", "[Log][FileLog]") {
+    prepareLogDir();
+    
+    CBLLogFileConfiguration config = {};
+    config.directory = slice(logDir);
+    config.usePlaintext = true;
+    
+    // Set setting different log levels:
+    CBLError error;
+    for (CBLLogLevel level : kLogLevels) {
+        // Set log level:
+        config.level = level;
+        REQUIRE(CBLLog_SetFileConfig(config, &error));
+        
+        // Write messages on each log level:
+        writeLogs();
+    }
+    
+    // Verify:
+    int lineCount = 1; // Header:
+    for (CBLLogLevel level : kLogLevels) {
+        if (level == CBLLogNone)
+            continue;
+        
+        vector<string> lines = readLogFile(level);
+        REQUIRE(lines.size() == ++lineCount);
+    }
+}
+
+
+TEST_CASE_METHOD(LogTest, "Custom Logging", "[Log][CustomLog]") {
+    // Set log callback:
+    static vector<CBLLogLevel>recs;
+    CBLLog_SetCallback([](CBLLogDomain domain, CBLLogLevel level, FLString msg) {
+        CHECK(level >= CBLLog_CallbackLevel());
+        CHECK(string(msg).find(kLogLevelNames[level]) == 0);
+        recs.push_back(level);
+    });
+    
+    // Set setting different log levels:
+    for (CBLLogLevel callbackLevel : kLogLevels) {
+        // Set log level:
+        CBLLog_SetCallbackLevel(callbackLevel);
+        CHECK(CBLLog_CallbackLevel() == callbackLevel);
+        
+        // Write messages on each log level:
+        recs.clear();
+        writeLogs();
+        
+        // Verify:
+        for (CBLLogLevel level : kLogLevels) {
+            if (level == CBLLogNone)
+                continue;
+            if (level >= callbackLevel)
+                CHECK(find(recs.begin(), recs.end(), level) != recs.end());
+            else
+                CHECK(find(recs.begin(), recs.end(), level) == recs.end());
+        }
+    }
+    
+    // Reset log callback:
+    CBLLog_SetCallbackLevel(CBLLogDebug);
+    CBLLog_SetCallback(nullptr);
+    REQUIRE(CBLLog_Callback() == nullptr);
+    recs.clear();
+    writeLogs();
+    CHECK(recs.empty());
+    CBLLog_SetCallbackLevel(CBLLogNone);
+}
+
+
+TEST_CASE_METHOD(LogTest, "Log Message", "[Log]") {
+    static vector<string>recs;
+    CBLLog_SetCallback([](CBLLogDomain domain, CBLLogLevel level, FLString msg) {
+        recs.push_back(string(msg));
+    });
+    CBLLog_SetCallbackLevel(CBLLogDebug);
+    
+    // Use CBL_Log:
+    CBL_Log(kCBLLogDomainDatabase, CBLLogInfo, "foo %s", "bar");
+    
+    // Use CBL_LogMessage:
+    CBL_LogMessage(kCBLLogDomainDatabase, CBLLogInfo, "hello world"_sl);
+    
+    REQUIRE(recs.size() == 2);
+    CHECK(recs[0] == "foo bar");
+    CHECK(recs[1] == "hello world");
+}


### PR DESCRIPTION
- Initialize the global log level of each specific domain to debug so logging can be further limited by the levels assigned to the current callback and/or binary file.
- Removed CBLLog_ConsoleLevelOfDomain and CBLLog_SetConsoleLevelOfDomain.
- Allowed both console and custom log working at the same time if both are enabled.
- Fixed CBL-2175 : Setting verbose log doesn’t work
- Fixed CBL-2188 : CBL_LogMessage() not logging to callback
- Fixed CBL-2181 : Parameter of CBLLog_SetCallback not marked as nullable