### PR TITLE
Catch BadDocID and log warning instead of throwing

### DIFF
--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -24,6 +24,7 @@
 #include "c4Collection.hh"
 #include "c4Database.hh"
 #include "c4Observer.hh"
+#include "Error.hh"
 #include "Internal.hh"
 #include "Listener.hh"
 #include "access_lock.hh"
@@ -359,14 +360,12 @@ private:
         Retained<C4Document> c4doc = nullptr;
         try {
             c4doc = _c4db.useLocked()->getDocument(docID, true, content);
-        } catch (...) {
-            C4Error err = C4Error::fromCurrentException();
-            if (err == C4Error{LiteCoreDomain, kC4ErrorBadDocID}) {
+        } catch (litecore::error& e) {
+            if (e == litecore::error::BadDocID) {
                 CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
-                        "Use an invalid document ID '%.*s' to get a document", FMTSLICE(docID));
+                        "Invalid document ID '%.*s' used", FMTSLICE(docID));
                 return nullptr;
             }
-            throw;
         }
         if (!c4doc || (!allRevisions && (c4doc->flags() & kDocDeleted)))
             return nullptr;

--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -366,6 +366,7 @@ private:
                         "Invalid document ID '%.*s' used", FMTSLICE(docID));
                 return nullptr;
             }
+            throw;
         }
         if (!c4doc || (!allRevisions && (c4doc->flags() & kDocDeleted)))
             return nullptr;

--- a/test/DatabaseTest.cc
+++ b/test/DatabaseTest.cc
@@ -250,6 +250,14 @@ TEST_CASE_METHOD(DatabaseTest, "Get Non Existing Document") {
     CHECK(error.code == 0);
 }
 
+TEST_CASE_METHOD(DatabaseTest, "Get Document with Empty ID") {
+    CBLError error;
+    ExpectingExceptions x;
+    const CBLDocument* doc = CBLDatabase_GetDocument(db, ""_sl, &error);
+    REQUIRE(doc == nullptr);
+    CHECK(error.code == 0);
+}
+
 
 #pragma mark - Save Document:
 


### PR DESCRIPTION
Catch BadDocID and log warning instead of throwing to match this specific behavior with the other platform.