### PR TITLE
API: Added `CBLBlobReader_Seek`, `CBLBlobReader_Position` (CBL-2573)

### DIFF
--- a/include/cbl/CBLBlob.h
+++ b/include/cbl/CBLBlob.h
@@ -125,6 +125,27 @@ CBL_CAPI_BEGIN
                            size_t maxLength,
                            CBLError* _cbl_nullable outError) CBLAPI;
 
+    /** Defines the interpretation of `offset` in \ref CBLBlobReader_Seek. */
+    typedef CBL_ENUM(uint8_t, CBLSeekBase) {
+        kCBLSeekModeFromStart,  ///< Offset is an absolute position starting from 0
+        kCBLSeekModeRelative,   ///< Offset is relative to the current stream position
+        kCBLSeekModeFromEnd     ///< Offset is relative to the end of the blob
+    };
+
+    /** Sets the position of a CBLBlobReadStream.
+        @param stream  The stream to reposition.
+        @param offset  The byte offset in the stream (relative to the `mode`).
+        @param base    The base position from which the offset is calculated.
+        @param outError  On failure, an error will be stored here if non-NULL.
+        @return  The new absolute position, or -1 on failure. */
+    int64_t CBLBlobReader_Seek(CBLBlobReadStream* stream,
+                               int64_t offset,
+                               CBLSeekBase base,
+                               CBLError* _cbl_nullable outError) CBLAPI;
+
+    /** Returns the current position of a CBLBlobReadStream. */
+    uint64_t CBLBlobReader_Position(CBLBlobReadStream* stream) CBLAPI;
+
     /** Closes a CBLBlobReadStream. */
     void CBLBlobReader_Close(CBLBlobReadStream* _cbl_nullable) CBLAPI;
 

--- a/src/CBLBlob_CAPI.cc
+++ b/src/CBLBlob_CAPI.cc
@@ -70,6 +70,20 @@ int CBLBlobReader_Read(CBLBlobReadStream* stream,
     } catchAndBridgeReturning(outError, -1)
 }
 
+int64_t CBLBlobReader_Seek(CBLBlobReadStream* stream,
+                           int64_t position,
+                           CBLSeekBase base,
+                           CBLError *outError) noexcept
+{
+    try {
+        return stream->seek(position, base);
+    } catchAndBridgeReturning(outError, -1);
+}
+
+uint64_t CBLBlobReader_Position(CBLBlobReadStream* stream) noexcept {
+    return stream->position();
+}
+
 void CBLBlobReader_Close(CBLBlobReadStream* stream) noexcept {
     delete stream;
 }

--- a/src/exports/CBL_Exports.txt
+++ b/src/exports/CBL_Exports.txt
@@ -44,6 +44,8 @@ CBLBlob_CreateJSON
 CBLBlob_CreateWithData
 CBLBlob_CreateWithStream
 CBLBlobReader_Read
+CBLBlobReader_Position
+CBLBlobReader_Seek
 CBLBlobReader_Close
 CBLBlobWriter_Create
 CBLBlobWriter_Close

--- a/src/exports/generated/CBL.def
+++ b/src/exports/generated/CBL.def
@@ -30,6 +30,8 @@ CBLBlob_CreateJSON
 CBLBlob_CreateWithData
 CBLBlob_CreateWithStream
 CBLBlobReader_Read
+CBLBlobReader_Position
+CBLBlobReader_Seek
 CBLBlobReader_Close
 CBLBlobWriter_Create
 CBLBlobWriter_Close

--- a/src/exports/generated/CBL.exp
+++ b/src/exports/generated/CBL.exp
@@ -28,6 +28,8 @@ _CBLBlob_CreateJSON
 _CBLBlob_CreateWithData
 _CBLBlob_CreateWithStream
 _CBLBlobReader_Read
+_CBLBlobReader_Position
+_CBLBlobReader_Seek
 _CBLBlobReader_Close
 _CBLBlobWriter_Create
 _CBLBlobWriter_Close

--- a/src/exports/generated/CBL.gnu
+++ b/src/exports/generated/CBL.gnu
@@ -28,6 +28,8 @@ CBL_C {
 		CBLBlob_CreateWithData;
 		CBLBlob_CreateWithStream;
 		CBLBlobReader_Read;
+		CBLBlobReader_Position;
+		CBLBlobReader_Seek;
 		CBLBlobReader_Close;
 		CBLBlobWriter_Create;
 		CBLBlobWriter_Close;

--- a/src/exports/generated/CBL_Android.gnu
+++ b/src/exports/generated/CBL_Android.gnu
@@ -29,6 +29,8 @@ CBL_C {
 		CBLBlob_CreateWithData;
 		CBLBlob_CreateWithStream;
 		CBLBlobReader_Read;
+		CBLBlobReader_Position;
+		CBLBlobReader_Seek;
 		CBLBlobReader_Close;
 		CBLBlobWriter_Create;
 		CBLBlobWriter_Close;

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -50,6 +50,8 @@ CBLBlob_CreateJSON
 CBLBlob_CreateWithData
 CBLBlob_CreateWithStream
 CBLBlobReader_Read
+CBLBlobReader_Position
+CBLBlobReader_Seek
 CBLBlobReader_Close
 CBLBlobWriter_Create
 CBLBlobWriter_Close

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -48,6 +48,8 @@ _CBLBlob_CreateJSON
 _CBLBlob_CreateWithData
 _CBLBlob_CreateWithStream
 _CBLBlobReader_Read
+_CBLBlobReader_Position
+_CBLBlobReader_Seek
 _CBLBlobReader_Close
 _CBLBlobWriter_Create
 _CBLBlobWriter_Close

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -48,6 +48,8 @@ CBL_C {
 		CBLBlob_CreateWithData;
 		CBLBlob_CreateWithStream;
 		CBLBlobReader_Read;
+		CBLBlobReader_Position;
+		CBLBlobReader_Seek;
 		CBLBlobReader_Close;
 		CBLBlobWriter_Create;
 		CBLBlobWriter_Close;

--- a/src/exports/generated/CBL_EE_Android.gnu
+++ b/src/exports/generated/CBL_EE_Android.gnu
@@ -49,6 +49,8 @@ CBL_C {
 		CBLBlob_CreateWithData;
 		CBLBlob_CreateWithStream;
 		CBLBlobReader_Read;
+		CBLBlobReader_Position;
+		CBLBlobReader_Seek;
 		CBLBlobReader_Close;
 		CBLBlobWriter_Create;
 		CBLBlobWriter_Close;


### PR DESCRIPTION
This looks like an accidental omission from the API. Other platforms' read streams support seeking.

I imagine this will require some API review... I've based the API on `fseek` and `ftell`.

Strictly speaking, `CBLBlobReader_Position` is unnecessary because you can either ask the blob itself, or you can call `CBLBlobReader_Seek(reader, 0, kCBLSeekModeRelative, nullptr)` which will return the current position.

CBL-2573