### PR TITLE
CBL-3233 : Update Scope and Collection API

### DIFF
--- a/include/cbl/CBLCollection.h
+++ b/include/cbl/CBLCollection.h
@@ -79,15 +79,20 @@ CBL_PUBLIC extern const FLString kCBLDefaultCollectionName;
     The default scope is exceptional in that it will always exists even there are no collections under it.
     @note  You are responsible for releasing the returned array.
     @param db  The database.
-    @return  The names of all existing scopes in the database */
-FLMutableArray CBLDatabase_ScopeNames(const CBLDatabase* db) CBLAPI;
+    @param outError  On failure, the error will be written here.
+    @return  The names of all existing scopes in the database, or NULL if an error occurred. */
+FLMutableArray _cbl_nullable CBLDatabase_ScopeNames(const CBLDatabase* db,
+                                                    CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns the names of all collections in the scope.
     @note  You are responsible for releasing the returned array.
     @param db  The database.
     @param scopeName  The name of the scope.
-    @return  The names of all collections in the scope. */
-FLMutableArray CBLDatabase_CollectionNames(const CBLDatabase* db, FLString scopeName) CBLAPI;
+    @param outError  On failure, the error will be written here.
+    @return  The names of all collections in the scope, or NULL if an error occurred. */
+FLMutableArray _cbl_nullable CBLDatabase_CollectionNames(const CBLDatabase* db,
+                                                         FLString scopeName,
+                                                         CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns an existing scope with the given name.
     The scope exists when there is at least one collection created under the scope.
@@ -99,8 +104,11 @@ FLMutableArray CBLDatabase_CollectionNames(const CBLDatabase* db, FLString scope
            it is released.
     @param db  The database.
     @param scopeName  The name of the scope.
-    @return  A \ref CBLScope instance, or NULL if the scope doesn't exist. */
-CBLScope* _cbl_nullable CBLDatabase_Scope(const CBLDatabase* db, FLString scopeName) CBLAPI;
+    @param outError  On failure, the error will be written here.
+    @return  A \ref CBLScope instance, or NULL if the scope doesn't exist or an error occurred. */
+CBLScope* _cbl_nullable CBLDatabase_Scope(const CBLDatabase* db,
+                                          FLString scopeName,
+                                          CBLError* _cbl_nullable outError) CBLAPI;
 
  /** Returns the existing collection with the given name and scope.
     @note  CBLCollection is ref-counted and is owned by the database object, and it will remain
@@ -110,10 +118,12 @@ CBLScope* _cbl_nullable CBLDatabase_Scope(const CBLDatabase* db, FLString scopeN
     @param db  The database.
     @param collectionName  The name of the collection.
     @param scopeName  The name of the scope.
-    @return A \ref CBLCollection instance, or NULL if the collection doesn't exist. */
+    @param outError  On failure, the error will be written here.
+    @return A \ref CBLCollection instance, or NULL if the collection doesn't exist or an error occurred. */
 CBLCollection* _cbl_nullable CBLDatabase_Collection(const CBLDatabase* db,
                                                     FLString collectionName,
-                                                    FLString scopeName) CBLAPI;
+                                                    FLString scopeName,
+                                                    CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Create a new collection.
     When creating a new collection, the collection name, and the scope name are required.
@@ -131,34 +141,37 @@ CBLCollection* _cbl_nullable CBLDatabase_Collection(const CBLDatabase* db,
     @param collectionName  The name of the collection.
     @param scopeName  The name of the scope.
     @param outError  On failure, the error will be written here.
-    @return  A \ref CBLCollection instance, or NULL if there is an error. */
+    @return  A \ref CBLCollection instance, or NULL if an error occurred. */
 CBLCollection* _cbl_nullable CBLDatabase_CreateCollection(CBLDatabase* db,
                                                           FLString collectionName,
                                                           FLString scopeName,
-                                                          CBLError* outError) CBLAPI;
+                                                          CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Delete the collection.
     @param db  The database.
     @param collectionName  The name of the collection.
     @param scopeName  The name of the scope.
     @param outError  On failure, the error will be written here.
-    @return  True if success, or False if there is an error. */
+    @return  True if success, or False if an error occurred. */
 bool CBLDatabase_DeleteCollection(CBLDatabase* db,
                                   FLString collectionName,
                                   FLString scopeName,
-                                  CBLError* outError) CBLAPI;
+                                  CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns the default scope.
     @note  The default scope always exist even there are no collections under it.
     @param db  The database.
-    @return  A \ref CBLScope instance. */
-CBLScope* CBLDatabase_DefaultScope(const CBLDatabase* db) CBLAPI;
+    @return  A \ref CBLScope instance, or NULL if an error occurred. */
+CBLScope* CBLDatabase_DefaultScope(const CBLDatabase* db,
+                                   CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns the default collection.
     @note  The default collection may not exist if it was deleted.
     @param db  The database.
-    @return  A \ref CBLCollection instance, or NULL if the default collection doesn't exist. */
-CBLCollection* _cbl_nullable CBLDatabase_DefaultCollection(const CBLDatabase* db) CBLAPI;
+    @param outError  On failure, the error will be written here.
+    @return  A \ref CBLCollection instance, or NULL if the default collection doesn't exist or an error occurred. */
+CBLCollection* _cbl_nullable CBLDatabase_DefaultCollection(const CBLDatabase* db,
+                                                           CBLError* _cbl_nullable outError) CBLAPI;
 
 /** @} */
 
@@ -384,9 +397,11 @@ bool CBLCollection_DeleteIndex(CBLCollection *collection,
 /** Returns the names of the indexes in the collection, as a Fleece array of strings.
     @note  You are responsible for releasing the returned Fleece array.
     @param collection  The collection.
-    @return  The index names in the collection */
+    @param outError  On failure, an error is written here.
+    @return  The index names in the collection, or NULL if an error occurred. */
 _cbl_warn_unused
-FLMutableArray CBLCollection_GetIndexNames(CBLCollection *collection) CBLAPI;
+FLMutableArray _cbl_nullable CBLCollection_GetIndexNames(CBLCollection *collection,
+                                                         CBLError* _cbl_nullable outError) CBLAPI;
 
 /** @} */
 

--- a/include/cbl/CBLScope.h
+++ b/include/cbl/CBLScope.h
@@ -73,8 +73,10 @@ FLString CBLScope_Name(const CBLScope* scope) CBLAPI;
 /** Returns the names of all collections in the scope.
     @note  You are responsible for releasing the returned array.
     @param scope  The scope.
-    @return  The names of all collections in the scope. */
-FLMutableArray CBLScope_CollectionNames(const CBLScope* scope) CBLAPI;
+    @param outError  On failure, the error will be written here.
+    @return  The names of all collections in the scope, or NULL if an error occurred. */
+FLMutableArray _cbl_nullable CBLScope_CollectionNames(const CBLScope* scope,
+                                                      CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns an existing collection in the scope with the given name.
     @note  CBLCollection is ref-counted and is owned by the database object, and it will remain
@@ -83,8 +85,11 @@ FLMutableArray CBLScope_CollectionNames(const CBLScope* scope) CBLAPI;
            the object needs to be retained, and it will remain valid until it is released.
     @param scope  The scope.
     @param collectionName  The name of the collection.
-    @return A \ref CBLCollection instance, or NULL if the collection doesn't exist. */
-CBLCollection* _cbl_nullable CBLScope_Collection(const CBLScope* scope, FLString collectionName) CBLAPI;
+    @param outError  On failure, the error will be written here.
+    @return A \ref CBLCollection instance, or NULL if the collection doesn't exist or an error occurred. */
+CBLCollection* _cbl_nullable CBLScope_Collection(const CBLScope* scope,
+                                                 FLString collectionName,
+                                                 CBLError* _cbl_nullable outError) CBLAPI;
 
 /** @} */
 /** @} */    // end of outer \defgroup

--- a/src/CBLCollection_CAPI.cc
+++ b/src/CBLCollection_CAPI.cc
@@ -28,31 +28,35 @@ const FLString kCBLDefaultCollectionName = FLSTR("_default");
 
 #pragma mark - SCOPE AND COLLECTION MANAGEMENT
 
-FLMutableArray CBLDatabase_ScopeNames(const CBLDatabase* db) noexcept {
+FLMutableArray CBLDatabase_ScopeNames(const CBLDatabase* db, CBLError* outError) noexcept {
     try {
         return db->scopeNames();
-    } catchAndWarn()
+    } catchAndBridge(outError)
 }
 
-FLMutableArray CBLDatabase_CollectionNames(const CBLDatabase* db, FLString scopeName) noexcept {
+FLMutableArray CBLDatabase_CollectionNames(const CBLDatabase* db,
+                                           FLString scopeName,
+                                           CBLError* outError) noexcept
+{
     try {
         return db->collectionNames(scopeName);
-    } catchAndWarn()
+    } catchAndBridge(outError)
 }
 
-CBLScope* CBLDatabase_Scope(const CBLDatabase* db, FLString scopeName) noexcept {
+CBLScope* CBLDatabase_Scope(const CBLDatabase* db, FLString scopeName, CBLError* outError) noexcept {
     try {
         return const_cast<CBLDatabase*>(db)->getScope(scopeName);
-    } catchAndWarn()
+    } catchAndBridge(outError)
 }
 
 CBLCollection* CBLDatabase_Collection(const CBLDatabase* db,
                                       FLString collectionName,
-                                      FLString scopeName) noexcept
+                                      FLString scopeName,
+                                      CBLError* outError) noexcept
 {
     try {
         return const_cast<CBLDatabase*>(db)->getCollection(collectionName, scopeName);
-    } catchAndWarn()
+    } catchAndBridge(outError)
 }
 
 CBLCollection* CBLDatabase_CreateCollection(CBLDatabase* db,
@@ -75,16 +79,16 @@ bool CBLDatabase_DeleteCollection(CBLDatabase* db,
     } catchAndBridge(outError)
 }
 
-CBLScope* CBLDatabase_DefaultScope(const CBLDatabase* db) noexcept {
+CBLScope* CBLDatabase_DefaultScope(const CBLDatabase* db, CBLError* outError) noexcept {
     try {
         return const_cast<CBLDatabase*>(db)->getDefaultScope();
-    } catchAndWarn()
+    } catchAndBridge(outError)
 }
 
-CBLCollection* CBLDatabase_DefaultCollection(const CBLDatabase* db) noexcept {
+CBLCollection* CBLDatabase_DefaultCollection(const CBLDatabase* db, CBLError* outError) noexcept {
     try {
         return const_cast<CBLDatabase*>(db)->getDefaultCollection(false);
-    } catchAndWarn()
+    } catchAndBridge(outError)
 }
 
 #pragma mark - ACCESSORS
@@ -279,10 +283,10 @@ bool CBLCollection_DeleteIndex(CBLCollection *collection,
     } catchAndBridge(outError)
 }
 
-FLMutableArray CBLCollection_GetIndexNames(CBLCollection *collection) noexcept {
+FLMutableArray CBLCollection_GetIndexNames(CBLCollection *collection, CBLError *outError) noexcept {
     try {
         return FLMutableArray_Retain(collection->indexNames());
-    } catchAndBridgeReturning(nullptr, FLMutableArray_New())
+    } catchAndBridge(outError)
 }
 
 #pragma mark - LISTENERS:

--- a/src/CBLDatabase.cc
+++ b/src/CBLDatabase.cc
@@ -111,6 +111,8 @@ CBLScope* CBLDatabase::getScope(slice scopeName) {
     
     auto c4db = _c4db->useLocked();
     
+    checkOpen();
+    
     CBLScope* scope = nullptr;
     
     bool exist = c4db->hasScope(scopeName);
@@ -140,6 +142,8 @@ CBLCollection* CBLDatabase::getCollection(slice collectionName, slice scopeName)
         scopeName = kC4DefaultScopeID;
 
     auto c4db = _c4db->useLocked();
+    
+    checkOpen();
     
     CBLCollection* collection = nullptr;
     auto spec = C4Database::CollectionSpec(collectionName, scopeName);
@@ -197,6 +201,8 @@ bool CBLDatabase::deleteCollection(slice collectionName, slice scopeName) {
 
 CBLCollection* CBLDatabase::getDefaultCollection(bool mustExist) {
     auto db = _c4db->useLocked();
+    
+    checkOpen();
     
     if (_defaultCollection &&
         !db->hasCollection({kC4DefaultCollectionName, kC4DefaultScopeID})) {

--- a/src/CBLDatabase_CAPI.cc
+++ b/src/CBLDatabase_CAPI.cc
@@ -321,7 +321,16 @@ bool CBLDatabase_DeleteIndex(CBLDatabase *db,
 FLArray CBLDatabase_GetIndexNames(CBLDatabase *db) noexcept {
     try {
         auto col = db->getDefaultCollection(true);
-        return CBLCollection_GetIndexNames(col);
+        
+        CBLError error;
+        auto result = CBLCollection_GetIndexNames(col, &error);
+        if (!result && error.code != 0) {
+            alloc_slice message = CBLError_Message(&error);
+            CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
+                    "Getting index names failed: %d/%d: %.*s",
+                    error.domain, error.code, (int)message.size, (char*)message.buf);
+        }
+        return result;
     } catchAndBridgeReturning(nullptr, FLMutableArray_New())
 }
 

--- a/src/CBLScope_CAPI.cc
+++ b/src/CBLScope_CAPI.cc
@@ -25,23 +25,24 @@ const FLString kCBLDefaultScopeName = FLSTR("_default");
 #pragma mark - ACCESSORS
 
 FLString CBLScope_Name(const CBLScope* scope) noexcept {
-    try {
-        return scope->name();
-    } catchAndWarn()
+    return scope->name();
 }
 
 #pragma mark - COLLECTIONS
 
-FLMutableArray CBLScope_CollectionNames(const CBLScope* scope) noexcept {
+FLMutableArray CBLScope_CollectionNames(const CBLScope* scope,
+                                        CBLError* outError) noexcept
+{
     try {
         return scope->collectionNames();
-    } catchAndWarn()
+    } catchAndBridge(outError)
 }
 
-CBLCollection* _cbl_nullable CBLScope_Collection(const CBLScope* scope,
-                                                 FLString collectionName) noexcept
+CBLCollection* CBLScope_Collection(const CBLScope* scope,
+                                   FLString collectionName,
+                                   CBLError* outError) noexcept
 {
     try {
         return scope->getCollection(collectionName);
-    } catchAndWarn()
+    } catchAndBridge(outError)
 }

--- a/src/CBLScope_Internal.hh
+++ b/src/CBLScope_Internal.hh
@@ -42,23 +42,27 @@ public:
     
     fleece::MutableArray collectionNames() const {
         LOCK(_mutex);
-        if (!_database) {
-            return fleece::MutableArray();
-        }
+        checkOpen();
         return _database->collectionNames(_name);
     }
     
     CBLCollection* _cbl_nullable getCollection(slice collectionName) const {
         LOCK(_mutex);
-        if (!_database) {
-            return nullptr;
-        }
+        checkOpen();
         return _database->getCollection(collectionName, _name);
     }
     
 protected:
     
     friend struct CBLDatabase;
+    
+    // Need to call under the _mutex lock
+    void checkOpen() const {
+        if (!_database) {
+            C4Error::raise(LiteCoreDomain, kC4ErrorNotOpen,
+                           "Invalid scope: db closed or deleted");
+        }
+    }
     
     void close() {
         LOCK(_mutex);

--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -39,7 +39,7 @@ public:
             sprintf(content, "This is the document #%03u.", start + i);
             FLSlot_SetString(FLMutableDict_Set(props, "content"_sl), slice(content));
             
-            CBLError error;
+            CBLError error = {};
             bool saved = CBLCollection_SaveDocument(col, doc, &error);
             CBLDocument_Release(doc);
             REQUIRE(saved);
@@ -47,7 +47,7 @@ public:
     }
     
     CBLDatabase* openDB() {
-        CBLError error;
+        CBLError error = {};
         CBLDatabase* db = CBLDatabase_Open(kDatabaseName, &kDatabaseConfiguration, &error);
         REQUIRE(db);
         return db;
@@ -62,7 +62,7 @@ public:
         checkError(error, kCBLErrorNotOpen);
     }
     
-    void testNotOpenErrorOnInvalidCollection(CBLCollection* col) {
+    void testInvalidCollection(CBLCollection* col) {
         REQUIRE(col);
         
         ExpectingExceptions x;
@@ -73,51 +73,63 @@ public:
         CHECK(CBLCollection_Count(col) == 0);
         
         // Document Functions:
-        CBLError error;
+        CBLError error = {};
         auto doc = CBLDocument_CreateWithID("doc1"_sl);
         CHECK(!CBLCollection_SaveDocument(col, doc, &error));
         checkNotOpenError(error);
         
+        error = {};
         auto conflictHandler = [](void *c, CBLDocument* d1, const CBLDocument* d2) -> bool { return true; };
         CHECK(!CBLCollection_SaveDocumentWithConflictHandler(col, doc, conflictHandler, nullptr, &error));
         checkNotOpenError(error);
         
+        error = {};
         CHECK(!CBLCollection_SaveDocumentWithConcurrencyControl(col, doc, kCBLConcurrencyControlLastWriteWins, &error));
         checkNotOpenError(error);
         
+        error = {};
         CHECK(!CBLCollection_GetDocument(col, "doc1"_sl, &error));
         checkNotOpenError(error);
         
+        error = {};
         CHECK(!CBLCollection_GetMutableDocument(col, "doc1"_sl, &error));
         checkNotOpenError(error);
         
+        error = {};
         CHECK(!CBLCollection_DeleteDocument(col, doc, &error));
         checkNotOpenError(error);
         
+        error = {};
         CHECK(!CBLCollection_DeleteDocumentWithConcurrencyControl(col, doc, kCBLConcurrencyControlLastWriteWins, &error));
         checkNotOpenError(error);
         
+        error = {};
         CHECK(!CBLCollection_PurgeDocument(col, doc, &error));
         checkNotOpenError(error);
         
+        error = {};
         CHECK(!CBLCollection_PurgeDocumentByID(col, "doc1"_sl, &error));
         checkNotOpenError(error);
         
+        error = {};
         CHECK(CBLCollection_GetDocumentExpiration(col, "doc1"_sl, &error) == 0);
         checkNotOpenError(error);
         
+        error = {};
         CHECK(!CBLCollection_SetDocumentExpiration(col, "doc1"_sl, CBL_Now(), &error));
         checkNotOpenError(error);
         
+        error = {};
         CHECK(!CBLCollection_CreateValueIndex(col, "Value"_sl, {}, &error));
         checkNotOpenError(error);
         
+        error = {};
         CHECK(!CBLCollection_CreateFullTextIndex(col, "FTS"_sl, {}, &error));
         checkNotOpenError(error);
         
-        FLMutableArray names = CBLCollection_GetIndexNames(col);
-        CHECK(FLArray_Count(names) == 0);
-        FLMutableArray_Release(names);
+        error = {};
+        CHECK(!CBLCollection_GetIndexNames(col, &error));
+        checkNotOpenError(error);
         
         auto listener = [](void* ctx, const CBLCollectionChange* change) { };
         auto token = CBLCollection_AddChangeListener(col, listener, nullptr);
@@ -130,17 +142,65 @@ public:
         // Release:
         CBLDocument_Release(doc);
     }
+    
+    void testInvalidScope(CBLScope* scope) {
+        REQUIRE(scope);
+        
+        CHECK(CBLScope_Name(scope));
+        
+        ExpectingExceptions x;
+        
+        CBLError error = {};
+        CHECK(!CBLScope_Collection(scope, "collection"_sl, &error));
+        checkNotOpenError(error);
+        
+        error = {};
+        CHECK(!CBLScope_CollectionNames(scope, &error));
+        checkNotOpenError(error);
+    }
+    
+    void testInvalidDatabase(CBLDatabase* database) {
+        REQUIRE(database);
+        
+        ExpectingExceptions x;
+        
+        CBLError error = {};
+        CHECK(!CBLDatabase_DefaultScope(db, &error));
+        checkNotOpenError(error);
+        
+        error = {};
+        CHECK(!CBLDatabase_DefaultCollection(db, &error));
+        checkNotOpenError(error);
+        
+        error = {};
+        CHECK(!CBLDatabase_ScopeNames(db, &error));
+        checkNotOpenError(error);
+        
+        error = {};
+        CHECK(!CBLDatabase_CollectionNames(db, "_default"_sl,  &error));
+        checkNotOpenError(error);
+        
+        error = {};
+        CHECK(!CBLDatabase_Collection(db, "_default"_sl, "_default"_sl, &error));
+        checkNotOpenError(error);
+        
+        error = {};
+        CHECK(!CBLDatabase_Scope(db, "_default"_sl, &error));
+        checkNotOpenError(error);
+    }
 };
 
 TEST_CASE_METHOD(CollectionTest, "Default Collection", "[Collection]") {
-    CBLCollection* col = CBLDatabase_DefaultCollection(db);
+    CBLError error = {};
+    CBLCollection* col = CBLDatabase_DefaultCollection(db, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == kCBLDefaultCollectionName);
     CHECK(CBLCollection_Count(col) == 0);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Default Collection Exists By Default", "[Collection]") {
-    CBLCollection* col = CBLDatabase_DefaultCollection(db);
+    CBLError error = {};
+    CBLCollection* col = CBLDatabase_DefaultCollection(db, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == kCBLDefaultCollectionName);
     CHECK(CBLCollection_Count(col) == 0);
@@ -149,7 +209,7 @@ TEST_CASE_METHOD(CollectionTest, "Default Collection Exists By Default", "[Colle
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
     
-    col = CBLDatabase_Collection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName);
+    col = CBLDatabase_Collection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == kCBLDefaultCollectionName);
     CHECK(CBLCollection_Count(col) == 0);
@@ -158,27 +218,29 @@ TEST_CASE_METHOD(CollectionTest, "Default Collection Exists By Default", "[Colle
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
     
-    FLMutableArray names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName);
+    FLMutableArray names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName, &error);
     CHECK(Array(names).toJSONString() == R"(["_default"])");
     FLMutableArray_Release(names);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Default Scope Exists By Default", "[Collection]") {
-    CBLScope* scope = CBLDatabase_DefaultScope(db);
+    CBLError error = {};
+    CBLScope* scope = CBLDatabase_DefaultScope(db, &error);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
     
-    scope = CBLDatabase_Scope(db, kCBLDefaultScopeName);
+    scope = CBLDatabase_Scope(db, kCBLDefaultScopeName, &error);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
     
-    FLMutableArray names = CBLDatabase_ScopeNames(db);
+    FLMutableArray names = CBLDatabase_ScopeNames(db, &error);
     CHECK(Array(names).toJSONString() == R"(["_default"])");
     FLMutableArray_Release(names);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Delete Default Collection", "[Collection]") {
-    CBLCollection* col = CBLDatabase_DefaultCollection(db);
+    CBLError error = {};
+    CBLCollection* col = CBLDatabase_DefaultCollection(db, &error);
     REQUIRE(col);
     
     // Add some docs:
@@ -186,10 +248,11 @@ TEST_CASE_METHOD(CollectionTest, "Delete Default Collection", "[Collection]") {
     CHECK(CBLCollection_Count(col) == 100);
     
     // Delete the default collection:
-    CBLError error;
     REQUIRE(CBLDatabase_DeleteCollection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName, &error));
-    CHECK(CBLDatabase_DefaultCollection(db) == nullptr);
-    CHECK(CBLDatabase_Collection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName) == nullptr);
+    CHECK(!CBLDatabase_DefaultCollection(db, &error));
+    CHECK(error.code == 0);
+    CHECK(!CBLDatabase_Collection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName, &error));
+    CHECK(error.code == 0);
     
     // Try to recreate the default collection:
     ExpectingExceptions x;
@@ -199,23 +262,23 @@ TEST_CASE_METHOD(CollectionTest, "Delete Default Collection", "[Collection]") {
 }
 
 TEST_CASE_METHOD(CollectionTest, "Get Default Scope After Delete Default Collection", "[Collection]") {
-    REQUIRE(CBLDatabase_DefaultCollection(db));
+    CBLError error = {};
+    REQUIRE(CBLDatabase_DefaultCollection(db, &error));
     
     // Delete the default collection:
-    CBLError error;
     REQUIRE(CBLDatabase_DeleteCollection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName, &error));
     
-    CBLScope* scope = CBLDatabase_DefaultScope(db);
+    CBLScope* scope = CBLDatabase_DefaultScope(db, &error);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
     
-    FLMutableArray names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName);
+    FLMutableArray names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName, &error);
     CHECK(FLArray_Count(names) == 0);
     FLMutableArray_Release(names);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Default Scope", "[Collection]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, kCBLDefaultScopeName, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
@@ -224,11 +287,11 @@ TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Default Scope", "
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
     
-    col = CBLDatabase_Collection(db, "colA"_sl, kCBLDefaultScopeName);
+    col = CBLDatabase_Collection(db, "colA"_sl, kCBLDefaultScopeName, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
     
-    FLMutableArray names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName);
+    FLMutableArray names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName, &error);
     CHECK(Array(names).toJSONString() == R"(["_default","colA"])");
     FLMutableArray_Release(names);
     
@@ -241,17 +304,17 @@ TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Default Scope", "
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
     
-    col = CBLDatabase_Collection(db, "colA"_sl, kCBLDefaultScopeName);
+    col = CBLDatabase_Collection(db, "colA"_sl, kCBLDefaultScopeName, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
     
-    names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName);
+    names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName, &error);
     CHECK(Array(names).toJSONString() == R"(["_default","colA","colB"])");
     FLMutableArray_Release(names);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Named Scope", "[Collection]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
