### PR TITLE
CBL-2969 : Add network interface option

### DIFF
--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -83,6 +83,8 @@ namespace cbl {
         unsigned maxAttemptWaitTime         = 0;
         
         unsigned heartbeat                  = 0;
+        
+        std::string networkInterface;
 
         Authenticator authenticator;
         CBLProxySettings* _cbl_nullable proxy = nullptr;
@@ -110,6 +112,8 @@ namespace cbl {
             conf.proxy = proxy;
             if (!headers.empty())
                 conf.headers = headers;
+            if (!networkInterface.empty())
+                conf.networkInterface = slice(networkInterface);
             if (!pinnedServerCertificate.empty())
                 conf.pinnedServerCertificate = slice(pinnedServerCertificate);
             if (!trustedRootCertificates.empty())

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -206,6 +206,9 @@ typedef struct {
     unsigned maxAttemptWaitTime;        ///< Max wait time between retry attempts in seconds. Specify 0 to use the default value of 300 seconds.
     //-- WebSocket:
     unsigned heartbeat;                 ///< The heartbeat interval in seconds. Specify 0 to use the default value of 300 seconds.
+    FLString networkInterface;          ///< The specific network interface to be used by the replicator to connect to the remote server.
+                                        ///< If not specified, an active network interface based on the OS's routing table will be used.
+    
     //-- HTTP settings:
     CBLAuthenticator* _cbl_nullable authenticator;    ///< Authentication credentials, if needed
     const CBLProxySettings* _cbl_nullable proxy;      ///< HTTP client proxy settings

--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -183,6 +183,7 @@ namespace cbl_internal {
             documentIDs = FLArray_MutableCopy(documentIDs, kFLDeepCopyImmutables);
             pinnedServerCertificate = (_pinnedServerCert = pinnedServerCertificate);
             trustedRootCertificates = (_trustedRootCerts = trustedRootCertificates);
+            networkInterface = (_networkInterface = networkInterface);
             if (proxy) {
                 _proxy = *proxy;
                 proxy = &_proxy;
@@ -270,6 +271,11 @@ namespace cbl_internal {
                 enc.writeKey(slice(kC4ReplicatorHeartbeatInterval));
                 enc.writeUInt(heartbeat);
             }
+            
+            if (networkInterface.buf) {
+                enc.writeKey(slice(kC4SocketOptionNetworkInterface));
+                enc.writeString(networkInterface);
+            }
         }
 
         ReplicatorConfiguration(const ReplicatorConfiguration&) =delete;
@@ -287,6 +293,7 @@ namespace cbl_internal {
         alloc_slice      _pinnedServerCert, _trustedRootCerts;
         CBLProxySettings _proxy;
         alloc_slice      _proxyHostname, _proxyUsername, _proxyPassword;
+        alloc_slice      _networkInterface;
     };
 }
 


### PR DESCRIPTION
* Added network interface option to the Replicator Configuration.

* The actual implementation was done in Lite Core ([1a2baa908c0969ba5afc133e29678d6cb59f7113](https://github.com/couchbase/couchbase-lite-core/commit/1a2baa908c0969ba5afc133e29678d6cb59f7113)) and sockpp ([c2edfd83d9d2afd834dc83521606f77a921a106a](https://github.com/couchbasedeps/sockpp/commit/c2edfd83d9d2afd834dc83521606f77a921a106a)).