### PR TITLE
Mark C++ API as volatile and include them in release package

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -1054,7 +1054,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n# Copy Fleece Headers:\ncp -R vendor/couchbase-lite-core/vendor/fleece/API/fleece/ \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\n\n# Remove C++ Headers (Go to the folder to workaroud rm cmd issue with path including spaces): \npushd \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\n\npopd\n";
+			shellScript = "set -e\n# Copy Fleece Headers:\ncp -R vendor/couchbase-lite-core/vendor/fleece/API/fleece/ \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\n";
 		};
 		27DBD088246C94B2002FD7A7 /* Merge static libs */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -58,13 +58,13 @@
 		27984E2E2249A240000FE777 /* CBLQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A3021CAC98F0045856E /* CBLQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27984E2F2249A240000FE777 /* CBLReplicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A2C21CAC98F0045856E /* CBLReplicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27984E302249A240000FE777 /* CBL_Compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A7021CAD6440045856E /* CBL_Compat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		27984E312249A247000FE777 /* CouchbaseLite.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE5021E6BC2100B60E3C /* CouchbaseLite.hh */; };
-		27984E322249A247000FE777 /* Base.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE3D21DEF0C700B60E3C /* Base.hh */; };
-		27984E332249A247000FE777 /* Blob.hh in Headers */ = {isa = PBXBuildFile; fileRef = 275BC4E22204E6A800DBE7D2 /* Blob.hh */; };
-		27984E342249A247000FE777 /* Database.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61DD821DEEC540027CCDB /* Database.hh */; };
-		27984E352249A247000FE777 /* Document.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4E21DEF54D00B60E3C /* Document.hh */; };
-		27984E362249A247000FE777 /* Query.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4F21E6AB1100B60E3C /* Query.hh */; };
-		27984E372249A247000FE777 /* Replicator.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C9B5F121F7D74A0040BC45 /* Replicator.hh */; };
+		27984E312249A247000FE777 /* CouchbaseLite.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE5021E6BC2100B60E3C /* CouchbaseLite.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E322249A247000FE777 /* Base.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE3D21DEF0C700B60E3C /* Base.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E332249A247000FE777 /* Blob.hh in Headers */ = {isa = PBXBuildFile; fileRef = 275BC4E22204E6A800DBE7D2 /* Blob.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E342249A247000FE777 /* Database.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61DD821DEEC540027CCDB /* Database.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E352249A247000FE777 /* Document.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4E21DEF54D00B60E3C /* Document.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E362249A247000FE777 /* Query.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4F21E6AB1100B60E3C /* Query.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E372249A247000FE777 /* Replicator.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C9B5F121F7D74A0040BC45 /* Replicator.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		27984E402249A85E000FE777 /* CouchbaseLite_Umbrella.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27984E3F2249A85E000FE777 /* CouchbaseLite_Umbrella.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		27B61D5621D5ABA60027CCDB /* CBLQuery_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27B61D5521D5ABA60027CCDB /* CBLQuery_CAPI.cc */; };
 		27B61D6A21D6B60D0027CCDB /* CBLTest.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61D6821D6B60D0027CCDB /* CBLTest.hh */; };
