### PR TITLE
Avoid UB-Sanitizer warning in CBLReplicatorConfig

### DIFF
--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -175,7 +175,8 @@ namespace cbl_internal {
         ReplicatorConfiguration(const CBLReplicatorConfiguration &conf) {
             *(CBLReplicatorConfiguration*)this = conf;
             retain(database);
-            endpoint = endpoint ? endpoint->clone() : nullptr;
+            if (endpoint)
+                endpoint = endpoint->clone();
             authenticator = authenticator ? authenticator->clone() : nullptr;
             headers = FLDict_MutableCopy(headers, kFLDeepCopyImmutables);
             channels = FLArray_MutableCopy(channels, kFLDeepCopyImmutables);


### PR DESCRIPTION
The statement `endpoint = endpoint ? endpoint->clone() : nullptr` triggers an
Undefined Behavior Sanitizer warning/breakpoint when `endpoint` is NULL,
because it stores NULL into a pointer declared as `_cbl_nonnull`. This occurs
during the "Bad config" unit test.

I made a simple fix to avoid storing anything into it when it's NULL.