### PR TITLE
CBL-2307: Always call the completion handler of the conflict resolver

### DIFF
--- a/src/ConflictResolver.cc
+++ b/src/ConflictResolver.cc
@@ -112,6 +112,10 @@ namespace cbl_internal {
                     // Revision is gone or not a leaf: Conflict must be resolved, so stop
                     SyncLog(Info, "Conflict in doc '%.*s' already resolved, nothing to do",
                             FMTSLICE(_docID));
+                    if (_completionHandler) {
+                        _completionHandler(this);       // the handler will most likely delete me
+                    }
+
                     return true;
                 }
 


### PR DESCRIPTION
Before, if a conflict resolution resulted in no work it was skipped which would never allow the replicator to exit busy status.