@@ -260,26 +323,26 @@ TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Named Scope", "[C
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == "scopeA"_sl);
     
-    col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl);
+    col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
     
-    FLMutableArray names = CBLDatabase_CollectionNames(db, "scopeA"_sl);
+    FLMutableArray names = CBLDatabase_CollectionNames(db, "scopeA"_sl, &error);
     CHECK(Array(names).toJSONString() == R"(["colA"])");
     FLMutableArray_Release(names);
     
     // Check the scope and scope names from database:
-    scope = CBLDatabase_Scope(db, "scopeA"_sl);
+    scope = CBLDatabase_Scope(db, "scopeA"_sl, &error);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == "scopeA"_sl);
     
-    FLMutableArray scopeNames = CBLDatabase_ScopeNames(db);
+    FLMutableArray scopeNames = CBLDatabase_ScopeNames(db, &error);
     CHECK(Array(scopeNames).toJSONString() == R"(["_default","scopeA"])");
     FLMutableArray_Release(scopeNames);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Create Existing Collection", "[Collection]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col1 = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1);
     CHECK(CBLCollection_Name(col1) == "colA"_sl);
@@ -292,17 +355,19 @@ TEST_CASE_METHOD(CollectionTest, "Create Existing Collection", "[Collection]") {
 }
 
 TEST_CASE_METHOD(CollectionTest, "Get Non Existing Collection", "[Collection]") {
-    CBLCollection* col1 = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl);
+    CBLError error = {};
+    CBLCollection* col1 = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl, &error);
     CHECK(col1 == nullptr);
