### PR TITLE
Add missing _cbl_nullable on return and remove _cbl_returns_nonnull

### DIFF
--- a/include/cbl/CBLBlob.h
+++ b/include/cbl/CBLBlob.h
@@ -142,8 +142,7 @@ CBL_CAPI_BEGIN
         @param contents  The data's address and length.
         @return  A new CBLBlob instance. */
     _cbl_warn_unused
-    CBLBlob* CBLBlob_CreateWithData(FLString contentType,
-                                    FLSlice contents) CBLAPI;
+    CBLBlob* CBLBlob_CreateWithData(FLString contentType, FLSlice contents) CBLAPI;
 
     /** A stream for writing a new blob to the database. */
     typedef struct CBLBlobWriteStream CBLBlobWriteStream;
@@ -205,8 +204,7 @@ CBL_CAPI_BEGIN
         @param slot  The position in the collection, as returned by functions like
                     \ref FLMutableArray_Set or \ref FLMutableDict_Set.
         @param blob  The CBLBlob to store (as a Dict) in the collection. */
-    void FLSlot_SetBlob(FLSlot slot,
-                        CBLBlob* blob) CBLAPI;
+    void FLSlot_SetBlob(FLSlot slot, CBLBlob* blob) CBLAPI;
 
 #ifdef __APPLE__
 #pragma mark - BINDING DEV SUPPORT FOR BLOB:
@@ -226,8 +224,8 @@ CBL_CAPI_BEGIN
         @param outError On failure, error info will be written here if specified. A nonexistent blob
                         is not considered a failure; in that event the error code will be zero.
         @return A \ref CBLBlob instance, or NULL if the doc doesn't exist or an error occurred. */
-    const CBLBlob* CBLDatabase_GetBlob(CBLDatabase* db, FLDict properties,
-                                       CBLError* _cbl_nullable outError) CBLAPI;
+    const CBLBlob* _cbl_nullable CBLDatabase_GetBlob(CBLDatabase* db, FLDict properties,
+                                                     CBLError* _cbl_nullable outError) CBLAPI;
 
     /** Save a new \ref CBLBlob object into the database without associating it with
         any documents. The properties of the saved \ref CBLBlob object will include

--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -132,9 +132,9 @@ bool CBL_DeleteDatabase(FLString name,
     @param outError  On failure, the error will be written here.
     @return  The new database object, or NULL on failure. */
 _cbl_warn_unused
