### PR TITLE
CBL-3184 : Improve access lock in CBLCollection

### DIFF
--- a/src/CBLCollection.cc
+++ b/src/CBLCollection.cc
@@ -71,7 +71,11 @@ namespace cbl_internal {
             Retained<CBLDatabase> db;
             try {
                 db = _collection->database();
-            } catch (...) { }
+            } catch (...) {
+                C4Error error = C4Error::fromCurrentException();
+                CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
+                        "Document changed notification failed: %s", error.description().c_str());
+            }
             
             if (db) {
                 db->notify(this, change);

--- a/src/CBLCollection_Internal.hh
+++ b/src/CBLCollection_Internal.hh
@@ -191,7 +191,11 @@ private:
         Retained<CBLDatabase> db;
         try {
             db = database();
-        } catch (...) { }
+        } catch (...) {
+            C4Error error = C4Error::fromCurrentException();
+            CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
+                    "Collection changed notification failed: %s", error.description().c_str());
+        }
         
         if (db) {
             db->notify(std::bind(&CBLCollection::callCollectionChangeListeners, this));

--- a/src/Listener.hh
+++ b/src/Listener.hh
@@ -162,7 +162,7 @@ namespace cbl_internal {
     template <class LISTENER>
     class Listeners : private ListenersBase {
     public:
-        fleece::Retained<CBLListenerToken> add(LISTENER listener, void *context) {
+        fleece::Retained<CBLListenerToken> add(LISTENER listener, void* _cbl_nullable context) {
             auto t = new ListenerToken<LISTENER>(listener, context);
             add(t);
             return t;

--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -296,7 +296,7 @@ TEST_CASE_METHOD(CollectionTest, "Get Non Existing Collection", "[Collection]") 
     CHECK(col1 == nullptr);
 }
 
-TEST_CASE_METHOD(CollectionTest, "Delete Collection", "[Collection][.CBL-3142]") {
+TEST_CASE_METHOD(CollectionTest, "Delete Collection", "[.CBL-3142]") {
     CBLError error;
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
@@ -450,7 +450,7 @@ TEST_CASE_METHOD(CollectionTest, "Overflow Collection and Scope Names", "[Collec
     CHECK(error.code == kCBLErrorInvalidParameter);
 }
 
-TEST_CASE_METHOD(CollectionTest, "Collection Name Case Sensitive", "[Collection][.3195]") {
+TEST_CASE_METHOD(CollectionTest, "Collection Name Case Sensitive", "[.CBL-3195]") {
     CBLError error;
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "COL1"_sl, "scopeA"_sl, &error);
     REQUIRE(col1a);
@@ -465,7 +465,7 @@ TEST_CASE_METHOD(CollectionTest, "Collection Name Case Sensitive", "[Collection]
     FLMutableArray_Release(colNames);
 }
 
-TEST_CASE_METHOD(CollectionTest, "Scope Name Case Sensitive", "[Collection][.CBL-3195]") {
+TEST_CASE_METHOD(CollectionTest, "Scope Name Case Sensitive", "[.CBL-3195]") {
     CBLError error;
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "col1"_sl, "SCOPEA"_sl, &error);
     REQUIRE(col1a);
@@ -480,7 +480,7 @@ TEST_CASE_METHOD(CollectionTest, "Scope Name Case Sensitive", "[Collection][.CBL
     FLMutableArray_Release(scopeNames);
 }
 
-TEST_CASE_METHOD(CollectionTest, "Create then Get Collection using Different DB Instances", "[Collection][Current]") {
+TEST_CASE_METHOD(CollectionTest, "Create then Get Collection using Different DB Instances", "[Collection]") {
     CBLError error;
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1a);
@@ -524,7 +524,7 @@ TEST_CASE_METHOD(CollectionTest, "Create then Create Collection using Different 
     CBLDatabase_Release(db2);
 }
 
-TEST_CASE_METHOD(CollectionTest, "Delete then Get Collection from Different DB Instances", "[Collection][.CBL-3196]") {
+TEST_CASE_METHOD(CollectionTest, "Delete then Get Collection from Different DB Instances", "[.CBL-3196]") {
     CBLError error;
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1a);
@@ -547,7 +547,7 @@ TEST_CASE_METHOD(CollectionTest, "Delete then Get Collection from Different DB I
     CBLDatabase_Release(db2);
 }
 
-TEST_CASE_METHOD(CollectionTest, "Delete and Recreate then Get Collection from Different DB Instances", "[Collection][.CBL-3142][.CBL-3196]") {
+TEST_CASE_METHOD(CollectionTest, "Delete and Recreate then Get Collection from Different DB Instances", "[.CBL-3142][.CBL-3196]") {
     CBLError error;
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1a);
@@ -608,7 +608,7 @@ TEST_CASE_METHOD(CollectionTest, "Close Database then Use Collection", "[Collect
     CBLCollection_Release(col);
 }
 
-TEST_CASE_METHOD(CollectionTest, "Delete Database then Use Collection", "[Collection][Current]") {
+TEST_CASE_METHOD(CollectionTest, "Delete Database then Use Collection", "[Collection]") {
     CBLError error;
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);


### PR DESCRIPTION
* Previously, in order to lock, CBLCollection calls database() to get the database pointer then calls useLocked() using the database pointer. Even though we have put some code to check if the database pointer is NULL or if the collection itself is valid in the database() function, the process to lock is not entirely safe as the moment from getting the returned database pointer and calling the useLocked() are not part of any lock and the database pointer could be freed during that time.

* This commit solves the above problem by making the CBLDatabase’s c4db access_lock a shared_ptr which will be shared with CBLCollection. This means that there will be no call to database pointer to lock anymore. As a bonus, when the shared_ptr of the c4db_access lock could be retained inside the CBLCollection, the shared_access_lock <Retained<C4Collection>> can be used. This makes the locking code when using c4col looks much cleaner.

* As LiteCore’s acces_lock also provides a way to set the SENTRY (now has protected access control), we could combine the logic to check whether the collection is valid or the database is released into the shared_access_lock’s useLocked itself. This commit creates C4CollectionAccessLock extended from shared_access_lock<Retained<C4Collection>> for that purpose.

* When calling the database to notify the collection changes, retain the database before calling as we cannot lock when notify the listeners.

* Remove "[Collection]" tag on the tests that need fixes.