+    CHECK(error.code == 0);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Delete Collection", "[.CBL-3142]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
     
-    col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl);
+    col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
     
@@ -313,8 +378,9 @@ TEST_CASE_METHOD(CollectionTest, "Delete Collection", "[.CBL-3142]") {
     // Delete:
     REQUIRE(CBLDatabase_DeleteCollection(db, "colA"_sl, "scopeA"_sl, &error));
     
-    col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl);
+    col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl, &error);
     CHECK(col == nullptr);
+    CHECK(error.code == 0);
     
     // Recreate: CBL-3142
     col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
@@ -322,65 +388,69 @@ TEST_CASE_METHOD(CollectionTest, "Delete Collection", "[.CBL-3142]") {
     CHECK(CBLCollection_Name(col) == "colA"_sl);
     CHECK(CBLCollection_Count(col) == 0);
 
-    col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl);
+    col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
     CHECK(CBLCollection_Count(col) == 0);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Get Collections from Scope", "[Collection]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* colA = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(colA);
     
     CBLCollection* colB = CBLDatabase_CreateCollection(db, "colB"_sl, "scopeA"_sl, &error);
     REQUIRE(colB);
     
-    CBLScope* scope = CBLDatabase_Scope(db, "scopeA"_sl);
+    CBLScope* scope = CBLDatabase_Scope(db, "scopeA"_sl, &error);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == "scopeA"_sl);
     
