### PR TITLE
CBL-3231 : Implement C4DatabaseAccessLock

### DIFF
--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -221,11 +221,11 @@ bool CBLDatabase_PerformMaintenance(CBLDatabase* db,
 /** Returns the database's name. */
 FLString CBLDatabase_Name(const CBLDatabase*) CBLAPI;
 
-/** Returns the database's full filesystem path. */
+/** Returns the database's full filesystem path, or null slice if the database is closed or deleted. */
 _cbl_warn_unused
 FLStringResult CBLDatabase_Path(const CBLDatabase*) CBLAPI;
 
-/** Returns the number of documents in the database. */
+/** Returns the number of documents in the database, or zero if the database is closed or deleted. */
 uint64_t CBLDatabase_Count(const CBLDatabase*) CBLAPI;
 
 /** Returns the database's configuration, as given when it was opened.

--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -78,6 +78,7 @@ CBLTest::CBLTest() {
 
 CBLTest::~CBLTest() {
     if (db) {
+        ExpectingExceptions x; // Database might have been closed by the test:
         CBLError error;
         if (!CBLDatabase_Close(db, &error))
             WARN("Failed to close database: " << error.domain << "/" << error.code);
@@ -86,6 +87,15 @@ CBLTest::~CBLTest() {
     if (CBL_InstanceCount() > 0)
         CBL_DumpInstances();
     CHECK(CBL_InstanceCount() == 0);
+}
+
+void CBLTest::checkError(CBLError& error, CBLErrorCode expectedCode, CBLErrorDomain expectedDomain) {
+    CHECK(error.domain == expectedDomain);
+    CHECK(error.code == expectedCode);
+}
+
+void CBLTest::checkNotOpenError(CBLError& error) {
+    checkError(error, kCBLErrorNotOpen);
 }
 
 

--- a/test/CBLTest.hh
+++ b/test/CBLTest.hh
@@ -71,6 +71,9 @@ public:
 
 
     CBLDatabase *db {nullptr};
+    
+    void checkError(CBLError& error, CBLErrorCode expectedCode, CBLErrorDomain expectedDomain = kCBLDomain);
+    void checkNotOpenError(CBLError& error);
 };
 
 

--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -53,15 +53,6 @@ public:
         return db;
     }
     
-    void checkError(CBLError& error, CBLErrorCode expectedCode, CBLErrorDomain expectedDomain = kCBLDomain) {
-        CHECK(error.domain == expectedDomain);
-        CHECK(error.code == expectedCode);
-    }
-    
-    void checkNotOpenError(CBLError& error) {
-        checkError(error, kCBLErrorNotOpen);
-    }
-    
     void testInvalidCollection(CBLCollection* col) {
         REQUIRE(col);
         


### PR DESCRIPTION
* Implemented C4DatabaseAccessLock which has a uselocked’s sentry to throw a NotOpen error if is was closed.

* Updated the Database’s close and delete logic to close the scopes and collections (invalidate the database pointer) right away.

* The C4DatabaseAccessLock’s useLockedIgnoredWhenClosed() is used by CBLDatabase’s destructor to ignore the closed logic and throwing NotOpen exception if the database has already been closed. This would allow to have having to disable breaking point from exception in many places that release the database in tests.

* CBL-3232 : Added tests to test the behavior when using the Database APIs on the closed or deleted database and fixed bugs.