### PR TITLE
Release new blobs set in doc returned by conflict resolver

### DIFF
--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -105,6 +105,10 @@ typedef bool (*CBLReplicationFilter)(void* _cbl_nullable context,
     when the replicator finds a newer server-side revision of a document that also has local
     changes. The local and remote changes must be resolved before the document can be pushed
     to the server.
+    @note  Any new CBLBlob objects set to the resolved document returned by the callback must
+            not be released. They need to be retained for installation while the resolved document
+            is being saved into the database, and the replicator will be responsible for
+            releasing them after they are installed.
     @warning  This callback will be called on a background thread managed by the replicator.
                 It must pay attention to thread-safety. However, unlike a filter callback,
                 it does not need to return quickly. If it needs to prompt for user input,

--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -262,9 +262,26 @@ private:
     }
 
     static CBLNewBlob* _cbl_nullable findNewBlob(FLDict dict);
-    bool saveBlobs(CBLDatabase *db) const;  // returns true if there are blobs
+    
+    // Walk through the Fleece object tree, find new mutable blob Dicts to install.
+    //
+    // The releaseNewBlob flag allows to release the matched CBLNewBlob objects after being
+    // installed. The flag is set to true only when saving new blobs while encoding the document
+    // returned by the replicator's conflict resolved. The new blobs set to the resolved doc needs
+    // to be retained until they are installed here.
+    bool saveBlobs(CBLDatabase *db, bool releaseNewBlob) const;  // returns true if there are blobs
+    
+    // Encode the document body and install new blobs if found into the database.
+    //
+    // The releaseNewBlob option tells whether the new blob object should be released after
+    // being install or not. This option is set to true only when encoding the document
+    // returned by the replicator's conflict resolved.
+    //
+    // The outRevFlags will be updated with kRevHasAttachments if there is a blob found while
+    // encoding the document body.
     alloc_slice encodeBody(CBLDatabase* db,
                            C4Database* c4db,
+                           bool releaseNewBlob,
                            C4RevisionFlags &outRevFlags) const;
 
     using ValueToBlobMap = std::unordered_map<FLDict, Retained<CBLBlob>>;

--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -389,6 +389,8 @@ public:
                 CHECK(localDoc["expletive"] == nullptr);
                 Blob blob(localDoc["signature"].asDict());
                 CHECK(blob.loadContent() == "Bob!"_sl);
+                Blob blob2(localDoc["signature2"].asDict());
+                CHECK(blob2.loadContent() == "Bob!"_sl);
             }
         }
         
@@ -427,6 +429,8 @@ public:
                 CHECK(remoteDoc["expletive"] == nullptr);
                 Blob blob(localDoc["signature"].asDict());
                 CHECK(blob.loadContent() == "Bob!"_sl);
+                Blob blob2(localDoc["signature2"].asDict());
+                CHECK(blob2.loadContent() == "Bob!"_sl);
             }
         }
     }
@@ -479,6 +483,7 @@ public:
                     
                     auto blob = Blob("text/plain"_sl, "Bob!"_sl); // C++ Blob (RefCounted)
                     mergedProps["signature"] = blob.properties();
+                    mergedProps["signature2"] = blob.properties();
                     // Prevent blob from being released after returning, blob will be released
                     // after the blob is installed when the merged document body is encoded
                     // to save.
@@ -508,9 +513,9 @@ TEST_CASE_METHOD(ReplicatorConflictTest, "Custom resolver : remote wins", "[Repl
 
 TEST_CASE_METHOD(ReplicatorConflictTest, "Custom resolver : merge", "[Replicator][Conflict]") {
     testConflict(false, false, false, ResolverMode::kMerge);
-    testConflict(false, true, false, ResolverMode::kMerge); // Remote deletion
-    testConflict(true, false, false, ResolverMode::kMerge); // Local deletion
-    testConflict(false, false, true, ResolverMode::kMerge); // Merge deletion
+    // testConflict(false, true, false, ResolverMode::kMerge); // Remote deletion
+    // testConflict(true, false, false, ResolverMode::kMerge); // Local deletion
+    // testConflict(false, false, true, ResolverMode::kMerge); // Merge deletion
 }
 
 

--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -513,9 +513,9 @@ TEST_CASE_METHOD(ReplicatorConflictTest, "Custom resolver : remote wins", "[Repl
 
 TEST_CASE_METHOD(ReplicatorConflictTest, "Custom resolver : merge", "[Replicator][Conflict]") {
     testConflict(false, false, false, ResolverMode::kMerge);
-    // testConflict(false, true, false, ResolverMode::kMerge); // Remote deletion
-    // testConflict(true, false, false, ResolverMode::kMerge); // Local deletion
-    // testConflict(false, false, true, ResolverMode::kMerge); // Merge deletion
+    testConflict(false, true, false, ResolverMode::kMerge); // Remote deletion
+    testConflict(true, false, false, ResolverMode::kMerge); // Local deletion
+    testConflict(false, false, true, ResolverMode::kMerge); // Merge deletion
 }
 
 

--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -318,6 +318,8 @@ public:
             db.deleteDocument(doc);
         } else {
             doc["expletive"] = "Shazbatt!";
+            auto blob = Blob("text/plain"_sl, "Blob!"_sl);
+            doc["signature"] = blob.properties();
             db.saveDocument(doc);
             expectedLocalRevID = doc.revisionID();
         }
@@ -329,6 +331,8 @@ public:
             otherDB.deleteDocument(doc);
         } else {
             doc["expletive"] = "Frak!";
+            auto blob = Blob("text/plain"_sl, "Pop!"_sl);
+            doc["signature"] = blob.properties();
             otherDB.saveDocument(doc);
             expectedRemoteRevID = CBLDocument_CanonicalRevisionID(doc.ref());
         }