-    CHECK(CBLScope_Collection(scope, "colA"_sl) == colA);
-    CHECK(CBLScope_Collection(scope, "colB"_sl) == colB);
-    CHECK(!CBLScope_Collection(scope, "colC"_sl));
+    CHECK(CBLScope_Collection(scope, "colA"_sl, &error) == colA);
+    CHECK(CBLScope_Collection(scope, "colB"_sl, &error) == colB);
+    CHECK(!CBLScope_Collection(scope, "colC"_sl, &error));
+    CHECK(error.code == 0);
     
-    FLMutableArray colNames = CBLScope_CollectionNames(scope);
+    FLMutableArray colNames = CBLScope_CollectionNames(scope, &error);
     CHECK(Array(colNames).toJSONString() == R"(["colA","colB"])");
     FLMutableArray_Release(colNames);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Delete All Collections in Scope", "[Collection]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* colA = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(colA);
     
     CBLCollection* colB = CBLDatabase_CreateCollection(db, "colB"_sl, "scopeA"_sl, &error);
     REQUIRE(colB);
     
-    CBLScope* scope = CBLDatabase_Scope(db, "scopeA"_sl);
+    CBLScope* scope = CBLDatabase_Scope(db, "scopeA"_sl, &error);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == "scopeA"_sl);
-    FLMutableArray scopeNames = CBLDatabase_ScopeNames(db);
+    FLMutableArray scopeNames = CBLDatabase_ScopeNames(db, &error);
     CHECK(Array(scopeNames).toJSONString() == R"(["_default","scopeA"])");
     FLMutableArray_Release(scopeNames);
     
     // Delete all collections in the scope:
