### PR TITLE
CBL-2187 : Fix deadlock when using doc or db in conflict handler running in different thread

### DIFF
--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -58,34 +58,33 @@ CBLDocument::~CBLDocument() {
 
 
 bool CBLDocument::save(CBLDatabase* db, const SaveOptions &opt) {
-    auto c4doc = _c4doc.useLocked();
-
+    Retained<C4Document> savingDoc = _c4doc.useLocked().get();
     if (opt.deleting) {
-        if (!c4doc)
+        if (!savingDoc)
             C4Error::raise(LiteCoreDomain, kC4ErrorNotFound, "Document is not in any database");
+        // Deleting doesn't have conflict handler option:
+        assert(!opt.conflictHandler);
     } else {
         checkMutable();
     }
     checkDBMatches(_db, db);
-
+    
+    bool retrying;
     Retained<C4Document> newDoc = nullptr;
-    db->useLocked([&](C4Database *c4db) {
-        C4Database::Transaction t(c4db);
-
-        // Encode properties: 
-        alloc_slice body;
-        C4RevisionFlags revFlags;
-        if (!opt.deleting) {
-            body = encodeBody(db, c4db, revFlags);
-        } else {
-            revFlags = kRevDeleted;
-        }
-
-        // Save:
-        Retained<C4Document> savingDoc = c4doc.get();
-
-        bool retrying;
-        do {
+    RetainedConst<CBLDocument> conflictingDoc = nullptr;
+    
+    do {
+        db->useLocked([&](C4Database *c4db) {
+            C4Database::Transaction t(c4db);
+            
+            alloc_slice body;
+            C4RevisionFlags revFlags;
+            if (!opt.deleting) {
+                body = encodeBody(db, c4db, revFlags);
+            } else {
+                revFlags = kRevDeleted;
+            }
+            
             retrying = false;
             if (savingDoc) {
                 // Update existing doc:
@@ -102,40 +101,45 @@ bool CBLDocument::save(CBLDatabase* db, const SaveOptions &opt) {
                 if (!newDoc && c4err != C4Error{LiteCoreDomain, kC4ErrorConflict})
                     C4Error::raise(c4err);
             }
-
-            if (!newDoc) {
-                // Conflict!
-                if (opt.conflictHandler) {
-                    // Custom conflict resolution:
-                    auto conflictingDoc = db->getDocument(_docID, true);
-                    if (conflictingDoc && conflictingDoc->revisionFlags() & kRevDeleted)
-                        conflictingDoc = nullptr;
-                    if (!opt.conflictHandler(opt.context, this, conflictingDoc))
-                        break;
-                    body = encodeBody(db, c4db, revFlags);
-                    if (conflictingDoc) {
-                        savingDoc = const_cast<C4Document*>(conflictingDoc->_c4doc.useLocked().get());
-                    } else {
-                        savingDoc = nullptr;
-                    }
-                    retrying = true;
-                } else if (opt.concurrency == kCBLConcurrencyControlLastWriteWins) {
+            
+            if (newDoc) {
+                // Success:
+                t.commit();
+            } else {
+                // Conflict:
+                if (opt.concurrency == kCBLConcurrencyControlLastWriteWins) {
                     // Last-write-wins; load current revision and retry:
                     savingDoc = c4db->getDocument(_docID, true, kDocGetCurrentRev);
                     retrying = true;
+                } else if (opt.conflictHandler) {
+                    // Get the conflicting doc used when calling the conflict handler.
+                    // The call to the conflict handler will be done outside the database's lock.
+                    conflictingDoc = db->getDocument(_docID, true);
                 }
             }
-        } while (retrying);
-
-        if (newDoc)
-            t.commit();
-    });
-
+        });
+        
+        if (!newDoc && !retrying && opt.conflictHandler) {
+            // Use conflict handler to solve the conflict:
+            if (conflictingDoc && conflictingDoc->revisionFlags() & kRevDeleted)
+                conflictingDoc = nullptr;
+            if (opt.conflictHandler(opt.context, this, conflictingDoc)) {
+                if (conflictingDoc) {
+                    savingDoc = const_cast<C4Document*>(conflictingDoc->_c4doc.useLocked().get());
+                    conflictingDoc = nullptr;
+                } else
+                    savingDoc = nullptr;
+                retrying = true;
+            }
+        }
+    } while (retrying);
+    
     if (!newDoc)
         return false;
 
     // Update my C4Document:
     _db = db;
+    auto c4doc = _c4doc.useLocked();
     c4doc.get() = move(newDoc);
     _revID = c4doc->selectedRev().revID;
     return true;

--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -181,7 +181,10 @@ public:
 
     struct SaveOptions {
         SaveOptions(CBLConcurrencyControl c)         :concurrency(c) { }
-        SaveOptions(CBLConflictHandler h, void* _cbl_nullable ctx) :conflictHandler(h), context(ctx) { }
+        SaveOptions(CBLConflictHandler h, void* _cbl_nullable ctx)
+        : conflictHandler(h)
+        ,context(ctx)
+        ,concurrency(kCBLConcurrencyControlFailOnConflict) { }
 
         CBLConcurrencyControl concurrency;
         CBLConflictHandler _cbl_nullable conflictHandler = nullptr;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,10 @@ project (CBL_C_Tests)
 
 set(TOP ${PROJECT_SOURCE_DIR}/../)
 
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+endif()
+    
 add_definitions(
     -DCBL_TESTS
     -DCATCH_CONFIG_CPP11_STREAM_INSERTABLE_CHECK

--- a/test/DatabaseTest.cc
+++ b/test/DatabaseTest.cc
@@ -428,6 +428,7 @@ TEST_CASE_METHOD(DatabaseTest, "Save Document with Conflict Handler") {
     FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
     
     CBLConflictHandler failConflict = [](void *c, CBLDocument *mine, const CBLDocument *existing) -> bool {
+        CHECK(!c);
         return false;
     };
     
@@ -475,6 +476,132 @@ TEST_CASE_METHOD(DatabaseTest, "Save Document with Conflict Handler") {
     CHECK(CBLDocument_Sequence(doc) == 3);
     CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\",\"name\":\"sally\",\"anotherName\":\"bob\"}"_sl);
     CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\",\"name\":\"sally\",\"anotherName\":\"bob\"}");
+    CBLDocument_Release(doc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Save Document with Conflict Handler : Called twice") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+    
+    CBLConflictHandler mergeConflict = [](void *c, CBLDocument *mine, const CBLDocument *existing) -> bool {
+        CHECK(c != nullptr);
+        CBLDatabase *theDB = (CBLDatabase*)c;
+        Dict dict = (CBLDocument_Properties(existing));
+        if (dict["name"].asString() == "bob"_sl) {
+            // Update the doc to cause a new conflict after first merge; the handler will be
+            // called again:
+            CHECK(CBLDatabase_LastSequence(theDB) == 2);
+            CBLError e;
+            CBLDocument* doc3 = CBLDatabase_GetMutableDocument(theDB, "foo"_sl, &e);
+            FLMutableDict props3 = CBLDocument_MutableProperties(doc3);
+            FLMutableDict_SetString(props3, "name"_sl, "max"_sl);
+            REQUIRE(CBLDatabase_SaveDocument(theDB, doc3, &e));
+            CBLDocument_Release(doc3);
+            CHECK(CBLDatabase_LastSequence(theDB) == 3);
+        } else {
+            CHECK(CBLDatabase_LastSequence(theDB) == 3);
+            CHECK(dict["name"].asString() == "max"_sl);
+        }
+        
+        FLMutableDict mergedProps = CBLDocument_MutableProperties(mine);
+        FLMutableDict_SetValue(mergedProps, "anotherName"_sl, dict["name"]);
+        return true;
+    };
+    
+    CBLError error;
+    REQUIRE(CBLDatabase_SaveDocument(db, doc, &error));
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 1);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+    CBLDocument_Release(doc);
+
+    CBLDocument* doc1 = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc1) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc1) == 1);
+    
+    CBLDocument* doc2 = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc2) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc2) == 1);
+    
+    FLMutableDict props1 = CBLDocument_MutableProperties(doc1);
+    FLMutableDict_SetString(props1, "name"_sl, "bob"_sl);
+    REQUIRE(CBLDatabase_SaveDocument(db, doc1, &error));
+    CHECK(CBLDocument_Sequence(doc1) == 2);
+    CBLDocument_Release(doc1);
+    
+    FLMutableDict props2 = CBLDocument_MutableProperties(doc2);
+    FLMutableDict_SetString(props2, "name"_sl, "sally"_sl);
+    CHECK(CBLDatabase_SaveDocumentWithConflictHandler(db, doc2, mergeConflict, db, &error));
+    CBLDocument_Release(doc2);
+    
+    doc = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 4);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\",\"name\":\"sally\",\"anotherName\":\"max\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\",\"name\":\"sally\",\"anotherName\":\"max\"}");
+    CBLDocument_Release(doc);
+}
+
+
+TEST_CASE_METHOD(DatabaseTest, "Save Document with Conflict Handler : On another thread") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+    
+    CBLConflictHandler mergeConflict = [](void *c, CBLDocument *myDoc, const CBLDocument *existingDoc) -> bool {
+        // Shouldn't have deadlock when accessing document or database properties
+        CHECK(c != nullptr);
+        CHECK(CBLDocument_Sequence(myDoc) > 0);
+        CHECK(CBLDatabase_LastSequence((CBLDatabase*)c) > 0);
+        
+        // Resolve in a different thread
+        thread t([](CBLDatabase* db, CBLDocument *mine, const CBLDocument *existing) {
+            // Shouldn't have deadlock when accessing document or database properties
+            CHECK(CBLDocument_Sequence(mine) > 0);
+            CHECK(CBLDatabase_LastSequence(db) > 0);
+            FLMutableDict mergedProps = CBLDocument_MutableProperties(mine);
+            FLMutableDict_SetString(mergedProps, "name"_sl, "max"_sl);
+        }, (CBLDatabase*)c, myDoc, existingDoc);
+        t.join();
+        
+        return true;
+    };
+    
+    CBLError error;
+    REQUIRE(CBLDatabase_SaveDocument(db, doc, &error));
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 1);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\"}");
+    CBLDocument_Release(doc);
+
+    CBLDocument* doc1 = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc1) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc1) == 1);
+    
+    CBLDocument* doc2 = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc2) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc2) == 1);
+    
+    FLMutableDict props1 = CBLDocument_MutableProperties(doc1);
+    FLMutableDict_SetString(props1, "name"_sl, "bob"_sl);
+    REQUIRE(CBLDatabase_SaveDocument(db, doc1, &error));
+    CHECK(CBLDocument_Sequence(doc1) == 2);
+    CBLDocument_Release(doc1);
+    
+    FLMutableDict props2 = CBLDocument_MutableProperties(doc2);
+    FLMutableDict_SetString(props2, "name"_sl, "sally"_sl);
+    CHECK(CBLDatabase_SaveDocumentWithConflictHandler(db, doc2, mergeConflict, db, &error));
+    CBLDocument_Release(doc2);
+    
+    doc = CBLDatabase_GetMutableDocument(db, "foo"_sl, &error);
+    CHECK(CBLDocument_ID(doc) == "foo"_sl);
+    CHECK(CBLDocument_Sequence(doc) == 3);
+    CHECK(alloc_slice(CBLDocument_CreateJSON(doc)) == "{\"greeting\":\"Howdy!\",\"name\":\"max\"}"_sl);
+    CHECK(Dict(CBLDocument_Properties(doc)).toJSONString() == "{\"greeting\":\"Howdy!\",\"name\":\"max\"}");
     CBLDocument_Release(doc);
 }
 


### PR DESCRIPTION
* Not lock the document while saving the document. This is inline with the implementation on the other platform. I have created CBL-2200 (post lithium) to prevent concurrent save/delete/purge on the same doc object.

* Call conflict handler outside database lock.

* Add more tests.