### PR TITLE
CBL-2253: Change CBL_CORE_API to CBL_PUBLIC and add explanation

### DIFF
--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -69,7 +69,7 @@ function(set_dylib_properties)
     endif()
     
     target_link_libraries(cblite PRIVATE zlibstatic Ws2_32)
-    target_compile_definitions(cblite-static PRIVATE LITECORE_EXPORTS)
+    target_compile_definitions(cblite-static PRIVATE CBL_EXPORTS)
 
     configure_file(
         "${PROJECT_SOURCE_DIR}/cmake/cblite.rc.in"

--- a/include/cbl/CBLBlob.h
+++ b/include/cbl/CBLBlob.h
@@ -54,12 +54,12 @@ CBL_CAPI_BEGIN
 
  */
 
-    CBL_CORE_API extern const FLSlice kCBLTypeProperty;             ///< `"@type"`
-    CBL_CORE_API extern const FLSlice kCBLBlobType;                 ///< `"blob"`
+    CBL_PUBLIC extern const FLSlice kCBLTypeProperty;             ///< `"@type"`
+    CBL_PUBLIC extern const FLSlice kCBLBlobType;                 ///< `"blob"`
 
-    CBL_CORE_API extern const FLSlice kCBLBlobDigestProperty;       ///< `"digest"`
-    CBL_CORE_API extern const FLSlice kCBLBlobLengthProperty;       ///< `"length"`
-    CBL_CORE_API extern const FLSlice kCBLBlobContentTypeProperty;  ///< `"content_type"`
+    CBL_PUBLIC extern const FLSlice kCBLBlobDigestProperty;       ///< `"digest"`
+    CBL_PUBLIC extern const FLSlice kCBLBlobLengthProperty;       ///< `"length"`
+    CBL_PUBLIC extern const FLSlice kCBLBlobContentTypeProperty;  ///< `"content_type"`
 
 
     CBL_REFCOUNTED(CBLBlob*, Blob);

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -31,7 +31,7 @@ CBL_CAPI_BEGIN
     @{ */
 
 /** The name of the HTTP cookie used by Sync Gateway to store session keys. */
-CBL_CORE_API extern const FLString kCBLAuthDefaultCookieName;
+CBL_PUBLIC extern const FLString kCBLAuthDefaultCookieName;
 
 /** An opaque object representing the location of a database to replicate with. */
 typedef struct CBLEndpoint CBLEndpoint;
@@ -129,7 +129,7 @@ typedef const CBLDocument* _cbl_nullable (*CBLConflictResolver)(void* _cbl_nulla
                                                   const CBLDocument* _cbl_nullable remoteDocument);
 
 /** Default conflict resolver. This always returns `localDocument`. */
-CBL_CORE_API extern const CBLConflictResolver CBLDefaultConflictResolver;
+CBL_PUBLIC extern const CBLConflictResolver CBLDefaultConflictResolver;
 
 
 /** Types of proxy servers, for CBLProxySettings. */

--- a/include/cbl/CBL_Compat.h
+++ b/include/cbl/CBL_Compat.h
@@ -105,15 +105,20 @@
 #endif
 
 
-// Export/import stuff:
+// On Windows, CBL_PUBLIC marks symbols as being exported from the shared library.
+// However, this is not the whole list of things that are exported.  The API methods
+// are exported using a definition list, but it is not possible to correctly include
+// initialized global variables, so those need to be marked (both in the header and 
+// implementation) with CBL_PUBLIC.  See kCBLTypeProperty in CBLBlob.h and CBLBlob_CPI.cc
+// for an example.
 #ifdef _MSC_VER
-    #ifdef LITECORE_EXPORTS
-        #define CBL_CORE_API __declspec(dllexport)
+    #ifdef CBL_EXPORTS
+        #define CBL_PUBLIC __declspec(dllexport)
     #else
-        #define CBL_CORE_API __declspec(dllimport)
+        #define CBL_PUBLIC __declspec(dllimport)
     #endif
 #else // _MSC_VER
-    #define CBL_CORE_API
+    #define CBL_PUBLIC
 #endif
 
 // Type-checking for printf-style vararg functions:

--- a/src/CBLBlob_CAPI.cc
+++ b/src/CBLBlob_CAPI.cc
@@ -22,11 +22,11 @@ using namespace std;
 using namespace fleece;
 
 
-CBL_CORE_API const FLSlice kCBLTypeProperty              = C4Document::kObjectTypeProperty;
-CBL_CORE_API const FLSlice kCBLBlobType                  = C4Blob::kObjectType_Blob;
-CBL_CORE_API const FLSlice kCBLBlobDigestProperty        = C4Blob::kDigestProperty;
-CBL_CORE_API const FLSlice kCBLBlobLengthProperty        = C4Blob::kLengthProperty;
-CBL_CORE_API const FLSlice kCBLBlobContentTypeProperty   = C4Blob::kContentTypeProperty;
+CBL_PUBLIC const FLSlice kCBLTypeProperty              = C4Document::kObjectTypeProperty;
+CBL_PUBLIC const FLSlice kCBLBlobType                  = C4Blob::kObjectType_Blob;
+CBL_PUBLIC const FLSlice kCBLBlobDigestProperty        = C4Blob::kDigestProperty;
+CBL_PUBLIC const FLSlice kCBLBlobLengthProperty        = C4Blob::kLengthProperty;
+CBL_PUBLIC const FLSlice kCBLBlobContentTypeProperty   = C4Blob::kContentTypeProperty;
 
 
 FLDict CBLBlob_Properties(const CBLBlob* blob) noexcept {

--- a/src/CBLLog.cc
+++ b/src/CBLLog.cc
@@ -216,7 +216,7 @@ bool CBLLog_SetFileConfig(CBLLogFileConfiguration config, CBLError *outError) CB
 }
 
 
-extern "C" CBL_CORE_API std::atomic_int gC4ExpectExceptions;
+extern "C" CBL_PUBLIC std::atomic_int gC4ExpectExceptions;
 
 void CBLLog_BeginExpectingExceptions() CBLAPI {
     ++gC4ExpectExceptions;

--- a/src/ConflictResolver.cc
+++ b/src/ConflictResolver.cc
@@ -46,7 +46,7 @@ static const CBLDocument* defaultConflictResolver(void *context,
     return resolved;
 }
 
-CBL_CORE_API const CBLConflictResolver CBLDefaultConflictResolver = &defaultConflictResolver;
+CBL_PUBLIC const CBLConflictResolver CBLDefaultConflictResolver = &defaultConflictResolver;
 
 
 namespace cbl_internal {


### PR DESCRIPTION
Note: choosing CBL_PUBLIC instead of CBL_API because of the already similarly named CBLAPI a few lines below.