### PR TITLE
CBL-2548 : Retain database in ListenerToken of CBLDocumentChangeListener

### DIFF
--- a/src/CBLDatabase.cc
+++ b/src/CBLDatabase.cc
@@ -131,7 +131,7 @@ namespace cbl_internal {
             _db->notify(this, _db, _docID);
         }
 
-        CBLDatabase* _db;
+        Retained<CBLDatabase> _db;
         alloc_slice _docID;
         unique_ptr<C4DocumentObserver> _c4obs;
     };


### PR DESCRIPTION
Retain database in the ListenerToken<CBLDocumentChangeListener> to allow to remove / release the token after closing and releasing the database (using CBLDatabase_Release). On the binding platform that uses GC, the order of releasing the object is not guaranteed so the database might be released before the token.
