### PR TITLE
@snej Make FLDict_GetBlob work in query results (CBL-2269)

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -578,10 +578,10 @@
 			isa = PBXGroup;
 			children = (
 				277FEE5021E6BC2100B60E3C /* CouchbaseLite.hh */,
-				27B61DD821DEEC540027CCDB /* Database.hh */,
-				277FEE4E21DEF54D00B60E3C /* Document.hh */,
 				277FEE3D21DEF0C700B60E3C /* Base.hh */,
 				275BC4E22204E6A800DBE7D2 /* Blob.hh */,
+				27B61DD821DEEC540027CCDB /* Database.hh */,
+				277FEE4E21DEF54D00B60E3C /* Document.hh */,
 				277FEE4F21E6AB1100B60E3C /* Query.hh */,
 				27C9B5F121F7D74A0040BC45 /* Replicator.hh */,
 			);

--- a/Xcode/xcconfigs/Tests.xcconfig
+++ b/Xcode/xcconfigs/Tests.xcconfig
@@ -8,3 +8,5 @@
 
 HEADER_SEARCH_PATHS     = include Xcode/generated_headers/public/cbl $(FLEECE)/API  $(FLEECE)/Fleece/Support  $(FLEECE)/vendor/catch
 PRODUCT_NAME            = cbl_tests
+
+LLVM_LTO                    = NO    // LTO makes tests very slow to link and confuses Instruments

--- a/Xcode/xcconfigs/XCTests.xcconfig
+++ b/Xcode/xcconfigs/XCTests.xcconfig
@@ -13,3 +13,5 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/.. @loader_path/..
 INFOPLIST_FILE          = Xcode/Tests-Info.plist
 PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.CouchbaseLiteTests
 PRODUCT_NAME            = $(TARGET_NAME)
+
+LLVM_LTO                    = NO    // LTO makes tests very slow to link and confuses Instruments

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -105,7 +105,7 @@ public: \
     explicit operator bool() const                {return valid();} \
     bool operator==(const CLASS &other) const     {return _ref == other._ref;} \
     bool operator!=(const CLASS &other) const     {return _ref != other._ref;} \
-    C_TYPE* ref() const                           {return (C_TYPE*)_ref;}\
+    C_TYPE* _cbl_nullable ref() const             {return (C_TYPE*)_ref;}\
 protected: \
     explicit CLASS(C_TYPE* ref)                   :SUPER((CBLRefCounted*)ref) { }
 

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -72,6 +72,8 @@ namespace cbl {
         }
 
         void clear()                                    {CBL_Release(_ref); _ref = nullptr;}
+        bool valid() const                              {return _ref != nullptr;} \
+        explicit operator bool() const                  {return valid();} \
 
         static std::string asString(FLSlice s)          {return slice(s).asString();}
         static std::string asString(FLSliceResult &&s)  {return alloc_slice(s).asString();}
@@ -101,7 +103,7 @@ public: \
     CLASS& operator=(const CLASS &other) noexcept {SUPER::operator=(other); return *this;} \
     CLASS& operator=(CLASS &&other) noexcept      {SUPER::operator=((SUPER&&)other); return *this;}\
     CLASS& operator=(std::nullptr_t)              {clear(); return *this;} \
