### PR TITLE
Fix console log enabled at INFO instead of WARNING

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		9320630126BDB340006917A5 /* CBLPlatform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLPlatform.h; sourceTree = "<group>"; };
 		9320631126BDB5CA006917A5 /* CBLPlatform_CAPI+Android.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "CBLPlatform_CAPI+Android.cc"; sourceTree = "<group>"; };
 		9320631426BDD059006917A5 /* CBLDatabase+Android.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "CBLDatabase+Android.cc"; sourceTree = "<group>"; };
+		934AD381270E797D0038D62E /* CBLLog_Internal.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CBLLog_Internal.hh; sourceTree = "<group>"; };
 		93965A6226A7CD50008728EE /* LogTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogTest.cc; sourceTree = "<group>"; };
 		93C70CD226C4D3F20093E927 /* CBLEncryptable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLEncryptable.h; sourceTree = "<group>"; };
 		93C70CE226C5B4BC0093E927 /* CBLEncryptable_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLEncryptable_CAPI.cc; sourceTree = "<group>"; };
@@ -496,6 +497,7 @@
 				271C2A7721CC750E0045856E /* CBLDocument.cc */,
 				277FEE7A21ED6C0000B60E3C /* CBLDocument_Internal.hh */,
 				93EC365D26C498AB00182B02 /* CBLEncryptable_Internal.hh */,
+				934AD381270E797D0038D62E /* CBLLog_Internal.hh */,
 				277B77D4245B44E900B222D3 /* CBLLog.cc */,
 				932062DA26BC6B43006917A5 /* CBLQuery.cc */,
 				27DBCF2E246B4352002FD7A7 /* CBLQuery_Internal.hh */,

--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -19,6 +19,7 @@
 #pragma once
 #include "CBLDatabase.h"
 #include "CBLDocument_Internal.hh"
+#include "CBLLog_Internal.hh"
 #include "CBLPrivate.h"
 #include "c4Collection.hh"
 #include "c4Database.hh"
@@ -60,11 +61,13 @@ public:
                              slice toName,
                              const CBLDatabaseConfiguration* _cbl_nullable config)
     {
+        CBLLog_Init();
         C4DatabaseConfig2 c4config = asC4Config(config);
         C4Database::copyNamed(fromPath, toName, c4config);
     }
 
     static void deleteDatabase(slice name, slice inDirectory) {
+        CBLLog_Init();
         C4Database::deleteNamed(name, effectiveDir(inDirectory));
     }
 
@@ -77,6 +80,7 @@ public:
                            "The context hasn't been initialized. Call CBL_Init(CBLInitContext*) to initialize the context");
         }
 #endif
+        CBLLog_Init();
         C4DatabaseConfig2 c4config = asC4Config(config);
         Retained<C4Database> c4db = C4Database::openNamed(name, c4config);
         return new CBLDatabase(c4db, name, c4config.parentDirectory);

--- a/src/CBLLog.cc
+++ b/src/CBLLog.cc
@@ -17,6 +17,7 @@
 //
 
 #include "CBLLog.h"
+#include "CBLLog_Internal.hh"
 #include "CBLPrivate.h"
 #include "c4Base.hh"
 #include "Internal.hh"
@@ -50,8 +51,6 @@ static alloc_slice sLogFileDir;
 
 static void c4LogCallback(C4LogDomain domain, C4LogLevel level, const char *fmt, va_list args);
 
-static void init();
-
 static C4LogLevel effectiveC4CallbackLogLevel();
 
 static void updateC4CallbackLogLevel();
@@ -61,7 +60,7 @@ static CBLLogDomain getCBLLogDomain(C4LogDomain domain);
 // Note: Cannot use static initializing here as the order of initializing static C4LogDomain
 // constants such as kC4DatabaseLog cannot be guaranteed to be done prior.
 static once_flag initFlag;
