### PR TITLE
Validate encryptable in arrays when saving doc

### DIFF
--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -176,8 +176,8 @@ alloc_slice CBLDocument::encodeBody(CBLDatabase* db,
                                     C4RevisionFlags &outRevFlags) const
 {
     auto c4doc = _c4doc.useLocked();
-    // Save new blobs:
-    bool hasBlobs = saveBlobs(db, releaseNewBlob);
+    // Save new blobs and check encryptables in arrays:
+    bool hasBlobs = saveBlobsAndCheckEncryptables(db, releaseNewBlob);
     outRevFlags = hasBlobs ? kRevHasAttachments : 0;
 
     // Now encode the properties to Fleece:
@@ -316,13 +316,16 @@ CBLEncryptable* CBLDocument::getEncryptableValue(FLDict dict) {
 #endif
 
 
-bool CBLDocument::saveBlobs(CBLDatabase *db, bool releaseNewBlob) const {
+bool CBLDocument::saveBlobsAndCheckEncryptables(CBLDatabase *db, bool releaseNewBlob) const {
     // Walk through the Fleece object tree, looking for new mutable blob Dicts to install,
     // and also checking if there are any blobs at all (mutable or not.)
-    // Once we've found at least one blob, we can skip immutable collections, because
-    // they can't contain new blobs.
+    // Once we've found at least one blob, we can skip checking blobs in immutable collections,
+    // because they can't contain new blobs.
     //
     // If the releaseNewBlob is enabled, the new blob will be released after it is installed.
+    //
+    // (EE Only) While walking through the object tree, check if there are any encryptables in
+    // an array and throw an unsupported error if that occurs.
     //
     // Note: If the same new blob is used in multiple places inside the object tree, the
     // blob will be installed only once as it will be unregistered from global sNewBlobs
@@ -336,10 +339,17 @@ bool CBLDocument::saveBlobs(CBLDatabase *db, bool releaseNewBlob) const {
         Dict dict = i.value().asDict();
         if (dict) {
             if (!dict.asMutable()) {
-                if (!foundBlobs)
+                if (!foundBlobs) {
                     foundBlobs = FLDict_IsBlob(dict);
+                    if (foundBlobs) {
+                        i.skipChildren();
+                        continue;
+                    }
+                }
+                #ifndef COUCHBASE_ENTERPRISE
                 if (foundBlobs)
                     i.skipChildren();
+                #endif
             } else if (FLDict_IsBlob(dict)) {
                 foundBlobs = true;
                 CBLNewBlob *newBlob = findNewBlob(dict);
@@ -350,11 +360,25 @@ bool CBLDocument::saveBlobs(CBLDatabase *db, bool releaseNewBlob) const {
                     }
                 }
                 i.skipChildren();
+                continue;
             }
-        } else if (!i.value().asArray().asMutable()) {
+            
+            #ifdef COUCHBASE_ENTERPRISE
+            if (FLDict_IsEncryptableValue(dict)) {
+                if (i.parent().asArray()) {
+                    C4Error::raise(LiteCoreDomain, kC4ErrorUnsupported,
+                                   "No support for encryptables in an array");
+                }
+                i.skipChildren();
+            }
+            #endif
+        }
+        #ifndef COUCHBASE_ENTERPRISE
+        else if (auto array = i.value().asArray(); array && !array.asMutable()) {
             if (foundBlobs)
                 i.skipChildren();
         }
+        #endif
     }
     return foundBlobs;
 }

--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -281,7 +281,13 @@ private:
     // installed. The flag is set to true only when saving new blobs while encoding the document
     // returned by the replicator's conflict resolved. The new blobs set to the resolved doc needs
     // to be retained until they are installed here.
-    bool saveBlobs(CBLDatabase *db, bool releaseNewBlob) const;  // returns true if there are blobs
+    //
+    // The method will returns true if there are blobs.
+    //
+    // (EE Only) Furthermore, while walking through the object tree, check if there are
+    // any encryptables in an array and throw an unsupported error if that occurs.
+    //
+    bool saveBlobsAndCheckEncryptables(CBLDatabase *db, bool releaseNewBlob) const;
     
     // Encode the document body and install new blobs if found into the database.
     //


### PR DESCRIPTION
* We do not support encryptables in arrays.

* (EE Only) Extended the saveBlobs function (called ) that walks the properties tree to find and install blobs to also validate the encryptables in arrays. For CE, the method will work the same way.

* When checking encryptables in arrays, it needs to also look into the immutable collections in the document properties as well because, for an example, the document can be set with JSON which will result to a shallow mutable properties.

CBL-2265