### PR TITLE
Fix cmake configuration failure on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,11 +224,12 @@ configure_package_config_file(
   INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/CouchbaseLite"
 )
 write_basic_package_version_file(
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/CouchbaseLite/CouchbaseLiteConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/CouchbaseLiteConfigVersion.cmake
     VERSION ${CBL_LIBRARY_VERSION} COMPATIBILITY SameMajorVersion
 )
 
 install(FILES ${CMAKE_BINARY_DIR}/CouchbaseLiteConfig.cmake
+              ${CMAKE_BINARY_DIR}/CouchbaseLiteConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CouchbaseLite)
 
 ### TESTS:


### PR DESCRIPTION
Failure message when attempting to build as non-root user on Linux

  CMake Error: Could not open file for write in copy operation /usr/local/lib/x86_64-linux-gnu/cmake/CouchbaseLite/CouchbaseLiteConfigVersion.cmake.tmp
  CMake Error: : System Error: No such file or directory
  CMake Error at cmake-3.11/Modules/WriteBasicConfigVersionFile.cmake:46 (configure_file):
    configure_file Problem configuring file
  Call Stack (most recent call first):
    cmake-3.11/Modules/CMakePackageConfigHelpers.cmake:209 (write_basic_config_version_file)
    CMakeLists.txt:226 (write_basic_package_version_file)

write_basic_package_version_file() should not be told to write
directly to the system libdir. This gets called during configuration,
when the build should not be trying to write to any system directories.

Instead write CouchbaseLiteConfigVersion.cmake to a local file, and copy
it to libdir area using the install target that already handles
CouchbaseLiteConfig.cmake