@@ -363,6 +367,8 @@ public:
                 REQUIRE(localDoc);
                 CHECK(localDoc["greeting"].asString() == "Howdy!"_sl);
                 CHECK(localDoc["expletive"].asString() == "Shazbatt!"_sl);
+                Blob blob(localDoc["signature"].asDict());
+                CHECK(blob.loadContent() == "Blob!"_sl);
             }
         } else if (resolverMode == ResolverMode::kRemoteWins) {
             if (deleteRemote) {
@@ -371,6 +377,8 @@ public:
                 REQUIRE(localDoc);
                 CHECK(localDoc["greeting"].asString() == "Howdy!"_sl);
                 CHECK(localDoc["expletive"].asString() == "Frak!"_sl);
+                Blob blob(localDoc["signature"].asDict());
+                CHECK(blob.loadContent() == "Pop!"_sl);
             }
         } else {
             if (deleteMerged) {
@@ -379,6 +387,8 @@ public:
                 REQUIRE(localDoc);
                 CHECK(localDoc["greeting"].asString() == "¡Hola!"_sl);
                 CHECK(localDoc["expletive"] == nullptr);
+                Blob blob(localDoc["signature"].asDict());
+                CHECK(blob.loadContent() == "Bob!"_sl);
             }
         }
         
@@ -395,6 +405,8 @@ public:
                 REQUIRE(remoteDoc);
                 CHECK(remoteDoc["greeting"].asString() == "Howdy!"_sl);
                 CHECK(remoteDoc["expletive"].asString() == "Shazbatt!"_sl);
+                Blob blob(localDoc["signature"].asDict());
+                CHECK(blob.loadContent() == "Blob!"_sl);
             }
         } else if (resolverMode == ResolverMode::kRemoteWins) {
             if (deleteRemote) {
@@ -403,6 +415,8 @@ public:
                 REQUIRE(remoteDoc);
                 CHECK(remoteDoc["greeting"].asString() == "Howdy!"_sl);
                 CHECK(remoteDoc["expletive"].asString() == "Frak!"_sl);
+                Blob blob(localDoc["signature"].asDict());
+                CHECK(blob.loadContent() == "Pop!"_sl);
             }
         } else {
             if (deleteMerged) {
@@ -411,6 +425,8 @@ public:
                 REQUIRE(remoteDoc);
                 CHECK(remoteDoc["greeting"].asString() == "¡Hola!"_sl);
                 CHECK(remoteDoc["expletive"] == nullptr);
+                Blob blob(localDoc["signature"].asDict());
+                CHECK(blob.loadContent() == "Bob!"_sl);
             }
         }
     }
@@ -459,8 +475,16 @@ public:
                 default:
                     CBLDocument *merged = CBLDocument_CreateWithID(documentID);
                     MutableDict mergedProps(CBLDocument_MutableProperties(merged));
-                    mergedProps.set("greeting"_sl, "¡Hola!");
-                    // do not release `merged`, otherwise it would be freed before returning!
+                    mergedProps["greeting"] = "¡Hola!";
+                    
+                    auto blob = Blob("text/plain"_sl, "Bob!"_sl); // C++ Blob (RefCounted)
+                    mergedProps["signature"] = blob.properties();
+                    // Prevent blob from being released after returning, blob will be released
+                    // after the blob is installed when the merged document body is encoded
+                    // to save.
+                    CBLBlob_Retain(blob.ref());
+                    
+                    // Do not release `merged`, otherwise it would be freed before returning!
                     return merged;
             }
         }


### PR DESCRIPTION
* Modified tests Custom resolver to test blobs in resolved doc. Found that during encoding the resolved doc body to save, the kHasAttachments flag has already been set properly if the doc contains blobs (CBL-2190).

* However found an issue that the new blobs set in the resolved doc need to be released but only after they are installed into the database. So fix the issue to allow the new blobs to be released and update the API comment of the conflict resolver callback that blobs need to be retained when returning the resolved doc.