### PR TITLE
Use Undefined value for missing values in Query’s array results

### DIFF
--- a/src/CBLQuery.cc
+++ b/src/CBLQuery.cc
@@ -88,12 +88,12 @@ Value CBLResultSet::property(slice prop) const {
 
 Array CBLResultSet::asArray() const {
     if (!_asArray) {
-        auto array = fleece::MutableArray::newArray();
+        auto array = MutableArray::newArray();
         unsigned nCols = _query->columnCount();
         array.resize(uint32_t(nCols));
         for (unsigned i = 0; i < nCols; ++i) {
             Value val = column(i);
-            array[i] = val ? val : Value::null();
+            array[i] = val ? val : Value(kFLUndefinedValue);
         }
         _asArray = array;
     }

--- a/src/exports/Fleece_Exports.txt
+++ b/src/exports/Fleece_Exports.txt
@@ -6,6 +6,7 @@
 # (See the master list at vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/Fleece.exp)
 
 kFLNullValue
+kFLUndefinedValue
 kFLEmptyArray
 kFLEmptyDict
 

--- a/src/exports/generated/CBL.def
+++ b/src/exports/generated/CBL.def
@@ -132,6 +132,7 @@ CBLReplicator_AddChangeListener
 CBLReplicator_AddDocumentReplicationListener
 CBLDefaultConflictResolver
 kFLNullValue
+kFLUndefinedValue
 kFLEmptyArray
 kFLEmptyDict
 FLSlice_Equal

--- a/src/exports/generated/CBL.exp
+++ b/src/exports/generated/CBL.exp
@@ -130,6 +130,7 @@ _CBLReplicator_AddChangeListener
 _CBLReplicator_AddDocumentReplicationListener
 _CBLDefaultConflictResolver
 _kFLNullValue
+_kFLUndefinedValue
 _kFLEmptyArray
 _kFLEmptyDict
 _FLSlice_Equal

--- a/src/exports/generated/CBL.gnu
+++ b/src/exports/generated/CBL.gnu
@@ -130,6 +130,7 @@ CBL_C {
 		CBLReplicator_AddDocumentReplicationListener;
 		CBLDefaultConflictResolver;
 		kFLNullValue;
+		kFLUndefinedValue;
 		kFLEmptyArray;
 		kFLEmptyDict;
 		FLSlice_Equal;

--- a/src/exports/generated/CBL_Android.gnu
+++ b/src/exports/generated/CBL_Android.gnu
@@ -131,6 +131,7 @@ CBL_C {
 		CBLReplicator_AddDocumentReplicationListener;
 		CBLDefaultConflictResolver;
 		kFLNullValue;
+		kFLUndefinedValue;
 		kFLEmptyArray;
 		kFLEmptyDict;
 		FLSlice_Equal;

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -152,6 +152,7 @@ CBLReplicator_AddChangeListener
 CBLReplicator_AddDocumentReplicationListener
 CBLDefaultConflictResolver
 kFLNullValue
+kFLUndefinedValue
 kFLEmptyArray
 kFLEmptyDict
 FLSlice_Equal

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -150,6 +150,7 @@ _CBLReplicator_AddChangeListener
 _CBLReplicator_AddDocumentReplicationListener
 _CBLDefaultConflictResolver
 _kFLNullValue
+_kFLUndefinedValue
 _kFLEmptyArray
 _kFLEmptyDict
 _FLSlice_Equal

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -150,6 +150,7 @@ CBL_C {
 		CBLReplicator_AddDocumentReplicationListener;
 		CBLDefaultConflictResolver;
 		kFLNullValue;
+		kFLUndefinedValue;
 		kFLEmptyArray;
 		kFLEmptyDict;
 		FLSlice_Equal;

--- a/src/exports/generated/CBL_EE_Android.gnu
+++ b/src/exports/generated/CBL_EE_Android.gnu
@@ -151,6 +151,7 @@ CBL_C {
 		CBLReplicator_AddDocumentReplicationListener;
 		CBLDefaultConflictResolver;
 		kFLNullValue;
+		kFLUndefinedValue;
 		kFLEmptyArray;
 		kFLEmptyDict;
 		FLSlice_Equal;

--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -64,6 +64,7 @@ const CBLDatabaseConfiguration CBLTest::kDatabaseConfiguration = []{
 CBLTest::CBLTest() {
     // Check that these have been correctly exported
     CHECK(FLValue_GetType(kFLNullValue) == kFLNull);
+    CHECK(FLValue_GetType(kFLUndefinedValue) == kFLUndefined);
     CHECK(FLValue_GetType((FLValue)kFLEmptyArray) == kFLArray);
     CHECK(FLValue_GetType((FLValue)kFLEmptyDict) == kFLDict);
 

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -285,12 +285,13 @@ TEST_CASE_METHOD(QueryTest, "Query Result As Array", "[Query]") {
     CBLError error;
     int errPos;
     query = CBLDatabase_CreateQuery(db, kCBLN1QLLanguage,
-                                    "SELECT name FROM _ WHERE birthday like '1959-%' ORDER BY birthday"_sl,
+                                    "SELECT name, foo FROM _ WHERE birthday like '1959-%' ORDER BY birthday"_sl,
                                     &errPos, &error);
     REQUIRE(query);
 
-    CHECK(CBLQuery_ColumnCount(query) == 1);
+    REQUIRE(CBLQuery_ColumnCount(query) == 2);
     CHECK(CBLQuery_ColumnName(query, 0) == "name"_sl);
+    CHECK(CBLQuery_ColumnName(query, 1) == "foo"_sl);
 
     alloc_slice explanation(CBLQuery_Explain(query));
     cerr << string(explanation);
@@ -303,7 +304,7 @@ TEST_CASE_METHOD(QueryTest, "Query Result As Array", "[Query]") {
     REQUIRE(results);
     while (CBLResultSet_Next(results)) {
         FLArray result = CBLResultSet_ResultArray(results);
-        REQUIRE(FLArray_Count(result) == 1);
+        REQUIRE(FLArray_Count(result) == 2);
         FLValue name = FLArray_Get(result, 0);
         FLDict dict = FLValue_AsDict(name);
         CHECK(dict);
@@ -312,8 +313,10 @@ TEST_CASE_METHOD(QueryTest, "Query Result As Array", "[Query]") {
         REQUIRE(n < 3);
         CHECK(first == kExpectedFirst[n]);
         CHECK(last == kExpectedLast[n]);
-        ++n;
         cerr << first << " " << last << "\n";
+        FLValue foo = FLArray_Get(result, 1);
+        CHECK(FLValue_GetType(foo) == kFLUndefined);
+        ++n;
     }
     CHECK(n == 3);
 }


### PR DESCRIPTION
* When creating an array result, use kFLUndefinedValue for the missing values.
* Updated Fleece export symbol

CBL-2409