-    FLMutableArray colNames = CBLScope_CollectionNames(scope);
+    FLMutableArray colNames = CBLScope_CollectionNames(scope, &error);
     for (Array::iterator i(colNames); i; ++i) {
         REQUIRE(CBLDatabase_DeleteCollection(db, i->asString(), CBLScope_Name(scope), &error));
     }
     FLMutableArray_Release(colNames);
     
     // Get collections from the scope object:
-    CHECK(!CBLScope_Collection(scope, "colA"_sl));
-    CHECK(!CBLScope_Collection(scope, "colB"_sl));
-    colNames = CBLScope_CollectionNames(scope);
+    CHECK(!CBLScope_Collection(scope, "colA"_sl, &error));
+    CHECK(error.code == 0);
+    CHECK(!CBLScope_Collection(scope, "colB"_sl, &error));
+    CHECK(error.code == 0);
+    colNames = CBLScope_CollectionNames(scope, &error);
     CHECK(Array(colNames).toJSONString() == R"([])");
     FLMutableArray_Release(colNames);
     
     // Check that the scope doesn't exist:
-    CHECK(!CBLDatabase_Scope(db, "scopeA"_sl));
-    scopeNames = CBLDatabase_ScopeNames(db);
+    CHECK(!CBLDatabase_Scope(db, "scopeA"_sl, &error));
+    CHECK(error.code == 0);
+    scopeNames = CBLDatabase_ScopeNames(db, &error);
     CHECK(Array(scopeNames).toJSONString() == R"(["_default"])");
     FLMutableArray_Release(scopeNames);
 }
