### PR TITLE
Validate Encryptables in arrays when saving doc

### DIFF
--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -281,7 +281,13 @@ private:
     // installed. The flag is set to true only when saving new blobs while encoding the document
     // returned by the replicator's conflict resolved. The new blobs set to the resolved doc needs
     // to be retained until they are installed here.
-    bool saveBlobs(CBLDatabase *db, bool releaseNewBlob) const;  // returns true if there are blobs
+    //
+    // The method will returns true if there are blobs.
+    //
+    // Furthermore, while walking through the object tree, check if there are any encryptables
+    // in an array and throw an unsupported error if that occurs.
+    //
+    bool saveBlobsAndCheckEncryptables(CBLDatabase *db, bool releaseNewBlob) const;
     
     // Encode the document body and install new blobs if found into the database.
     //


### PR DESCRIPTION
* We do not support Encryptables in arrays.

* Extended the saveBlobs function that walks the properties tree to find and install blobs to also validate the Encryptables in arrays.

* When checking Encryptables in arrays, it needs to also look into the immutable collections in the document properties as well because, for an example, the document can be set with JSON which will result to a shallow mutable properties.

CBL-2265