### PR TITLE
Create a cmake script to generate dynamic build information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,8 @@ else()
     message("Building Community Edition")
 endif()
 
-configure_file(
-    "${PROJECT_SOURCE_DIR}/include/cbl/CBL_Edition.h.in"
-    "${PROJECT_BINARY_DIR}/generated_headers/public/cbl/CBL_Edition.h"
-)
+include(cmake/generate_edition.cmake)
+generate_edition()
 
 add_definitions("-DCMAKE")
 include(CheckIncludeFile)

--- a/cmake/generate_edition.cmake
+++ b/cmake/generate_edition.cmake
@@ -1,0 +1,104 @@
+macro(generate_edition)
+    if(CMAKE_SCRIPT_MODE_FILE STREQUAL CMAKE_CURRENT_LIST_FILE)
+        # Script mode, use environment
+        set(CBLITE_CE_DIR "${CMAKE_CURRENT_LIST_FILE}/../..")
+        if(NOT DEFINED VERSION)
+            message(
+                FATAL_ERROR 
+                "No version information passed (use -DVERSION=X.Y.Z)"
+            )
+        endif()
+
+        set(CouchbaseLite_C_VERSION ${VERSION})
+        if(NOT DEFINED OUTPUT_DIR)
+            message(
+                FATAL_ERROR 
+                "No output directory information passed (use -DOUTPUT_DIR=...)"
+            )
+        endif()
+
+        if(NOT DEFINED BLD_NUM)
+            message(
+                FATAL_ERROR 
+                "No build number information passed (use -DBLD_NUM=###)"
+            )
+        endif()
+        set(CouchbaseLite_C_BUILD ${BLD_NUM})
+
+        string(REPLACE "." ";" TMP ${CouchbaseLite_C_VERSION})
+        list(LENGTH TMP TMP_COUNT)
+        if(NOT TMP_COUNT EQUAL 3)
+            message(FATAL_ERROR "Invalid version passed (${CouchbaseLite_C_VERSION}), must be format X.Y.Z")
+        endif()
+
+        list(GET TMP 0 CouchbaseLite_C_VERSION_MAJOR)
+        list(GET TMP 1 CouchbaseLite_C_VERSION_MINOR)
+        list(GET TMP 2 CouchbaseLite_C_VERSION_PATCH)
+    else()
+        set(CBLITE_CE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+        set(OUTPUT_DIR ${PROJECT_BINARY_DIR})
+        if(NOT DEFINED CouchbaseLite_C_VERSION OR
+            NOT DEFINED CouchbaseLite_C_VERSION_MAJOR OR
+            NOT DEFINED CouchbaseLite_C_VERSION_MINOR OR
+            NOT DEFINED CouchbaseLite_C_VERSION_PATCH)
+            message(FATAL_ERROR "Required variable from parent not defined, aborting...")
+        endif()
+
+        if(DEFINED ENV{BLD_NUM})
+            set(CouchbaseLite_C_BUILD $ENV{BLD_NUM})
+        else()
+            message(WARNING "No BLD_NUM set, defaulting to 0...")
+            set(CouchbaseLite_C_BUILD 0)
+        endif()
+    endif()
+
+    math(EXPR CouchbaseLite_C_VERNUM "${CouchbaseLite_C_VERSION_MAJOR} * 1000000 + ${CouchbaseLite_C_VERSION_MINOR} * 1000 + ${CouchbaseLite_C_VERSION_PATCH}")
+    string(TIMESTAMP CouchbaseLite_C_SOURCE_ID)
+
+    find_package(Git)
+    if(Git_FOUND)
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+            WORKING_DIRECTORY ${CBLITE_CE_DIR} 
+            OUTPUT_VARIABLE HASH
+            RESULT_VARIABLE SUCCESS
+        )
+
+        if(NOT SUCCESS EQUAL 0)
+            message(WARNING "Failed to get CE hash of build!")
+        else()
+            string(SUBSTRING ${HASH} 0 7 HASH)
+        endif()
+        
+        if(BUILD_ENTERPRISE)
+            set(EE_PATH ${CBLITE_CE_DIR}/../couchbase-lite-c-ee)
+            execute_process(
+                COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+                WORKING_DIRECTORY ${EE_PATH} 
+                OUTPUT_VARIABLE EE_HASH
+                RESULT_VARIABLE SUCCESS
+            )
+
+            if(NOT SUCCESS EQUAL 0)
+                message(WARNING "Failed to get EE hash of build!")
+            else()
+                string(SUBSTRING ${EE_HASH} 0 7 EE_HASH)
+            endif()
+
+            string(PREPEND HASH "${EE_HASH}+")
+        endif()
+        string(APPEND CouchbaseLite_C_SOURCE_ID " ${HASH}")
+    else()
+        string(APPEND CouchbaseLite_C_SOURCE_ID " <unknown commit>")
+    endif()
+    
+    configure_file(
+        "${CBLITE_CE_DIR}/include/cbl/CBL_Edition.h.in"
+        "${OUTPUT_DIR}/generated_headers/public/cbl/CBL_Edition.h"
+    )
+    message(STATUS "Wrote ${OUTPUT_DIR}/generated_headers/public/cbl/CBL_Edition.h...")
+endmacro()
+
+if(CMAKE_SCRIPT_MODE_FILE STREQUAL CMAKE_CURRENT_LIST_FILE)
+    generate_edition()
+endif()