@@ -392,10 +462,10 @@ TEST_CASE_METHOD(CollectionTest, "Valid Collection and Scope Names", "[Collectio
     };
 
     for (auto name : names) {
-        CBLError error;
+        CBLError error = {};
         CBLCollection* col = CBLDatabase_CreateCollection(db, slice(name), slice(name), &error);
         REQUIRE(col);
-        col = CBLDatabase_Collection(db, slice(name), slice(name));
+        col = CBLDatabase_Collection(db, slice(name), slice(name), &error);
         CHECK(col == col);
     }
 }
@@ -413,7 +483,7 @@ TEST_CASE_METHOD(CollectionTest, "Invalid Collection and Scope Names", "[Collect
     
     for (auto name : names) {
         ExpectingExceptions x;
-        CBLError error;
+        CBLError error = {};
         CBLCollection* col = CBLDatabase_CreateCollection(db, slice(name), "scopeA"_sl, &error);
         REQUIRE(!col);
         CHECK(error.domain == kCBLDomain);
@@ -432,7 +502,7 @@ TEST_CASE_METHOD(CollectionTest, "Overflow Collection and Scope Names", "[Collec
         name = name + "a";
     }
     
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, slice(name), slice(name), &error);
     REQUIRE(col);
     
@@ -451,7 +521,7 @@ TEST_CASE_METHOD(CollectionTest, "Overflow Collection and Scope Names", "[Collec
 }
 
 TEST_CASE_METHOD(CollectionTest, "Collection Name Case Sensitive", "[.CBL-3195]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "COL1"_sl, "scopeA"_sl, &error);
     REQUIRE(col1a);
     
@@ -460,13 +530,13 @@ TEST_CASE_METHOD(CollectionTest, "Collection Name Case Sensitive", "[.CBL-3195]"
     
     CHECK(col1a != col1b);
     
-    FLMutableArray colNames = CBLDatabase_CollectionNames(db, "scopeA"_sl);
+    FLMutableArray colNames = CBLDatabase_CollectionNames(db, "scopeA"_sl, &error);
     CHECK(Array(colNames).toJSONString() == R"(["_default",COL1","col1"])");
     FLMutableArray_Release(colNames);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Scope Name Case Sensitive", "[.CBL-3195]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "col1"_sl, "SCOPEA"_sl, &error);
     REQUIRE(col1a);
     
@@ -475,13 +545,13 @@ TEST_CASE_METHOD(CollectionTest, "Scope Name Case Sensitive", "[.CBL-3195]") {
     
     CHECK(col1a != col1b);
     
-    FLMutableArray scopeNames = CBLDatabase_ScopeNames(db);
+    FLMutableArray scopeNames = CBLDatabase_ScopeNames(db, &error);
     CHECK(Array(scopeNames).toJSONString() == R"(["_default",SCOPEA","scopea"])");
     FLMutableArray_Release(scopeNames);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Create then Get Collection using Different DB Instances", "[Collection]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1a);
     createNumberedDocs(col1a, 10);
