### PR TITLE
Minor change to C++ API to match the other platforms

### DIFF
--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -82,7 +82,7 @@ namespace cbl {
     class MutableDocument : public Document {
     public:
         explicit MutableDocument(nullptr_t)             {_ref = (CBLRefCounted*)CBLDocument_CreateWithID(fleece::nullslice);}
-        explicit MutableDocument(slice docID)     {_ref = (CBLRefCounted*)CBLDocument_CreateWithID(docID);}
+        explicit MutableDocument(slice docID)           {_ref = (CBLRefCounted*)CBLDocument_CreateWithID(docID);}
 
         fleece::MutableDict properties()                {return CBLDocument_MutableProperties(ref());}
 
@@ -160,11 +160,11 @@ namespace cbl {
 
 
     inline bool Database::saveDocument(MutableDocument &doc,
-                                       SaveConflictHandler conflictHandler)
+                                       ConflictHandler conflictHandler)
     {
         CBLConflictHandler cHandler = [](void *context, CBLDocument *myDoc,
                                              const CBLDocument *otherDoc) -> bool {
-            return (*(SaveConflictHandler*)context)(MutableDocument(myDoc),
+            return (*(ConflictHandler*)context)(MutableDocument(myDoc),
                                                     Document(otherDoc));
         };
         CBLError error;

--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -68,6 +68,15 @@ namespace cbl {
     /** A single query result; ResultSet::iterator iterates over these. */
     class Result {
     public:
+        uint64_t count() const {
+            return CBLQuery_ColumnCount(CBLResultSet_GetQuery(_ref));
+        }
+        
+        alloc_slice toJSON() const {
+            FLDict dict = CBLResultSet_ResultDict(_ref);
+            return alloc_slice(FLValue_ToJSON((FLValue)dict));
+        }
+        
         fleece::Value valueAtIndex(unsigned i) const {
             return CBLResultSet_ValueAtIndex(_ref, i);
         }
@@ -220,6 +229,11 @@ namespace cbl {
         return iterator();
     }
 
+    // Query
+    
+    Query Database::createQuery(CBLQueryLanguage language, slice queryString) {
+        return Query(*this, language, queryString);
+    }
 }
 
 CBL_ASSUME_NONNULL_END

--- a/test/DatabaseTest_Cpp.cc
+++ b/test/DatabaseTest_Cpp.cc
@@ -191,13 +191,13 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database notifications") {
     int dbListenerCalls = 0, fooListenerCalls = 0;
     {
         // Add a listener:
-        auto dbListener = db.addListener([&](Database callbackdb, vector<slice> docIDs) {
+        auto dbListener = db.addChangeListener([&](Database callbackdb, vector<slice> docIDs) {
             ++dbListenerCalls;
             CHECK(callbackdb == db);
             CHECK(docIDs.size() == 1);
             CHECK(docIDs[0] == "foo");
         });
-        auto fooListener = db.addDocumentListener("foo", [&](Database callbackdb, slice docID) {
+        auto fooListener = db.addDocumentChangeListener("foo", [&](Database callbackdb, slice docID) {
             ++fooListenerCalls;
             CHECK(callbackdb == db);
             CHECK(docID == "foo");
@@ -218,19 +218,19 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database notifications") {
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Scheduled database notifications") {
     // Add a listener:
     int dbListenerCalls = 0, fooListenerCalls = 0, barListenerCalls = 0, notificationsReadyCalls = 0;
-    auto dbListener = db.addListener([&](Database callbackdb, vector<slice> docIDs) {
+    auto dbListener = db.addChangeListener([&](Database callbackdb, vector<slice> docIDs) {
         ++dbListenerCalls;
         CHECK(callbackdb == db);
         CHECK(docIDs.size() == 2);
         CHECK(docIDs[0] == "foo");
         CHECK(docIDs[1] == "bar");
     });
-    auto fooListener = db.addDocumentListener("foo", [&](Database callbackdb, slice docID) {
+    auto fooListener = db.addDocumentChangeListener("foo", [&](Database callbackdb, slice docID) {
         ++fooListenerCalls;
         CHECK(callbackdb == db);
         CHECK(docID == "foo");
     });
-    auto barListener = db.addDocumentListener("bar", [&](Database callbackdb, slice docID) {
+    auto barListener = db.addDocumentChangeListener("bar", [&](Database callbackdb, slice docID) {
         ++barListenerCalls;
         CHECK(callbackdb == db);
         CHECK(docID == "bar");


### PR DESCRIPTION
* Minimum changes to C++ API to match the other platforms’ API.
* Renamed Database::SaveConflictHandler class to ConflictHandler
* Renamed Database::purgeDocumentByID() to purgeDocument()
* Renamed Database::Listener to ChangeListener and DocumentListener to DocumentChangeListener
* Added Database:: createQuery()
* Added Result::count() and toJSON()
* Made Authenticator and Endpoint class RefCounted
* Renamed Replicator::DocumentListener to DocumentReplicationListener
* Note: Created CBL-2724, CBL-2725, and CBL-2726 for additional bug fixes and improvement.