### PR TITLE
Disable Android library stripping

### DIFF
--- a/jenkins/ci_build_android.sh
+++ b/jenkins/ci_build_android.sh
@@ -63,7 +63,7 @@ function build_variant {
         -DEDITION=$EDITION \
 	    ..
 
-    ${CMAKE_PATH}/ninja install/strip
+    ${CMAKE_PATH}/ninja install
 }
 
 ln -sf ${WORKSPACE}/couchbase-lite-c-ee/couchbase-lite-core-EE ${WORKSPACE}/couchbase-lite-c/vendor/couchbase-lite-core-EE


### PR DESCRIPTION
It will happen anyway when building an app, and this way the distributed file can be upload to crash reporting services for proper symbolication