### PR TITLE
API: Added blob setters: FLMutableDict_SetBlob + 2 more

### DIFF
--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -69,6 +69,9 @@ namespace cbl {
         std::string digest() const                  {return asString(CBLBlob_Digest(ref()));}
         fleece::Dict properties() const             {return CBLBlob_Properties(ref());}
 
+        // Allows Blob to be assigned to mutable Dict/Array item, e.g. `dict["foo"] = blob`
+        operator fleece::Dict() const               {return properties();}
+
         alloc_slice loadContent() {
             CBLError error;
             fleece::alloc_slice content = CBLBlob_Content(ref(), &error);

--- a/include/cbl/CBLBlob.h
+++ b/include/cbl/CBLBlob.h
@@ -200,11 +200,31 @@ CBL_CAPI_BEGIN
         return FLDict_GetBlob(FLValue_AsDict(value));
     }
 
-    /** Stores a blob reference in a Fleece mutable Array or Dict.
-        @param slot  The position in the collection, as returned by functions like
-                    \ref FLMutableArray_Set or \ref FLMutableDict_Set.
-        @param blob  The CBLBlob to store (as a Dict) in the collection. */
     void FLSlot_SetBlob(FLSlot slot, CBLBlob* blob) CBLAPI;
+
+    /** Stores a blob reference into an array.
+        @param array  The array to store into.
+        @param index  The position in the array at which to store the blob reference.
+        @param blob  The blob reference to be stored. */
+    static inline void FLMutableArray_SetBlob(FLMutableArray array, uint32_t index, CBLBlob *blob) {
+        FLSlot_SetBlob(FLMutableArray_Set(array, index), blob);
+    }
+
+    /** Appends a blob reference to an array.
+        @param array  The array to store into.
+        @param blob  The blob reference to be stored. */
+    static inline void FLMutableArray_AppendBlob(FLMutableArray array, CBLBlob *blob) {
+        FLSlot_SetBlob(FLMutableArray_Append(array), blob);
+    }
+
+    /** Stores a blob reference into a Dict.
+        @param dict  The Dict to store into.
+        @param key  The key to associate the blob reference with.
+        @param blob  The blob reference to be stored. */
+    static inline void FLMutableDict_SetBlob(FLMutableDict dict, FLString key, CBLBlob *blob) {
+        FLSlot_SetBlob(FLMutableDict_Set(dict, key), blob);
+    }
+
 
 #ifdef __APPLE__
 #pragma mark - BINDING DEV SUPPORT FOR BLOB:

--- a/test/BlobTest.cc
+++ b/test/BlobTest.cc
@@ -78,7 +78,7 @@ TEST_CASE_METHOD(BlobTest, "Create blob with stream", "[Blob]") {
     // Set blob in a document and save:
     auto doc = CBLDocument_CreateWithID("doc1"_sl);
     auto props = CBLDocument_MutableProperties(doc);
-    FLSlot_SetBlob(FLMutableDict_Set(props, "blob"_sl), blob);
+    FLMutableDict_SetBlob(props, "blob"_sl, blob);
     CHECK(CBLDatabase_SaveDocument(db, doc, &error));
     
     // Check content:

--- a/test/BlobTest_Cpp.cc
+++ b/test/BlobTest_Cpp.cc
@@ -151,19 +151,15 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blobs in arrays/dicts", "[Blob]") {
         MutableDocument doc("blobbo");
         MutableArray array = MutableArray::newArray();
         array.insertNulls(0, 1);
-        CBLBlob *blob1 = CBLBlob_CreateWithData(slice(kBlobContentType), kBlobContents);
-        FLSlot_SetBlob(array[0], blob1);
+        Blob blob1(kBlobContentType, kBlobContents);
+        array[0] = blob1;
 
         MutableDict dict = MutableDict::newDict();
-        CBLBlob *blob2 = CBLBlob_CreateWithData(slice(kBlobContentType), kBlobContents);
-        FLSlot_SetBlob(dict["b"], blob2);
+        dict["b"] = Blob(kBlobContentType, kBlobContents);
 
         doc["array"] = array;
         doc["dict"] = dict;
         db.saveDocument(doc);
-
-        CBLBlob_Release(blob1);
-        CBLBlob_Release(blob2);
     }
 
     Document doc = db.getDocument("blobbo");

--- a/test/DatabaseTest.cc
+++ b/test/DatabaseTest.cc
@@ -1151,7 +1151,7 @@ TEST_CASE_METHOD(DatabaseTest, "Maintenance : Compact and Integrity Check") {
     FLMutableDict dict = CBLDocument_MutableProperties(doc);
     FLSlice blobContent = FLStr("I'm Blob.");
     CBLBlob *blob1 = CBLBlob_CreateWithData("text/plain"_sl, blobContent);
-    FLSlot_SetBlob(FLMutableDict_Set(dict, FLStr("blob")), blob1);
+    FLMutableDict_SetBlob(dict, FLStr("blob"), blob1);
     
     // Save doc:
     CBLError error;
@@ -1433,7 +1433,7 @@ TEST_CASE_METHOD(DatabaseTest, "Set blob in document", "[Blob]") {
     // Set blob in document
     CBLDocument* doc = CBLDocument_CreateWithID("doc1"_sl);
     FLMutableDict docProps = CBLDocument_MutableProperties(doc);
-    FLSlot_SetBlob(FLMutableDict_Set(docProps, FLStr("blob")), blob);
+    FLMutableDict_SetBlob(docProps, FLSTR("blob"), blob);
     CHECK(CBLDatabase_SaveDocument(db, doc, &error));
     CBLDocument_Release(doc);
     CBLBlob_Release(blob);
@@ -1490,7 +1490,7 @@ TEST_CASE_METHOD(DatabaseTest, "Save blob and set blob in document", "[Blob]") {
     // Set blob in document
     CBLDocument* doc = CBLDocument_CreateWithID("doc1"_sl);
     FLMutableDict docProps = CBLDocument_MutableProperties(doc);
-    FLSlot_SetBlob(FLMutableDict_Set(docProps, FLStr("blob")), blob);
+    FLMutableDict_SetBlob(docProps, FLSTR("blob"), blob);
     CHECK(CBLDatabase_SaveDocument(db, doc, &error));
     CBLDocument_Release(doc);
     CBLBlob_Release(blob);


### PR DESCRIPTION
Added three inline convenience functions that wrap FLSlot_SetBlob, matching the
ones recently added to Fleece.h for the other data types.

I removed the doc-comment from FLSlot_SetBlob, to make it less prominent in the
API docs, and avoid confusing users.

In the C++ API I added an implicit conversion from Blob to Dict, so that Blob
can be assigned to a Dict or Array item, e.g. `dict["foo"] = blob`.

(Since this is an API change, Pasin's got final approval.)