-static void init() {
+void CBLLog_Init() {
     call_once(initFlag, [](){
         // Initialize log level of each domain to debug (lowest level):
         for (int i = 0; i < sizeof(kC4Domains)/sizeof(kC4Domains[0]); ++i) {
@@ -81,7 +80,7 @@ CBLLogLevel CBLLog_ConsoleLevel() CBLAPI {
 
 
 void CBLLog_SetConsoleLevel(CBLLogLevel level) CBLAPI {
-    init();
+    CBLLog_Init();
     if (sConsoleLogLevel.exchange(level) != level)
         updateC4CallbackLogLevel();
 }
@@ -93,7 +92,7 @@ CBLLogLevel CBLLog_CallbackLevel() CBLAPI {
 
 
 void CBLLog_SetCallbackLevel(CBLLogLevel level) CBLAPI {
-    init();
+    CBLLog_Init();
     if (sCustomLogLevel.exchange(level) != level)
         updateC4CallbackLogLevel();
 }
@@ -105,7 +104,7 @@ CBLLogCallback CBLLog_Callback() CBLAPI {
 
 
 void CBLLog_SetCallback(CBLLogCallback callback) CBLAPI {
-    init();
+    CBLLog_Init();
     if (sCustomCallback.exchange(callback) != callback)
         updateC4CallbackLogLevel();
 }
@@ -195,7 +194,7 @@ const CBLLogFileConfiguration* CBLLog_FileConfig() CBLAPI {
 
 
 bool CBLLog_SetFileConfig(CBLLogFileConfiguration config, CBLError *outError) CBLAPI {
-    init();
+    CBLLog_Init();
     
     sLogFileDir = config.directory;     // copy string to the heap
     config.directory = sLogFileDir;     // and put the heap copy in the struct

--- a/src/CBLLog_Internal.hh
+++ b/src/CBLLog_Internal.hh
@@ -1,0 +1,37 @@
+//
+// CBLLog_Internal.hh
+//
+// Copyright © 2021 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+ * Initialize the log level of each log domains to DEBUG so that
+ * the log level of all domains could be controlled by using c4log_setCallbackLevel()
+ * and c4log_writeToBinaryFile() and setup the log callback with the WARNING as its default
+ * log level.
+ *
+ * This method is safe to call multiple times but the initializing logic will be executed only
+ * once when the method is called the first time.
+ *
+ * @NOTE As we cannot use static initializer to initialize the log level and the log callback,
+ * we will need to call CBLLog_Init() from the top level methods that logs (level < Warnings)
+ * are expected including CBLDatabase's open(), copyDatabase(), deleteDatabase(),
+ * Andriod's CBL_Init(), and any methods used for configuring logs in CBLLog.cc.
+ *
+ * In the future, if calling CBLLog_Init() becomes painfully hard to track, we could consider
+ * changing the default log level of each domain in LiteCore from INFO to WARNING so that calling
+ * CBLLog_Init() is not needed beside from the methods used for configuring logs.
+ */
+void CBLLog_Init();

--- a/src/Internal.cc
+++ b/src/Internal.cc
@@ -17,6 +17,7 @@
 //
 
 #include "Internal.hh"
+#include "CBLLog_Internal.hh"
 #include "c4Base.hh"
 #include "fleece/Fleece.h"
 #include "betterassert.hh"
@@ -65,6 +66,8 @@ namespace cbl_internal {
         }
         precondition(context.filesDir != nullptr);
         precondition(context.tempDir != nullptr);
+        
+        CBLLog_Init();
         
         litecore::FilePath filesDir(context.filesDir, "");
         filesDir.mustExistAsDir();


### PR DESCRIPTION
* Background : The default log level of each domain in LiteCore is INFO. Without configuring anything, LiteCore will write logs at INFO+ level to the console via vprintf. However, the default console log level in CBL is WARNING. An attempt to use static intitalizer to setup the default console log level to WARNING was failed as some extern constants were not initialized prior the static inititalizer.

* Changed the previous static init() function to CBL_Init() function that will be called by the top level functions that expects log messages including CBLDatabase’s open(), copyDatabase(), deleteDatabase(), Android’s CBL_Init(), and any functions used for configuring logging.

* NOTE: If calling CBL_Init() becomes hard to track in the future, we should consider changing the default log level in LiteCore from INFO to WARNING.

CBL-2449