@@ -1054,7 +1054,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n# Copy Fleece Headers:\ncp -R vendor/couchbase-lite-core/vendor/fleece/API/fleece/ \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\n\n# Remove C++ Headers (Go to the folder to workaroud rm cmd issue with path including spaces): \npushd \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\nrm -f *.hh\n\npopd\n";
+			shellScript = "set -e\n# Copy Fleece Headers:\ncp -R vendor/couchbase-lite-core/vendor/fleece/API/fleece/ \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\n\n# Remove C++ Headers (Go to the folder to workaroud rm cmd issue with path including spaces): \npushd \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\n\npopd\n";
 		};
 		27DBD088246C94B2002FD7A7 /* Merge static libs */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,13 +209,17 @@ install(
 )
 
 file(GLOB C_HEADERS ${PROJECT_SOURCE_DIR}/include/cbl/*.h)
+file(GLOB CPP_HEADERS ${PROJECT_SOURCE_DIR}/include/cbl++/*.hh)
 file(GLOB FLEECE_HEADERS ${PROJECT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/fleece/*.h)
+file(GLOB FLEECE_CPP_HEADERS ${PROJECT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/fleece/*.hh)
 
 install(EXPORT CouchbaseLiteTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CouchbaseLite)
 
 install(FILES ${C_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl)
+install(FILES ${CPP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl++)
 install(FILES ${PROJECT_BINARY_DIR}/generated_headers/public/cbl/CBL_Edition.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl)
 install(FILES ${FLEECE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fleece)
+install(FILES ${FLEECE_CPP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fleece++)
 
 include(CMakePackageConfigHelpers)
 set(TARGETS_EXPORT_NAME "CouchbaseLiteTargets")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,8 +210,8 @@ install(
 
 file(GLOB C_HEADERS ${PROJECT_SOURCE_DIR}/include/cbl/*.h)
 file(GLOB CPP_HEADERS ${PROJECT_SOURCE_DIR}/include/cbl++/*.hh)
-file(GLOB FLEECE_HEADERS ${PROJECT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/fleece/*.h)
-file(GLOB FLEECE_CPP_HEADERS ${PROJECT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/fleece/*.hh)
+file(GLOB FLEECE_HEADERS ${PROJECT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/fleece/*.h
+		        ${PROJECT_SOURCE_DIR}/vendor/couchbase-lite-core/vendor/fleece/API/fleece/*.hh)
 
 install(EXPORT CouchbaseLiteTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CouchbaseLite)
 
@@ -219,7 +219,6 @@ install(FILES ${C_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl)
 install(FILES ${CPP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl++)
 install(FILES ${PROJECT_BINARY_DIR}/generated_headers/public/cbl/CBL_Edition.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbl)
 install(FILES ${FLEECE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fleece)
-install(FILES ${FLEECE_CPP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fleece++)
 
 include(CMakePackageConfigHelpers)
 set(TARGETS_EXPORT_NAME "CouchbaseLiteTargets")

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ FLSlice greeting = FLValue_AsString( FLDict_Get(readProps, FLStr("greeting")) );
 CBLDocument_Release(readDoc);
 ```
 
-### Others
+### C++
 
-**NOTE**: The C++ API is not part of the official release.
+**NOTE**: The C++ API is a [volatile](https://docs.couchbase.com/couchbase-lite/3.0/android/compatibility.html#interface-stability) API which means that the API is not finalized, and may change in future releases.  
 
 ```cpp
 // Open a database:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ CBLDocument_Release(readDoc);
 
 ### C++
 
-**NOTE**: The C++ API is a [volatile](https://docs.couchbase.com/couchbase-lite/3.0/android/compatibility.html#interface-stability) API which means that the API is not finalized, and may change in future releases.  
+**NOTE**: The C++ API is a [volatile](https://docs.couchbase.com/couchbase-lite/3.0/c/compatibility.html#interface-stability) API which means that the API is not finalized, and may change in future releases.  
 
 ```cpp
 // Open a database:

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -29,8 +29,8 @@
 #   include "cbl/CBLLog.h"
 #endif
 
-// PLEASE NOTE: This C++ wrapper API is provided as a convenience only.
-// It is not considered part of the official Couchbase Lite API.
+// VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
+// future releases.
 
 CBL_ASSUME_NONNULL_BEGIN
 

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -22,8 +22,8 @@
 #include "fleece/Mutable.hh"
 #include <string>
 
-// PLEASE NOTE: This C++ wrapper API is provided as a convenience only.
-// It is not considered part of the official Couchbase Lite API.
+// VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
+// future releases.
 
 CBL_ASSUME_NONNULL_BEGIN
 

--- a/include/cbl++/CouchbaseLite.hh
+++ b/include/cbl++/CouchbaseLite.hh
@@ -16,8 +16,8 @@
 // limitations under the License.
 //
 
-// PLEASE NOTE: This C++ wrapper API is provided as a convenience only.
-// It is not considered part of the official Couchbase Lite API.
+// VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
+// future releases.
 
 #pragma once
 #include "Blob.hh"

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -27,8 +27,8 @@
 #include <string>
 #include <vector>
 
-// PLEASE NOTE: This C++ wrapper API is provided as a convenience only.
-// It is not considered part of the official Couchbase Lite API.
+// VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
+// future releases.
 
 CBL_ASSUME_NONNULL_BEGIN
 

--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -22,8 +22,8 @@
 #include "fleece/Mutable.hh"
 #include <string>
 
-// PLEASE NOTE: This C++ wrapper API is provided as a convenience only.
-// It is not considered part of the official Couchbase Lite API.
+// VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
+// future releases.
 
 CBL_ASSUME_NONNULL_BEGIN
 

--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -23,8 +23,8 @@
 #include <string>
 #include <vector>
 
-// PLEASE NOTE: This C++ wrapper API is provided as a convenience only.
-// It is not considered part of the official Couchbase Lite API.
+// VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
+// future releases.
 
 CBL_ASSUME_NONNULL_BEGIN
 

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -23,8 +23,8 @@
 #include <string>
 #include <vector>
 
-// PLEASE NOTE: This C++ wrapper API is provided as a convenience only.
-// It is not considered part of the official Couchbase Lite API.
+// VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
+// future releases.
 
 CBL_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
* Marked CBL C++ API as volatile. 
* Copied CBL C++ and fleece C++ headers to the release package built by CMake
* Modified XCode Project to include CBL C++ and fleece C++ headers in the framework bundle
* Updated README about the volatile status of CBL C++ API
* NOTE: 
1. Fleece C++ API was not marked as Volatile.
2. I have experimented with #pragma message("") to add warning message about Volatile API at the header level. The result was pretty annoying as the warning messages will be shown every single time that the header is included during the build (probably in IDE as well). So I decided not to do that in this PR unless we think it's necessary. 