### PR TITLE
Add missing headers in modulemap file

### DIFF
--- a/Xcode/CouchbaseLite.modulemap
+++ b/Xcode/CouchbaseLite.modulemap
@@ -6,6 +6,8 @@ framework module CouchbaseLite {
     header "CBLBlob.h"
     header "CBLDatabase.h"
     header "CBLDocument.h"
+    header "CBLEncryptable.h"
+    header "CBLPlatform.h"
     header "CBLLog.h"
     header "CBLQuery.h"
     header "CBLReplicator.h"


### PR DESCRIPTION
Added CBLEncryptable.h and CBLPlatform.h to CouchbaseLite.modulemap.

CBL-2361