### PR TITLE
CBL-2202 : Register new blob using digest

### DIFF
--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -260,11 +260,8 @@ CBLNewBlob* CBLDocument::findNewBlob(FLDict dict) {
         auto digest = Dict(dict)[kCBLBlobDigestProperty].asString();
         assert(digest);
         auto i = newBlobs.find(digest);
-        if (i == newBlobs.end()) {
-            CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
-                    "Couldn't find a registered new blob with digest '%.*s'", FMTSLICE(digest));
+        if (i == newBlobs.end())
             return nullptr;
-        } 
         return i->second;
     });
 }

--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -260,8 +260,12 @@ CBLNewBlob* CBLDocument::findNewBlob(FLDict dict) {
         auto digest = Dict(dict)[kCBLBlobDigestProperty].asString();
         assert(digest);
         auto i = newBlobs.find(digest);
-        if (i == newBlobs.end())
+        if (i == newBlobs.end()) {
+            CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
+                    "New blob instance looked up with digest '%.*s' was not found; the blob might have already been installed.",
+                    FMTSLICE(digest));
             return nullptr;
+        }
         return i->second;
     });
 }


### PR DESCRIPTION
Registered new blob using digest (slice) instead of blob properties (FLDict) so that the registered blob could be found when setting indirect blob properties into the document.

Note: slice is a subclass of pure_slice which implements hash function and == operator based on the slice's content.