--- a/cmake/generate_edition.cmake
+++ b/cmake/generate_edition.cmake
@@ -1,6 +1,6 @@
 macro(generate_edition)
     if(CMAKE_SCRIPT_MODE_FILE STREQUAL CMAKE_CURRENT_LIST_FILE)
-        # Script mode, use environment
+        # Script mode, use passed values
         set(CBLITE_CE_DIR "${CMAKE_CURRENT_LIST_FILE}/../..")
         if(NOT DEFINED VERSION)
             message(
@@ -8,8 +8,8 @@ macro(generate_edition)
                 "No version information passed (use -DVERSION=X.Y.Z)"
             )
         endif()
-
         set(CouchbaseLite_C_VERSION ${VERSION})
+
         if(NOT DEFINED OUTPUT_DIR)
             message(
                 FATAL_ERROR 
@@ -35,6 +35,7 @@ macro(generate_edition)
         list(GET TMP 1 CouchbaseLite_C_VERSION_MINOR)
         list(GET TMP 2 CouchbaseLite_C_VERSION_PATCH)
     else()
+        # CMakeLists.txt mode, use already available values or environment
         set(CBLITE_CE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
         set(OUTPUT_DIR ${PROJECT_BINARY_DIR})
         if(NOT DEFINED CouchbaseLite_C_VERSION OR

--- a/include/cbl/CBL_Edition.h.in
+++ b/include/cbl/CBL_Edition.h.in
@@ -19,3 +19,8 @@
 #ifndef COUCHBASE_ENTERPRISE
 #cmakedefine COUCHBASE_ENTERPRISE
 #endif
+
+#define CBLITE_VERSION "@CouchbaseLite_C_VERSION@"
+#define CBLITE_VERSION_NUMBER @CouchbaseLite_C_VERNUM@
+#define CBLITE_BUILD_NUMBER @CouchbaseLite_C_BUILD@
+#define CBLITE_SOURCE_ID "@CouchbaseLite_C_SOURCE_ID@"


### PR DESCRIPTION
This will be scooped up as part of the main CMake configuration, but also it can be run in standalone by invoking CMake in script processing mode such as the following:

`cmake -DVERSION="3.0.0" -DOUTPUT_DIR="$pwd" -DBLD_NUM=67 -DBUILD_ENTERPRISE=ON -P ..\cmake\generate_edition.cmake`

This means it can be used in the Xcode build as well