-CBLDatabase* CBLDatabase_Open(FLSlice name,
-                              const CBLDatabaseConfiguration* _cbl_nullable config,
-                              CBLError* _cbl_nullable outError) CBLAPI;
+CBLDatabase* _cbl_nullable CBLDatabase_Open(FLSlice name,
+                                            const CBLDatabaseConfiguration* _cbl_nullable config,
+                                            CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Closes an open database. */
 bool CBLDatabase_Close(CBLDatabase*,

--- a/include/cbl/CBLDocument.h
+++ b/include/cbl/CBLDocument.h
@@ -69,9 +69,9 @@ typedef bool (*CBLConflictHandler)(void* _cbl_nullable context,
                     considered a failure; in that event the error code will be zero.)
     @return  A new \ref CBLDocument instance, or NULL if the doc doesn't exist or an error occurred. */
 _cbl_warn_unused
-const CBLDocument* CBLDatabase_GetDocument(const CBLDatabase* database,
-                                           FLString docID,
-                                           CBLError* _cbl_nullable outError) CBLAPI;
+const CBLDocument* _cbl_nullable CBLDatabase_GetDocument(const CBLDatabase* database,
+                                                         FLString docID,
+                                                         CBLError* _cbl_nullable outError) CBLAPI;
 
 CBL_REFCOUNTED(CBLDocument*, Document);
 
@@ -185,15 +185,15 @@ bool CBLDatabase_PurgeDocumentByID(CBLDatabase* database,
                     considered a failure; in that event the error code will be zero.)
     @return  A new \ref CBLDocument instance, or NULL if the doc doesn't exist or an error occurred. */
 _cbl_warn_unused
-CBLDocument* CBLDatabase_GetMutableDocument(CBLDatabase* database,
-                                            FLString docID,
-                                            CBLError* _cbl_nullable outError) CBLAPI;
+CBLDocument* _cbl_nullable CBLDatabase_GetMutableDocument(CBLDatabase* database,
+                                                          FLString docID,
+                                                          CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Creates a new, empty document in memory, with a randomly-generated unique ID.
     It will not be added to a database until saved.
     @return  The new mutable document instance. */
 _cbl_warn_unused
-CBLDocument* CBLDocument_Create(void) CBLAPI _cbl_returns_nonnull;
+CBLDocument* CBLDocument_Create(void) CBLAPI;
 
 /** Creates a new, empty document in memory, with the given ID.
     It will not be added to a database until saved.
@@ -203,7 +203,7 @@ CBLDocument* CBLDocument_Create(void) CBLAPI _cbl_returns_nonnull;
     @param docID  The ID of the new document, or NULL to assign a new unique ID.
     @return  The new mutable document instance. */
 _cbl_warn_unused
-CBLDocument* CBLDocument_CreateWithID(FLString docID) CBLAPI _cbl_returns_nonnull;
+CBLDocument* CBLDocument_CreateWithID(FLString docID) CBLAPI;
 
 /** Creates a new mutable CBLDocument instance that refers to the same document as the original.
     If the original document has unsaved changes, the new one will also start out with the same
@@ -211,8 +211,7 @@ CBLDocument* CBLDocument_CreateWithID(FLString docID) CBLAPI _cbl_returns_nonnul
     @note  You must release the new reference when you're done with it. Similarly, the original
            document still exists and must also be released when you're done with it.*/
 _cbl_warn_unused
-CBLDocument* CBLDocument_MutableCopy(const CBLDocument* original) CBLAPI
-    _cbl_returns_nonnull;
+CBLDocument* CBLDocument_MutableCopy(const CBLDocument* original) CBLAPI;
 
 /** @} */
 
@@ -257,7 +256,7 @@ FLDict CBLDocument_Properties(const CBLDocument*) CBLAPI;
     @warning  When the document is released, this reference to the properties becomes invalid.
             If you need to use any properties after releasing the document, you must retain them
             by calling \ref FLValue_Retain (and of course later release them.) */
-FLMutableDict CBLDocument_MutableProperties(CBLDocument*) CBLAPI _cbl_returns_nonnull;
+FLMutableDict CBLDocument_MutableProperties(CBLDocument*) CBLAPI;
 
 /** Sets a mutable document's properties.
     Call \ref CBLDatabase_SaveDocument to persist the changes.

--- a/include/cbl/CBLLog.h
+++ b/include/cbl/CBLLog.h
@@ -123,7 +123,7 @@ typedef struct {
 } CBLLogFileConfiguration;
 
 /** Gets the current file logging configuration, or NULL if none is configured. */
-const CBLLogFileConfiguration* CBLLog_FileConfig(void) CBLAPI;
+const CBLLogFileConfiguration* _cbl_nullable CBLLog_FileConfig(void) CBLAPI;
 
 /** Sets the file logging configuration, and begins logging to files. */
 bool CBLLog_SetFileConfig(CBLLogFileConfiguration, CBLError* _cbl_nullable outError) CBLAPI;

--- a/include/cbl/CBLQuery.h
+++ b/include/cbl/CBLQuery.h
@@ -65,11 +65,11 @@ typedef CBL_ENUM(uint32_t, CBLQueryLanguage) {
     @param outError  On failure, the error will be written here.
     @return  The new query object. */
 _cbl_warn_unused
-CBLQuery* CBLDatabase_CreateQuery(const CBLDatabase* db,
-                                  CBLQueryLanguage language,
-                                  FLString queryString,
-                                  int* _cbl_nullable outErrorPos,
-                                  CBLError* _cbl_nullable outError) CBLAPI;
+CBLQuery* _cbl_nullable CBLDatabase_CreateQuery(const CBLDatabase* db,
+                                                CBLQueryLanguage language,
+                                                FLString queryString,
+                                                int* _cbl_nullable outErrorPos,
+                                                CBLError* _cbl_nullable outError) CBLAPI;
 
 CBL_REFCOUNTED(CBLQuery*, Query);
 
@@ -88,15 +88,15 @@ void CBLQuery_SetParameters(CBLQuery* query,
                             FLDict parameters) CBLAPI;
 
 /** Returns the query's current parameter bindings, if any. */
-FLDict CBLQuery_Parameters(const CBLQuery* query) CBLAPI;
+FLDict _cbl_nullable CBLQuery_Parameters(const CBLQuery* query) CBLAPI;
 
 /** Runs the query, returning the results.
     To obtain the results you'll typically call \ref CBLResultSet_Next in a `while` loop,
     examining the values in the \ref CBLResultSet each time around.
     @note  You must release the result set when you're finished with it. */
 _cbl_warn_unused
-CBLResultSet* CBLQuery_Execute(CBLQuery*,
-                               CBLError* _cbl_nullable outError) CBLAPI;
+CBLResultSet* _cbl_nullable CBLQuery_Execute(CBLQuery*,
+                                             CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns information about the query, including the translated SQLite form, and the search
     strategy. You can use this to help optimize the query: the word `SCAN` in the strategy
@@ -229,9 +229,9 @@ CBLListenerToken* CBLQuery_AddChangeListener(CBLQuery* query,
     @param outError  If the query failed to run, the error will be stored here.
     @return  A new object containing the query's current results, or NULL if the query failed to run. */
 _cbl_warn_unused
-CBLResultSet* CBLQuery_CopyCurrentResults(const CBLQuery* query,
-                                          CBLListenerToken *listener,
-                                          CBLError* _cbl_nullable outError) CBLAPI;
+CBLResultSet* _cbl_nullable CBLQuery_CopyCurrentResults(const CBLQuery* query,
+                                                        CBLListenerToken *listener,
+                                                        CBLError* _cbl_nullable outError) CBLAPI;
 
 /** @} */
 

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -46,7 +46,8 @@ typedef struct CBLEndpoint CBLEndpoint;
     If an invalid endpoint URL is specified, an error will be returned.
     */
 _cbl_warn_unused
-CBLEndpoint* CBLEndpoint_CreateWithURL(FLString url, CBLError* _cbl_nullable outError) CBLAPI;
+CBLEndpoint* _cbl_nullable CBLEndpoint_CreateWithURL(FLString url,
+                                                     CBLError* _cbl_nullable outError) CBLAPI;
 
 #ifdef COUCHBASE_ENTERPRISE
 /** Creates a new endpoint representing another local database. (Enterprise Edition only.) */
@@ -230,8 +231,8 @@ CBL_REFCOUNTED(CBLReplicator*, Replicator);
 
 /** Creates a replicator with the given configuration. */
 _cbl_warn_unused
-CBLReplicator* CBLReplicator_Create(const CBLReplicatorConfiguration*,
-                                    CBLError* _cbl_nullable outError) CBLAPI;
+CBLReplicator* _cbl_nullable CBLReplicator_Create(const CBLReplicatorConfiguration*,
+                                                  CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns the configuration of an existing replicator. */
 const CBLReplicatorConfiguration* CBLReplicator_Config(CBLReplicator*) CBLAPI;
@@ -316,8 +317,8 @@ CBLReplicatorStatus CBLReplicator_Status(CBLReplicator*) CBLAPI;
            `pushFilter` or `docIDs`, are ignored.
     \warning  You are responsible for releasing the returned array via \ref FLValue_Release. */
 _cbl_warn_unused
-FLDict CBLReplicator_PendingDocumentIDs(CBLReplicator*,
-                                        CBLError* _cbl_nullable outError) CBLAPI;
+FLDict _cbl_nullable CBLReplicator_PendingDocumentIDs(CBLReplicator*,
+                                                      CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Indicates whether the document with the given ID has local changes that have not yet been
     pushed to the server by this replicator.

--- a/include/cbl/CBL_Compat.h
+++ b/include/cbl/CBL_Compat.h
@@ -34,12 +34,10 @@
     #include <sal.h>
     #define CBLINLINE               __forceinline
     #define _cbl_nonnull            _In_
-    #define _cbl_returns_nonnull    _Ret_notnull_
     #define _cbl_warn_unused        _Check_return_
     #define _cbl_deprecated
 #else
     #define CBLINLINE               inline
-    #define _cbl_returns_nonnull    __attribute__((returns_nonnull))
     #define _cbl_warn_unused        __attribute__((warn_unused_result))
     #define _cbl_deprecated         __attribute__((deprecated()))
 #endif
@@ -76,8 +74,6 @@
 // In between CBL_ASSUME_NONNULL_BEGIN and CBL_ASSUME_NONNULL_END, all pointer declarations implicitly
 // disallow NULL values, unless annotated with _cbl_nullable (which must come after the `*`.)
 // (_cbl_nonnull is occasionally necessary when there are C arrays or multiple levels of pointers.)
-// NOTE: Does not apply to function return values, for some reason. Those may still be null,
-//       unless annotated with _cbl_returns_nonnull.
 // NOTE: Only supported in Clang, so far.
 #if __has_feature(nullability)
 #  define CBL_ASSUME_NONNULL_BEGIN  _Pragma("clang assume_nonnull begin")


### PR DESCRIPTION
* Added missing _cbl_nullable on return
* Removed obsolete _cbl_returns_nonnull as the APIs have already been marked with CBL_ASSUME_NONNULL_BEGIN and CBL_ASSUME_NONNULL_END.