@@ -489,7 +559,7 @@ TEST_CASE_METHOD(CollectionTest, "Create then Get Collection using Different DB 
     
     // Using another instance to get the collection:
     CBLDatabase* db2 = openDB();
-    CBLCollection* col1b = CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl);
+    CBLCollection* col1b = CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1b);
     CHECK(col1a != col1b);
     CHECK(CBLCollection_Count(col1b) == 10);
@@ -503,7 +573,7 @@ TEST_CASE_METHOD(CollectionTest, "Create then Get Collection using Different DB 
 }
 
 TEST_CASE_METHOD(CollectionTest, "Create then Create Collection using Different DB Instances", "[Collection]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1a);
     createNumberedDocs(col1a, 10);
@@ -525,14 +595,14 @@ TEST_CASE_METHOD(CollectionTest, "Create then Create Collection using Different 
 }
 
 TEST_CASE_METHOD(CollectionTest, "Delete then Get Collection from Different DB Instances", "[.CBL-3196]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1a);
     createNumberedDocs(col1a, 10);
     CHECK(CBLCollection_Count(col1a) == 10);
     
     CBLDatabase* db2 = openDB();
-    CBLCollection* col1b = CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl);
+    CBLCollection* col1b = CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1b);
     CHECK(col1a != col1b);
     CHECK(CBLCollection_Count(col1b) == 10);
