### PR TITLE
CBL-2775: Enable ICU shim for Linux builds

### DIFF
--- a/cmake/platform_linux_desktop.cmake
+++ b/cmake/platform_linux_desktop.cmake
@@ -37,6 +37,7 @@ function(init_vars)
 
     
     set(CBL_CXX_FLAGS "${CBL_CXX_FLAGS} -Wno-psabi" CACHE INTERNAL "")
+    set(LITECORE_DYNAMIC_ICU ON CACHE BOOL "If enabled, search for ICU at runtime so as not to depend on a specific version")
 endfunction()
 
 function(set_dylib_properties)


### PR DESCRIPTION
This will allow a reduction in the number of unique builds needed for platform coverage.  Basically, at this point only two unique builds will be needed -> Builds for distros that are built against GCC 8+ and those that are not