### PR TITLE
Use setProgressLevel and remove extra encodeOptions

### DIFF
--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -550,6 +550,34 @@ TEST_CASE_METHOD(ReplicatorConflictTest, "Custom resolver : merge", "[Replicator
 }
 
 
+TEST_CASE_METHOD(ReplicatorLocalTest, "Document Replication Listener", "[Replicator]") {
+    // No listener:
+    MutableDocument doc("foo");
+    doc["greeting"] = "Howdy!";
+    db.saveDocument(doc);
+    
+    config.replicatorType = kCBLReplicatorTypePush;
+    enableDocReplicationListener = false;
+    replicate();
+    CHECK(replicatedDocIDs.empty());
+    
+    // Add listener:
+    doc["greeting"] = "Hello!";
+    db.saveDocument(doc);
+    enableDocReplicationListener = true;
+    replicate();
+    CHECK(asVector(replicatedDocIDs) == vector<string>{"foo"});
+    
+    // Remove listener:
+    doc["greeting"] = "Hi!";
+    db.saveDocument(doc);
+    enableDocReplicationListener = false;
+    replicatedDocIDs.clear();
+    replicate();
+    CHECK(replicatedDocIDs.empty());
+}
+
+
 class ReplicatorFilterTest : public ReplicatorLocalTest {
 public:
     int count = 0;

--- a/test/ReplicatorTest.cc
+++ b/test/ReplicatorTest.cc
@@ -108,6 +108,27 @@ TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate with auth and proxy", "[Replica
 }
 
 
+// CBL-2337
+TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate with freed auth and doc listener", "[Replicator]") {
+    CBLError error;
+    config.endpoint = CBLEndpoint_CreateWithURL("ws://fsdfds.vzcsg/foobar"_sl, &error);
+    
+    CBLAuthenticator* auth = CBLAuth_CreatePassword("username"_sl, "p@ssw0RD"_sl);
+    config.authenticator = auth;
+    
+    repl = CBLReplicator_Create(&config, &error);
+    
+    // Free the authenticator after creating the replicator
+    CBLAuth_Free(auth);
+    
+    // Note: replicate() will add a document listener
+    replicate({ kCBLNetworkDomain, kCBLNetErrUnknownHost });
+    
+    // Clean up
+    config.authenticator = nullptr;
+}
+
+
 #pragma mark - ACTUAL-NETWORK TESTS:
 
 


### PR DESCRIPTION
* Instead of using configuration to progress level for document replication listeners, used setProgressLevel.

* Added OnEmptyCallback callback to the (Private) ListenersBase and Listeners class.

* Removed extra calls to encodeOptions as it is not needed anymore.

CBL-2337