### PR TITLE
Fix empty server certs being loaded. Adds C++ header installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,11 +200,13 @@ install(
 )
 
 file(GLOB C_HEADERS ${PROJECT_SOURCE_DIR}/include/cbl/*.h)
-file(GLOB FLEECE_HEADERS ${PROJECT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/fleece/*.h)
+file(GLOB CPP_HEADERS ${PROJECT_SOURCE_DIR}/include/cbl++/*.hh)
+file(GLOB FLEECE_HEADERS ${PROJECT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/fleece/*.h*)
 
 install(EXPORT CouchbaseLiteTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CouchbaseLite)
 
 install(FILES ${C_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl)
+install(FILES ${CPP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl++)
 install(FILES ${PROJECT_BINARY_DIR}/generated_headers/public/cbl/CBL_Edition.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl)
 install(FILES ${FLEECE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fleece)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,13 +200,11 @@ install(
 )
 
 file(GLOB C_HEADERS ${PROJECT_SOURCE_DIR}/include/cbl/*.h)
-file(GLOB CPP_HEADERS ${PROJECT_SOURCE_DIR}/include/cbl++/*.hh)
-file(GLOB FLEECE_HEADERS ${PROJECT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/fleece/*.h*)
+file(GLOB FLEECE_HEADERS ${PROJECT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/fleece/*.h)
 
 install(EXPORT CouchbaseLiteTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CouchbaseLite)
 
 install(FILES ${C_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl)
-install(FILES ${CPP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl++)
 install(FILES ${PROJECT_BINARY_DIR}/generated_headers/public/cbl/CBL_Edition.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl)
 install(FILES ${FLEECE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fleece)
 

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -106,8 +106,10 @@ namespace cbl {
             conf.proxy = proxy;
             if (!headers.empty())
                 conf.headers = headers;
-            conf.pinnedServerCertificate = slice(pinnedServerCertificate);
-            conf.trustedRootCertificates = slice(trustedRootCertificates);
+            if (!pinnedServerCertificate.empty())
+                conf.pinnedServerCertificate = slice(pinnedServerCertificate);
+            if (!trustedRootCertificates.empty())
+                conf.trustedRootCertificates = slice(trustedRootCertificates);
             if (!channels.empty())
                 conf.channels = channels;
             if (!documentIDs.empty())


### PR DESCRIPTION
Not sure if the C++ headers not being installed was meant to be there - can't see why it would be. A `/usr/local/` install now works as expected for me. 

But mainly the fix ensures that string views of zero length strings are not used inadvertently. 