@@ -541,21 +611,23 @@ TEST_CASE_METHOD(CollectionTest, "Delete then Get Collection from Different DB I
     REQUIRE(CBLDatabase_DeleteCollection(db, "colA"_sl, "scopeA"_sl, &error));
     CHECK(CBLCollection_Count(col1a) == 0);
     CHECK(CBLCollection_Count(col1b) == 0);
-    CHECK(!CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl));
-    CHECK(!CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl));
+    CHECK(!CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl, &error));
+    CHECK(error.code == 0);
+    CHECK(!CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl, &error));
+    CHECK(error.code == 0);
     
     CBLDatabase_Release(db2);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Delete and Recreate then Get Collection from Different DB Instances", "[.CBL-3142][.CBL-3196]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1a);
     createNumberedDocs(col1a, 10);
     CHECK(CBLCollection_Count(col1a) == 10);
     
     CBLDatabase* db2 = openDB();
-    CBLCollection* col1b = CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl);
+    CBLCollection* col1b = CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1b);
     CHECK(col1a != col1b);
     CHECK(CBLCollection_Count(col1b) == 10);
@@ -571,7 +643,7 @@ TEST_CASE_METHOD(CollectionTest, "Delete and Recreate then Get Collection from D
     CHECK(CBLCollection_Count(col1a) == 0);
     CHECK(CBLCollection_Count(col1b) == 0);
     
-    CBLCollection* col1d = CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl);
+    CBLCollection* col1d = CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col1d);
     CHECK(col1d != col1b);
     
@@ -579,7 +651,7 @@ TEST_CASE_METHOD(CollectionTest, "Delete and Recreate then Get Collection from D
 }
 
 TEST_CASE_METHOD(CollectionTest, "Delete Collection then Use Collection", "[Collection]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     
@@ -587,13 +659,13 @@ TEST_CASE_METHOD(CollectionTest, "Delete Collection then Use Collection", "[Coll
     
     REQUIRE(CBLDatabase_DeleteCollection(db, "colA"_sl, "scopeA"_sl, &error));
     
-    testNotOpenErrorOnInvalidCollection(col);
+    testInvalidCollection(col);
     
     CBLCollection_Release(col);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Close Database then Use Collection", "[Collection]") {
-    CBLError error;
+    CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     
@@ -603,13 +675,13 @@ TEST_CASE_METHOD(CollectionTest, "Close Database then Use Collection", "[Collect
     CBLDatabase_Release(db);
     db = nullptr;
     
-    testNotOpenErrorOnInvalidCollection(col);
+    testInvalidCollection(col);
     
     CBLCollection_Release(col);
 }
 
-TEST_CASE_METHOD(CollectionTest, "Delete Database then Use Collection", "[Collection]") {
-    CBLError error;
+TEST_CASE_METHOD(CollectionTest, "Delete Database then Use Scope", "[Collection]") {
+    CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     
@@ -619,7 +691,41 @@ TEST_CASE_METHOD(CollectionTest, "Delete Database then Use Collection", "[Collec
     CBLDatabase_Release(db);
     db = nullptr;
     
-    testNotOpenErrorOnInvalidCollection(col);
+    CBLScope* scope = CBLCollection_Scope(col);
+    REQUIRE(scope);
+    
+    testInvalidScope(scope);
     
     CBLCollection_Release(col);
+}
+
+TEST_CASE_METHOD(CollectionTest, "Close Database then Use Scope", "[Collection]") {
+    CBLError error = {};
+    CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
+    REQUIRE(col);
+    
+    CBLCollection_Retain(col);
+    
+    REQUIRE(CBLDatabase_Close(db, &error));
+    CBLDatabase_Release(db);
+    db = nullptr;
+    
+    CBLScope* scope = CBLCollection_Scope(col);
+    REQUIRE(scope);
+    
+    testInvalidScope(scope);
+    
+    CBLCollection_Release(col);
+}
+
+TEST_CASE_METHOD(CollectionTest, "Close Database then Create Or Get Collections and Scopes", "[Collection]") {
+    CBLError error = {};
+    CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
+    
+    REQUIRE(CBLDatabase_Close(db, &error));
+    
+    testInvalidDatabase(db);
+    
+    CBLDatabase_Release(db);
+    db = nullptr;
 }


### PR DESCRIPTION
* Updated the API based on the updated on 20220601.
* Added more collection tests to test the behavior when database is closed or deleted.
* Simply implemented checking whether database is closed and throwing exception. This will be enhanced by using the database’s access lock in CBL-3231 to avoid large PR.