### PR TITLE
Fix the strip script order

### DIFF
--- a/jenkins/strip.sh
+++ b/jenkins/strip.sh
@@ -8,12 +8,13 @@ if [[ $# > 1 ]]; then
 fi
 
 pushd $WORKING_DIR
+COMMAND="${PREFIX}objcopy --only-keep-debug libcblite.so tmp"
+eval ${COMMAND}
 COMMAND="find . -name \"*.a\" | xargs ${PREFIX}strip --strip-unneeded"
 eval ${COMMAND}
 rm libcblite.so*
+mv tmp libcblite.so.sym
 make -j8 cblite
-COMMAND="${PREFIX}objcopy --only-keep-debug libcblite.so libcblite.so.sym"
-eval ${COMMAND}
 COMMAND="${PREFIX}strip --strip-unneeded libcblite.so"
 eval ${COMMAND}
 COMMAND="${PREFIX}objcopy --add-gnu-debuglink=libcblite.so.sym libcblite.so"


### PR DESCRIPTION
Before it was stripping all the static libraries before extracting debug information which means that there was no debug information left to extract