### PR TITLE
Stop Replicators and Live Queries when closing or deleting database

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		27DBD09C246CA60E002FD7A7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 271A98AF243FDF55008C032D /* SystemConfiguration.framework */; };
 		27DBD0A9246CA667002FD7A7 /* CBLLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 277B77C6245B44BE00B222D3 /* CBLLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6938073022DE96C200727053 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 277CC9B122BC4E2E00B245CB /* Security.framework */; };
+		932062DB26BC6B43006917A5 /* CBLQuery.cc in Sources */ = {isa = PBXBuildFile; fileRef = 932062DA26BC6B43006917A5 /* CBLQuery.cc */; };
 		93965A6326A7CD50008728EE /* LogTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 93965A6226A7CD50008728EE /* LogTest.cc */; };
 		93965A6426A7CD50008728EE /* LogTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 93965A6226A7CD50008728EE /* LogTest.cc */; };
 /* End PBXBuildFile section */
@@ -374,6 +375,7 @@
 		27DBCF41246B81EE002FD7A7 /* LibC++Debug.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "LibC++Debug.cc"; sourceTree = "<group>"; };
 		27DBD096246C99AF002FD7A7 /* mergeIntoStaticLib.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = mergeIntoStaticLib.sh; sourceTree = "<group>"; };
 		27DBD097246C9DE7002FD7A7 /* CBLDatabase+Apple.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "CBLDatabase+Apple.mm"; sourceTree = "<group>"; };
+		932062DA26BC6B43006917A5 /* CBLQuery.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLQuery.cc; sourceTree = "<group>"; };
 		93965A6226A7CD50008728EE /* LogTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogTest.cc; sourceTree = "<group>"; };
 		93D0AFF1262619B800777AFC /* generate_edition_header.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = generate_edition_header.sh; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -489,6 +491,7 @@
 				271C2A7721CC750E0045856E /* CBLDocument.cc */,
 				277FEE7A21ED6C0000B60E3C /* CBLDocument_Internal.hh */,
 				277B77D4245B44E900B222D3 /* CBLLog.cc */,
+				932062DA26BC6B43006917A5 /* CBLQuery.cc */,
 				27DBCF2E246B4352002FD7A7 /* CBLQuery_Internal.hh */,
 				27D11BFF235140E300C58A70 /* CBLReplicator_Internal.hh */,
 				277FEE7621ED62AA00B60E3C /* CBLReplicatorConfig.hh */,
@@ -1188,6 +1191,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				932062DB26BC6B43006917A5 /* CBLQuery.cc in Sources */,
 				271C2A6F21CAD5B30045856E /* CBLBase_CAPI.cc in Sources */,
 				277B77D5245B44E900B222D3 /* CBLLog.cc in Sources */,
 				271C2A7221CADB170045856E /* CBLDatabase.cc in Sources */,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(
     src/CBLDocument.cc
     src/CBLDocument_CAPI.cc
     src/CBLLog.cc
+    src/CBLQuery.cc
     src/CBLQuery_CAPI.cc
     src/CBLReplicator_CAPI.cc
     src/ConflictResolver.cc

--- a/src/CBLQuery.cc
+++ b/src/CBLQuery.cc
@@ -1,0 +1,35 @@
+//
+// CBLQuery.cc
+//
+// Copyright © 2018 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "CBLDatabase_Internal.hh"
+#include "CBLQuery_Internal.hh"
+
+void ListenerToken<CBLQueryChangeListener>::setEnabled(bool enabled) {
+    auto c4query = _query->_c4query.useLocked();
+    CBLDatabase* db = const_cast<CBLDatabase*>(_query->database());
+    if (enabled) {
+        if (!db->registerStoppable(this)) {
+            CBL_Log(kCBLLogDomainQuery, kCBLLogWarning,
+                    "Couldn't enable the Query Listener as the database is closing or closed.");
+            return;
+        }
+    }
+    _c4obs->setEnabled(enabled);
+    if (!enabled)
+        db->unregisterStoppable(this);
+}

--- a/src/Internal.hh
+++ b/src/Internal.hh
@@ -42,6 +42,12 @@ protected:
 };
 
 
+struct CBLStoppable {
+    virtual ~CBLStoppable() = default;
+    virtual void stop() = 0;
+};
+
+
 namespace cbl_internal {
     // Converting C4Error <--> CBLError
     static inline       C4Error* _cbl_nullable internal(CBLError* _cbl_nullable error) {return (C4Error*)error;}


### PR DESCRIPTION
Implemented the logic to allow to register and unregister stoppable objects (Replicators and Query Listener Tokens) to the database so that the database can calls to stop when it is being closed or deleted.

CBL-2135 and CBL-2221