-    bool valid() const                            {return _ref != nullptr;} \
+    bool valid() const                            {return RefCounted::valid();} \
     explicit operator bool() const                {return valid();} \
     bool operator==(const CLASS &other) const     {return _ref == other._ref;} \
     bool operator!=(const CLASS &other) const     {return _ref != other._ref;} \

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -39,7 +39,7 @@ namespace cbl {
     public:
         static bool isBlob(fleece::Dict d)  {return FLDict_IsBlob(d);}
 
-        /* Creates a new blobgiven its contents as a single block of data.
+        /** Creates a new blob, given its contents as a single block of data.
             @note  The memory pointed to by `contents` is no longer needed after this call completes
                     (it will have been written to the database.)
             @param contentType  The MIME type (optional).
@@ -56,8 +56,11 @@ namespace cbl {
         inline Blob(slice contentType,
                     BlobWriteStream& writer);
 
-        /** Constructs a Blob instance on an existing blob reference in a document. */
-        Blob(fleece::Dict d)
+        /** Constructs a Blob instance on an existing blob reference in a document or query result.
+            @note If the dict argument is not actually a blob reference, this Blob object will be
+            invalid; you can check that by calling its `valid` method or testing it with its
+            `operator bool`. */
+        Blob(fleece::Dict d) 
         :RefCounted((CBLRefCounted*) FLDict_GetBlob(d))
         { }
 

--- a/include/cbl/CBLBlob.h
+++ b/include/cbl/CBLBlob.h
@@ -74,7 +74,7 @@ CBL_CAPI_BEGIN
     /** Returns a CBLBlob object corresponding to a blob dictionary in a document.
         @param blobDict  A dictionary in a document.
         @return  A CBLBlob instance for this blob, or NULL if the dictionary is not a blob. */
-    const CBLBlob* FLDict_GetBlob(FLDict _cbl_nullable blobDict) CBLAPI;
+    const CBLBlob* _cbl_nullable FLDict_GetBlob(FLDict _cbl_nullable blobDict) CBLAPI;
 
 #ifdef __APPLE__
 #pragma mark - BLOB METADATA:
@@ -112,8 +112,8 @@ CBL_CAPI_BEGIN
 
     /** Opens a stream for reading a blob's content. */
     _cbl_warn_unused
-    CBLBlobReadStream* CBLBlob_OpenContentStream(const CBLBlob* blob,
-                                                 CBLError* _cbl_nullable outError) CBLAPI;
+    CBLBlobReadStream* _cbl_nullable CBLBlob_OpenContentStream(const CBLBlob* blob,
+                                                               CBLError* _cbl_nullable) CBLAPI;
 
     /** Reads data from a blob.
         @param stream  The stream to read from.
@@ -155,8 +155,8 @@ CBL_CAPI_BEGIN
 
         If for some reason you need to abort, just call \ref CBLBlobWriter_Close. */
     _cbl_warn_unused
-    CBLBlobWriteStream* CBLBlobWriter_Create(CBLDatabase* db,
-                                             CBLError* _cbl_nullable outError) CBLAPI;
+    CBLBlobWriteStream* _cbl_nullable CBLBlobWriter_Create(CBLDatabase* db,
+                                                           CBLError* _cbl_nullable) CBLAPI;
 
     /** Closes a blob-writing stream, if you need to give up without creating a \ref CBLBlob. */
     void CBLBlobWriter_Close(CBLBlobWriteStream* _cbl_nullable) CBLAPI;
@@ -198,7 +198,7 @@ CBL_CAPI_BEGIN
         @param value  The value (dictionary) in the document.
         @return  A \ref CBLBlob instance for this blob, or `NULL` if the value is not a blob.
         @note You are responsible for releasing the \ref CBLBlob object.  */
-    static inline const CBLBlob* FLValue_GetBlob(FLValue _cbl_nullable value) {
+    static inline const CBLBlob* _cbl_nullable FLValue_GetBlob(FLValue _cbl_nullable value) {
         return FLDict_GetBlob(FLValue_AsDict(value));
     }
 

--- a/src/CBLDatabase.cc
+++ b/src/CBLDatabase.cc
@@ -66,6 +66,22 @@ bool CBLEncryptionKey_FromPassword(CBLEncryptionKey *key, FLString password) CBL
 #pragma mark - QUERY:
 
 
+Retained<CBLQuery> CBLDatabase::createQuery(CBLQueryLanguage language,
+                                            slice queryString,
+                                            int* _cbl_nullable outErrPos) const
+{
+    alloc_slice json;
+    if (language == kCBLJSONLanguage) {
+        json = convertJSON5(queryString); // allow JSON5 as a convenience
+        queryString = json;
+    }
+    auto c4query = _c4db.useLocked()->newQuery((C4QueryLanguage)language, queryString, outErrPos);
+    if (!c4query)
+        return nullptr;
+    return new CBLQuery(this, std::move(c4query), _c4db);
+}
+
+
 namespace cbl_internal {
 
     void ListenerToken<CBLQueryChangeListener>::queryChanged() {

--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -20,7 +20,6 @@
 #include "CBLDatabase.h"
 #include "CBLDocument_Internal.hh"
 #include "CBLPrivate.h"
-#include "CBLQuery_Internal.hh"
 #include "c4Collection.hh"
 #include "c4Database.hh"
 #include "c4Observer.hh"
@@ -150,7 +149,7 @@ public:
         C4Database::Transaction t(c4db);
         Retained<C4Document> c4doc = c4db->getDocument(docID, false, kDocGetCurrentRev);
         if (c4doc)
-            c4doc = c4doc->update(nullslice, kRevDeleted);
+            c4doc = c4doc->update(fleece::nullslice, kRevDeleted);
         if (!c4doc)
             return false;
         t.commit();
@@ -176,18 +175,7 @@ public:
 
     Retained<CBLQuery> createQuery(CBLQueryLanguage language,
                                    slice queryString,
-                                   int* _cbl_nullable outErrPos) const
-    {
-        alloc_slice json;
-        if (language == kCBLJSONLanguage) {
-            json = convertJSON5(queryString); // allow JSON5 as a convenience
-            queryString = json;
-        }
-        auto c4query = _c4db.useLocked()->newQuery((C4QueryLanguage)language, queryString, outErrPos);
-        if (!c4query)
-            return nullptr;
-        return new CBLQuery(this, std::move(c4query), _c4db);
-    }
+                                   int* _cbl_nullable outErrPos) const;
     
     void createValueIndex(slice name, CBLValueIndexConfiguration config) {
         C4IndexOptions options = {};
@@ -349,7 +337,7 @@ private:
         if (inDirectory) {
             return inDirectory;
         } else {
-            static const string kDir = defaultDirectory();
+            static const std::string kDir = defaultDirectory();
             return slice(kDir);
         }
     }
@@ -371,7 +359,7 @@ private:
     }
 
     void databaseChanged() {
-        notify(bind(&CBLDatabase::callDBListeners, this));
+        notify(std::bind(&CBLDatabase::callDBListeners, this));
     }
 
     void callDBListeners() {

--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -170,11 +170,13 @@ public:
 #pragma mark - Blobs:
 
 
-    CBLBlob*  _cbl_nullable getBlob(FLDict dict);
+    CBLBlob*  _cbl_nullable getBlob(FLDict dict, const C4BlobKey&);
 
     static void registerNewBlob(CBLNewBlob* blob);
 
     static void unregisterNewBlob(CBLNewBlob* blob);
+
+    static CBLNewBlob* _cbl_nullable findNewBlob(FLDict dict);
 
 
 #pragma mark - Save/delete:
@@ -261,8 +263,6 @@ private:
             C4Error::raise(LiteCoreDomain, kC4ErrorNotWriteable, "Document object is immutable");
     }
 
-    static CBLNewBlob* _cbl_nullable findNewBlob(FLDict dict);
-    
     // Walk through the Fleece object tree, find new mutable blob Dicts to install.
     //
     // The releaseNewBlob flag allows to release the matched CBLNewBlob objects after being

--- a/src/CBLPrivate.h
+++ b/src/CBLPrivate.h
@@ -49,6 +49,7 @@ CBL_CAPI_BEGIN
         FLHeapSlice revID;          ///< The latest revision ID (or null if doc was purged)
         uint64_t sequence;          ///< The latest sequence number (or 0 if doc was purged)
         uint32_t bodySize;          ///< The size of the revision body in bytes
+        uint8_t flags;
     } CBLDatabaseChange;    // Note: This must remain identical in layout to C4DatabaseChange
 
     typedef void (*CBLDatabaseChangeDetailListener)(void* _cbl_nullable context,

--- a/src/CBLQuery_CAPI.cc
+++ b/src/CBLQuery_CAPI.cc
@@ -21,6 +21,7 @@
 #include "CBLQuery_Internal.hh"
 #include <string>
 
+using namespace std;
 
 CBLQuery* CBLDatabase_CreateQuery(const CBLDatabase* db,
                                   CBLQueryLanguage language,

--- a/test/CBLTest_Cpp.hh
+++ b/test/CBLTest_Cpp.hh
@@ -21,6 +21,22 @@
 #include "CBLTest.hh"
 
 
+namespace cbl {
+    // Make Catch write something better than "{?}" when it logs a CBL object:
+    #define DEFINE_WRITE_OP(CLASS) \
+        static inline std::ostream& operator<< (std::ostream &out, const cbl::CLASS &rc) { \
+            return out << "cbl::" #CLASS "[@" << (void*)rc.ref() << "]"; \
+        }
+    DEFINE_WRITE_OP(Blob)
+    DEFINE_WRITE_OP(Database)
+    DEFINE_WRITE_OP(Document)
+    DEFINE_WRITE_OP(MutableDocument)
+    DEFINE_WRITE_OP(Query)
+    DEFINE_WRITE_OP(Replicator)
+    DEFINE_WRITE_OP(ResultSet)
+}
+
+
 class CBLTest_Cpp {
 public:
     static const fleece::alloc_slice kDatabaseDir;

--- a/test/DatabaseTest.cc
+++ b/test/DatabaseTest.cc
@@ -1305,6 +1305,7 @@ TEST_CASE_METHOD(DatabaseTest, "Set blob in document", "[Blob]") {
     doc = CBLDatabase_GetMutableDocument(db, "doc1"_sl, &error);
     docProps = CBLDocument_MutableProperties(doc);
     const CBLBlob* blob2 = FLValue_GetBlob(FLDict_Get(docProps, "blob"_sl));
+    REQUIRE(blob2);
     FLSliceResult content = CBLBlob_Content(blob2, &error);
     CHECK((slice)content == blobContent);
     FLSliceResult_Release(content);

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -431,7 +431,7 @@ static int countResults(ResultSet &results) {
     return n;
 }
 
-TEST_CASE_METHOD(QueryTest_Cpp, "Query Listener, C++ API", "[Query]") {
+TEST_CASE_METHOD(QueryTest_Cpp, "Query Listener C++ API", "[Query]") {
     Query query(db, kCBLN1QLLanguage, "SELECT name WHERE birthday like '1959-%' ORDER BY birthday");
     {
         auto rs = query.execute();


### PR DESCRIPTION
Using new Fleece API `FLDoc_SetAssociated` (https://github.com/couchbaselabs/fleece/pull/109) to associate a CBLQuery with the Fleece data of a query result set. This then allows CBLBlob to discover when a Value belongs to such a result set, and create a CBLBlob on it.

Other changes:
* Added some missing `_cbl_nullable` annotations; this was triggering the
  Clang UB Sanitizer during tests.
* CBLQuery_Internal.hh still had some `using namespace` declarations, which
  we've decided we don't want in headers, so I removed them. This then meant
  I had to add some missing `std::` and `fleece::` prefixes in other headers
  that now became syntax errors.
* I had to move several CBLResultSet methods from the header to the .cc file,
  because they use CBLBlob but the header can't include CBLBlob_Internal.hh
  without creating an include loop. Once I'd done that, it seemed cleaner to
  move the class's other nontrivial methods to the .cc file too.

For CBL-2269

### Also: Free bonus minor-improvements commit!!!1!

* C++ API: Make the `valid` and `operator bool` methods more visible in the
  header; I overlooked them for a while today because they were declared only in
  the CBL_REFCOUNTED_BOILERPLATE macro.
* Added some `operator<<` overloads so Catch can log CBL C++ objects better.
* Renamed a unit test, taking a comma out of its name because for some reason
  Xcode's scheme editor cannot properly quote an arg with commas in it.
* Xcode: Sorted the filenames in the include/cbl++ group.
* Xcode: Disable LTO when building tests in Release.