### PR TITLE
CBL-3187 : Deprecate pre-collection APIs

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 		FC5FBBA32821B3450066157F /* CBLCollection.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLCollection.cc; sourceTree = "<group>"; };
 		FC5FBBA42821B3450066157F /* CBLCollection_Internal.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CBLCollection_Internal.hh; sourceTree = "<group>"; };
 		FC5FBBB42821CC2E0066157F /* CBLCollection_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLCollection_CAPI.cc; sourceTree = "<group>"; };
+		FC8B21272852D3ED008D24F8 /* CBLCompat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLCompat.h; sourceTree = "<group>"; };
 		FCD8298B283591D4004AA814 /* CollectionTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CollectionTest.cc; sourceTree = "<group>"; };
 		FCD8299C2835AC20004AA814 /* CBLScope_Internal.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CBLScope_Internal.hh; sourceTree = "<group>"; };
 		FCD829B12835ECE0004AA814 /* CBLScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLScope.h; sourceTree = "<group>"; };
@@ -533,6 +534,7 @@
 				27886C8C21F64C1400069BEA /* Listener.cc */,
 				27886C8B21F64C1400069BEA /* Listener.hh */,
 				275FA3342236E54D001C392D /* CBLPrivate.h */,
+				FC8B21272852D3ED008D24F8 /* CBLCompat.h */,
 				27229262260BD3D600A3A41F /* C Glue */,
 				27B61D7E21D6B6900027CCDB /* dylib_main.cc */,
 				2716F8F5247D9D6700BE21D9 /* exports */,

--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -226,6 +226,7 @@ _cbl_warn_unused
 FLStringResult CBLDatabase_Path(const CBLDatabase*) CBLAPI;
 
 /** Returns the number of documents in the database. */
+_cbl_deprecated("Use CBLCollection_Count on the default collection instead.")
 uint64_t CBLDatabase_Count(const CBLDatabase*) CBLAPI;
 
 /** Returns the database's configuration, as given when it was opened.
@@ -254,6 +255,7 @@ const CBLDatabaseConfiguration CBLDatabase_Config(const CBLDatabase*) CBLAPI;
     @param db  The database that changed.
     @param numDocs  The number of documents that changed (size of the `docIDs` array)
     @param docIDs  The IDs of the documents that changed, as a C array of `numDocs` C strings. */
+_cbl_deprecated("Use CBLCollectionChangeListener instead.")
 typedef void (*CBLDatabaseChangeListener)(void* _cbl_nullable context,
                                           const CBLDatabase* db,
                                           unsigned numDocs,
@@ -266,6 +268,7 @@ typedef void (*CBLDatabaseChangeListener)(void* _cbl_nullable context,
     @param context  An opaque value that will be passed to the callback.
     @return  A token to be passed to \ref CBLListener_Remove when it's time to remove the
             listener.*/
+_cbl_deprecated("Use CBLCollection_AddChangeListener on the default collection instead.")
 _cbl_warn_unused
 CBLListenerToken* CBLDatabase_AddChangeListener(const CBLDatabase* db,
                                                 CBLDatabaseChangeListener listener,

--- a/include/cbl/CBLDocument.h
+++ b/include/cbl/CBLDocument.h
@@ -68,6 +68,7 @@ typedef bool (*CBLConflictHandler)(void* _cbl_nullable context,
     @param outError  On failure, the error will be written here. (A nonexistent document is not
                     considered a failure; in that event the error code will be zero.)
     @return  A new \ref CBLDocument instance, or NULL if the doc doesn't exist or an error occurred. */
+_cbl_deprecated("Use CBLCollection_GetDocument on the default collection instead.")
 _cbl_warn_unused
 const CBLDocument* _cbl_nullable CBLDatabase_GetDocument(const CBLDatabase* database,
                                                          FLString docID,
@@ -84,6 +85,7 @@ CBL_REFCOUNTED(CBLDocument*, Document);
     @param doc  The mutable document to save.
     @param outError  On failure, the error will be written here.
     @return  True on success, false on failure. */
+_cbl_deprecated("Use CBLCollection_SaveDocument on the default collection instead.")
 bool CBLDatabase_SaveDocument(CBLDatabase* db,
                               CBLDocument* doc,
                               CBLError* _cbl_nullable outError) CBLAPI;
@@ -98,6 +100,7 @@ bool CBLDatabase_SaveDocument(CBLDatabase* db,
     @param concurrency  Conflict-handling strategy (fail or overwrite).
     @param outError  On failure, the error will be written here.
     @return  True on success, false on failure. */
+_cbl_deprecated("Use CBLCollection_SaveDocumentWithConcurrencyControl on the default collection instead.")
 bool CBLDatabase_SaveDocumentWithConcurrencyControl(CBLDatabase* db,
                                                     CBLDocument* doc,
                                                     CBLConcurrencyControl concurrency,
@@ -111,6 +114,7 @@ bool CBLDatabase_SaveDocumentWithConcurrencyControl(CBLDatabase* db,
     @param context  An arbitrary value to be passed to the \p conflictHandler.
     @param outError  On failure, the error will be written here.
     @return  True on success, false on failure. */
+_cbl_deprecated("Use CBLCollection_SaveDocumentWithConflictHandler on the default collection instead.")
 bool CBLDatabase_SaveDocumentWithConflictHandler(CBLDatabase* db,
                                                  CBLDocument* doc,
                                                  CBLConflictHandler conflictHandler,
@@ -123,6 +127,7 @@ bool CBLDatabase_SaveDocumentWithConflictHandler(CBLDatabase* db,
     @param document  The document to delete.
     @param outError  On failure, the error will be written here.
     @return  True if the document was deleted, false if an error occurred. */
+_cbl_deprecated("Use CBLCollection_DeleteDocument on the default collection instead.")
 bool CBLDatabase_DeleteDocument(CBLDatabase *db,
                                 const CBLDocument* document,
                                 CBLError* _cbl_nullable outError) CBLAPI;
@@ -134,6 +139,7 @@ bool CBLDatabase_DeleteDocument(CBLDatabase *db,
     @param concurrency  Conflict-handling strategy.
     @param outError  On failure, the error will be written here.
     @return  True if the document was deleted, false if an error occurred. */
+_cbl_deprecated("Use CBLCollection_DeleteDocumentWithConcurrencyControl on the default collection instead.")
 bool CBLDatabase_DeleteDocumentWithConcurrencyControl(CBLDatabase *db,
                                                       const CBLDocument* document,
                                                       CBLConcurrencyControl concurrency,
@@ -149,6 +155,7 @@ bool CBLDatabase_DeleteDocumentWithConcurrencyControl(CBLDatabase *db,
     @param document  The document to delete.
     @param outError  On failure, the error will be written here.
     @return  True if the document was purged, false if it doesn't exist or the purge failed. */
+_cbl_deprecated("Use CBLCollection_PurgeDocument on the default collection instead.")
 bool CBLDatabase_PurgeDocument(CBLDatabase* db,
                                const CBLDocument* document,
                                CBLError* _cbl_nullable outError) CBLAPI;
@@ -159,8 +166,8 @@ bool CBLDatabase_PurgeDocument(CBLDatabase* db,
     @param database  The database.
     @param docID  The document ID to purge.
     @param outError  On failure, the error will be written here.
-    @return  True if the document was purged, false if it doesn't exist or the purge failed.
- */
+    @return  True if the document was purged, false if it doesn't exist or the purge failed. */
+_cbl_deprecated("Use CBLCollection_PurgeDocumentByID on the default collection instead.")
 bool CBLDatabase_PurgeDocumentByID(CBLDatabase* database,
                                    FLString docID,
                                    CBLError* _cbl_nullable outError) CBLAPI;
@@ -184,6 +191,7 @@ bool CBLDatabase_PurgeDocumentByID(CBLDatabase* database,
     @param outError  On failure, the error will be written here. (A nonexistent document is not
                     considered a failure; in that event the error code will be zero.)
     @return  A new \ref CBLDocument instance, or NULL if the doc doesn't exist or an error occurred. */
+_cbl_deprecated("Use CBLCollection_GetMutableDocument on the default collection instead.")
 _cbl_warn_unused
 CBLDocument* _cbl_nullable CBLDatabase_GetMutableDocument(CBLDatabase* database,
                                                           FLString docID,
@@ -289,6 +297,7 @@ bool CBLDocument_SetJSON(CBLDocument*,
     @return  The expiration time as a CBLTimestamp (milliseconds since Unix epoch),
              or 0 if the document does not have an expiration,
              or -1 if the call failed. */
+_cbl_deprecated("Use CBLCollection_GetDocumentExpiration instead.")
 CBLTimestamp CBLDatabase_GetDocumentExpiration(CBLDatabase* db,
                                                FLSlice docID,
                                                CBLError* _cbl_nullable outError) CBLAPI;
@@ -300,6 +309,7 @@ CBLTimestamp CBLDatabase_GetDocumentExpiration(CBLDatabase* db,
                         or 0 if the document should never expire.
     @param outError  On failure, an error is written here.
     @return  True on success, false on failure. */
+_cbl_deprecated("Use CBLCollection_SetDocumentExpiration instead.")
 bool CBLDatabase_SetDocumentExpiration(CBLDatabase* db,
                                        FLSlice docID,
                                        CBLTimestamp expiration,
@@ -324,6 +334,7 @@ bool CBLDatabase_SetDocumentExpiration(CBLDatabase* db,
     @param context  An arbitrary value given when the callback was registered.
     @param db  The database containing the document.
     @param docID  The document's ID. */
+_cbl_deprecated("Use CBLCollectionChangeListener instead.")
 typedef void (*CBLDocumentChangeListener)(void *context,
                                           const CBLDatabase* db,
                                           FLString docID);
@@ -336,6 +347,7 @@ typedef void (*CBLDocumentChangeListener)(void *context,
     @param context  An opaque value that will be passed to the callback.
     @return  A token to be passed to \ref CBLListener_Remove when it's time to remove the
             listener.*/
+_cbl_deprecated("Use CBLCollection_AddDocumentChangeListener on the default collection instead.")
 _cbl_warn_unused
 CBLListenerToken* CBLDatabase_AddDocumentChangeListener(const CBLDatabase* db,
                                                         FLString docID,

--- a/include/cbl/CBLQuery.h
+++ b/include/cbl/CBLQuery.h
@@ -277,6 +277,7 @@ typedef struct {
     Indexes are persistent.
     If an identical index with that name already exists, nothing happens (and no error is returned.)
     If a non-identical index with that name already exists, it is deleted and re-created. */
+_cbl_deprecated("Use CBLCollection_CreateValueIndex on the default collection instead.")
 bool CBLDatabase_CreateValueIndex(CBLDatabase *db,
                                   FLString name,
                                   CBLValueIndexConfiguration config,
@@ -314,12 +315,14 @@ typedef struct {
     Indexes are persistent.
     If an identical index with that name already exists, nothing happens (and no error is returned.)
     If a non-identical index with that name already exists, it is deleted and re-created. */
+_cbl_deprecated("Use CBLCollection_CreateFullTextIndex on the default collection instead.")
 bool CBLDatabase_CreateFullTextIndex(CBLDatabase *db,
                                      FLString name,
                                      CBLFullTextIndexConfiguration config,
                                      CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Deletes an index given its name. */
+_cbl_deprecated("Use CBLCollection_DeleteIndex on the default collection instead.")
 bool CBLDatabase_DeleteIndex(CBLDatabase *db,
                              FLString name,
                              CBLError* _cbl_nullable outError) CBLAPI;
@@ -327,6 +330,7 @@ bool CBLDatabase_DeleteIndex(CBLDatabase *db,
 /** Returns the names of the indexes on this database, as a Fleece array of strings.
     @note  You are responsible for releasing the returned Fleece array. */
 _cbl_warn_unused
+_cbl_deprecated("Use CBLCollection_GetIndexNames on the default collection instead.")
 FLArray CBLDatabase_GetIndexNames(CBLDatabase *db) CBLAPI;
 
 /** @} */

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -156,6 +156,7 @@ typedef struct {
     \note   If a null \ref FLSliceResult or an error is returned, the document will be failed to
             replicate with the \ref kCBLErrorCrypto error when. For security reason, the encryption
             cannot be skipped. */
+_cbl_deprecated("Use CBLDocumentPropertyEncryptor instead.")
 typedef FLSliceResult (*CBLPropertyEncryptor) (
     void* context,              ///< Replicator’s context
     FLString documentID,        ///< Document ID
@@ -172,6 +173,7 @@ typedef FLSliceResult (*CBLPropertyEncryptor) (
     \note   The decryption will be skipped (the encrypted data will be kept) when a null \ref FLSliceResult
             without an error is returned. If an error is returned, the document will be failed to replicate
             with the \ref kCBLErrorCrypto error. */
+_cbl_deprecated("Use CBLDocumentPropertyDecryptor instead.")
 typedef FLSliceResult (*CBLPropertyDecryptor) (
     void* context,              ///< Replicator’s context
     FLString documentID,        ///< Document ID
@@ -234,6 +236,7 @@ typedef struct {
 
 /** The configuration of a replicator. */
 typedef struct {
+    _cbl_deprecated("Use collections instead.")
     CBLDatabase* database;                  ///< The database to replicate
     CBLEndpoint* endpoint;                  ///< The address of the other database to replicate with
     CBLReplicatorType replicatorType;       ///< Push, pull or both
@@ -266,16 +269,23 @@ typedef struct {
     FLSlice pinnedServerCertificate;    ///< An X.509 cert to "pin" TLS connections to (PEM or DER)
     FLSlice trustedRootCertificates;    ///< Set of anchor certs (PEM format)
     //-- Filtering:
+    _cbl_deprecated("Use CBLReplicationCollection.channels instead.")
     FLArray _cbl_nullable channels;                   ///< Optional set of channels to pull from
+    _cbl_deprecated("Use CBLReplicationCollection.documentIDs instead.")
     FLArray _cbl_nullable documentIDs;                ///< Optional set of document IDs to replicate
+    _cbl_deprecated("Use CBLReplicationCollection.pushFilter instead.")
     CBLReplicationFilter _cbl_nullable pushFilter;    ///< Optional callback to filter which docs are pushed
+    _cbl_deprecated("Use CBLReplicationCollection.pullFilter instead.")
     CBLReplicationFilter _cbl_nullable pullFilter;    ///< Optional callback to validate incoming docs
+    _cbl_deprecated("Use CBLReplicationCollection.conflictResolver instead.")
     CBLConflictResolver _cbl_nullable conflictResolver;///< Optional conflict-resolver callback
     void* _cbl_nullable context;                      ///< Arbitrary value that will be passed to callbacks
     
 #ifdef COUCHBASE_ENTERPRISE
     //-- Property Encryption
+    _cbl_deprecated("Use documentPropertyEncryptor instead.")
     CBLPropertyEncryptor propertyEncryptor;           ///< Optional callback to encrypt \ref CBLEncryptable values of the documents in the default collection. If the default collection is not part of the replication, the replicator will fail to create with an error.
+    _cbl_deprecated("Use documentPropertyDecryptor instead.")
     CBLPropertyDecryptor propertyDecryptor;           ///< Optional callback to decrypt encrypted \ref CBLEncryptable values of the documents in the default collection. If the default collection is not part of the replication, the replicator will fail to create with an error.
     
     CBLDocumentPropertyEncryptor documentPropertyEncryptor;   ///< Optional callback to encrypt \ref CBLEncryptable values.
@@ -382,6 +392,7 @@ CBLReplicatorStatus CBLReplicator_Status(CBLReplicator*) CBLAPI;
            `pushFilter` or `docIDs`, are ignored.
     @warning  You are responsible for releasing the returned array via \ref FLValue_Release.
     @warning  If the default collection is not part of the replication, a NULL with an error will be returned. */
+_cbl_deprecated("Use CBLReplicator_PendingDocumentIDs2 instead.")
 _cbl_warn_unused
 FLDict _cbl_nullable CBLReplicator_PendingDocumentIDs(CBLReplicator*, CBLError* _cbl_nullable outError) CBLAPI;
 
@@ -394,6 +405,7 @@ FLDict _cbl_nullable CBLReplicator_PendingDocumentIDs(CBLReplicator*, CBLError* 
     @note  A `false` result means the document is not pending, _or_ there was an error.
            To tell the difference, compare the error code to zero.
     @warning  If the default collection is not part of the replication, a NULL with an error will be returned. */
+_cbl_deprecated("Use CBLReplicator_IsDocumentPending2 instead.")
 bool CBLReplicator_IsDocumentPending(CBLReplicator *repl,
                                      FLString docID,
                                      CBLError* _cbl_nullable outError) CBLAPI;

--- a/include/cbl/CBL_Compat.h
+++ b/include/cbl/CBL_Compat.h
@@ -35,11 +35,11 @@
     #define CBLINLINE               __forceinline
     #define _cbl_nonnull            _In_
     #define _cbl_warn_unused        _Check_return_
-    #define _cbl_deprecated
+    #define _cbl_deprecated(MSG)    __declspec(deprecated(MSG))
 #else
     #define CBLINLINE               inline
     #define _cbl_warn_unused        __attribute__((warn_unused_result))
-    #define _cbl_deprecated         __attribute__((deprecated()))
+    #define _cbl_deprecated(MSG)    __attribute((deprecated(MSG)))
 #endif
 
 // Macros for defining typed enumerations and option flags.

--- a/src/CBLCompat.h
+++ b/src/CBLCompat.h
@@ -1,0 +1,35 @@
+//
+// CBLCompat.h
+//
+// Copyright (c) 2022 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if defined(__clang__)
+    #define CBL_START_WARNINGS_SUPPRESSION _Pragma( "clang diagnostic push" )
+    #define CBL_STOP_WARNINGS_SUPPRESSION _Pragma( "clang diagnostic pop" )
+    #define CBL_IGNORE_DEPRECATED_API _Pragma( "clang diagnostic ignored \"-Wdeprecated-declarations\"" )
+#elif defined(__GNUC__)
+    #define CBL_START_WARNINGS_SUPPRESSION _Pragma( "GCC diagnostic push" )
+    #define CBL_STOP_WARNINGS_SUPPRESSION _Pragma( "GCC diagnostic pop" )
+    #define CBL_IGNORE_DEPRECATED_API _Pragma( "GCC diagnostic ignored \"-Wdeprecated-declarations\"" )
+#elif defined(_MSC_VER)
+    #define CBL_START_WARNINGS_SUPPRESSION __pragma( warning(push) )
+    #define CBL_STOP_WARNINGS_SUPPRESSION __pragma( warning(pop) )
+    #define CBL_IGNORE_DEPRECATED_API
+#else
+    #define CBL_START_WARNINGS_SUPPRESSION
+    #define CBL_STOP_WARNINGS_SUPPRESSION
+    #define CBL_IGNORE_DEPRECATED_API
+#endif

--- a/src/CBLDatabase_CAPI.cc
+++ b/src/CBLDatabase_CAPI.cc
@@ -19,9 +19,9 @@
 #include "CBLDatabase_Internal.hh"
 #include "CBLBlob_Internal.hh"
 #include "CBLCollection_Internal.hh"
+#include "CBLCompat.h"
 #include "CBLDatabase.h"
 #include "CBLDocument_Internal.hh"
-
 
 using namespace std;
 using namespace fleece;
@@ -337,6 +337,8 @@ FLArray CBLDatabase_GetIndexNames(CBLDatabase *db) noexcept {
 
 #pragma mark - CHANGE LISTENERS
 
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
 
 namespace cbl_internal {
     struct DatabaseChangeContext {
@@ -352,6 +354,7 @@ namespace cbl_internal {
     };
 }
 
+CBL_STOP_WARNINGS_SUPPRESSION
 
 CBLListenerToken* CBLDatabase_AddChangeListener(const CBLDatabase* db,
                                                 CBLDatabaseChangeListener listener,

--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -17,6 +17,7 @@
 //
 
 #pragma once
+#include "CBLCompat.h"
 #include "CBLDatabase.h"
 #include "CBLDocument_Internal.hh"
 #include "CBLLog_Internal.hh"
@@ -223,7 +224,12 @@ protected:
     friend struct CBLURLEndpointListener;
     friend class cbl_internal::AllConflictsResolver;
     friend struct cbl_internal::CBLLocalEndpoint;
+    
+    CBL_START_WARNINGS_SUPPRESSION
+    CBL_IGNORE_DEPRECATED_API
     friend struct cbl_internal::ListenerToken<CBLDocumentChangeListener>;
+    CBL_STOP_WARNINGS_SUPPRESSION
+    
     friend struct cbl_internal::ListenerToken<CBLQueryChangeListener>;
     friend struct cbl_internal::ListenerToken<CBLCollectionDocumentChangeListener>;
     

--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -18,7 +18,12 @@
 
 #pragma once
 
+#include "CBLCompat.h"
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
 #include "CBLReplicator.h"
+CBL_STOP_WARNINGS_SUPPRESSION
+
 #include "CBLDatabase_Internal.hh"
 #include "Internal.hh"
 #include "c4ReplicatorTypes.h"
@@ -162,6 +167,8 @@ namespace cbl_internal {
 
 #pragma mark - CONFIGURATION:
 
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
 
 namespace cbl_internal {
     // Managed config object that retains/releases its properties.
@@ -296,5 +303,7 @@ namespace cbl_internal {
         alloc_slice      _networkInterface;
     };
 }
+
+CBL_STOP_WARNINGS_SUPPRESSION
 
 CBL_ASSUME_NONNULL_END

--- a/src/CBLReplicator_CAPI.cc
+++ b/src/CBLReplicator_CAPI.cc
@@ -16,7 +16,6 @@
 // limitations under the License.
 //
 
-#include "CBLReplicator.h"
 #include "CBLReplicator_Internal.hh"
 
 

--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -16,7 +16,12 @@
 // limitations under the License.
 //
 
+#include "CBLCompat.h"
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
 #include "CBLReplicator.h"
+CBL_STOP_WARNINGS_SUPPRESSION
+
 #include "CBLReplicatorConfig.hh"
 #include "CBLDocument_Internal.hh"
 #include "CBLCollection_Internal.hh"
@@ -61,6 +66,8 @@ static CBLReplicatorStatus external(const C4ReplicatorStatus &c4status) {
     };
 }
 
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
 
 struct CBLReplicator final : public CBLRefCounted, public CBLStoppable {
 public:
@@ -410,5 +417,7 @@ private:
     Listeners<CBLDocumentReplicationListener>   _docListeners;
     C4ReplicatorProgressLevel                   _progressLevel {kC4ReplProgressOverall};
 };
+
+CBL_STOP_WARNINGS_SUPPRESSION
 
 CBL_ASSUME_NONNULL_END

--- a/test/BlobTest.cc
+++ b/test/BlobTest.cc
@@ -18,11 +18,14 @@
 
 #include "CBLTest.hh"
 #include "CBLPrivate.h"
+#include "CBLCompat.h"
 #include <string>
 
 using namespace fleece;
 using namespace std;
 
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
 
 class BlobTest : public CBLTest { };
 
@@ -163,3 +166,5 @@ TEST_CASE_METHOD(BlobTest, "Create JSON from Blob", "[Blob]") {
     CHECK(alloc_slice(CBLBlob_CreateJSON(gotBlob)) == "{\"content_type\":\"text/plain\",\"digest\":\"sha1-dXNgUcxC3n7lxfrYkbLUG4gOKRw=\",\"length\":34,\"@type\":\"blob\"}"_sl);
     CBLDocument_Release(doc);
 }
+
+CBL_STOP_WARNINGS_SUPPRESSION

--- a/test/BlobTest_Cpp.cc
+++ b/test/BlobTest_Cpp.cc
@@ -21,8 +21,6 @@
 #include "fleece/Mutable.hh"
 #include <string>
 
-#include "cbl++/CouchbaseLite.hh"
-
 using namespace std;
 using namespace fleece;
 using namespace cbl;

--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -184,7 +184,11 @@ unsigned ImportJSONLines(string&& path, CBLDatabase* database) {
         sprintf(docID, "%07u", numDocs+1);
         auto doc = CBLDocument_CreateWithID(slice(docID));
         REQUIRE(CBLDocument_SetJSON(doc, line, &error));
-        CHECK(CBLDatabase_SaveDocumentWithConcurrencyControl(database, doc, kCBLConcurrencyControlFailOnConflict, &error));
+        auto collection = CBLDatabase_DefaultCollection(database, &error);
+        REQUIRE(collection);
+        CHECK(CBLCollection_SaveDocumentWithConcurrencyControl(collection, doc,
+                                                               kCBLConcurrencyControlFailOnConflict,
+                                                               &error));
         CBLDocument_Release(doc);
         ++numDocs;
         return true;

--- a/test/CBLTest.hh
+++ b/test/CBLTest.hh
@@ -17,7 +17,14 @@
 //
 
 #pragma once
+
+#include "CBLCompat.h"
+
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
 #include "cbl/CouchbaseLite.h"
+CBL_STOP_WARNINGS_SUPPRESSION
+
 #include "CBLPrivate.h"
 #include "fleece/slice.hh"
 #include <functional>

--- a/test/CBLTest_Cpp.hh
+++ b/test/CBLTest_Cpp.hh
@@ -17,9 +17,13 @@
 //
 
 #pragma once
-#include "cbl++/CouchbaseLite.hh"
+
 #include "CBLTest.hh"
 
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
+#include "cbl++/CouchbaseLite.hh"
+CBL_STOP_WARNINGS_SUPPRESSION
 
 namespace cbl {
     // Make Catch write something better than "{?}" when it logs a CBL object:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ add_definitions(
 include_directories(
     ${TOP}test/
     ${TOP}include/
-    ${TOP}/src/        # Just for CBLPrivate.h
+    ${TOP}/src/        # For CBLPrivate.h and CBLCompat.h
     ${TOP}vendor/couchbase-lite-core/vendor/fleece/API/
     ${TOP}vendor/couchbase-lite-core/vendor/fleece/vendor/catch/
     ${TOP}vendor/couchbase-lite-core/vendor/fleece/vendor/libb64/

--- a/test/DatabaseTest.cc
+++ b/test/DatabaseTest.cc
@@ -29,6 +29,9 @@ using namespace fleece;
 
 static constexpr const slice kOtherDBName = "CBLTest_OtherDB";
 
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
+
 class DatabaseTest : public CBLTest {
 public:
     CBLDatabase* otherDB = nullptr;
@@ -1789,3 +1792,5 @@ TEST_CASE_METHOD(DatabaseTest, "Delete Database with Active Live Query") {
     // Sleeping to ensure async cleanup
     this_thread::sleep_for(200ms);
 }
+
+CBL_STOP_WARNINGS_SUPPRESSION

--- a/test/DatabaseTest_Cpp.cc
+++ b/test/DatabaseTest_Cpp.cc
@@ -98,10 +98,14 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Save Document With Property") {
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Delete Unsaved Doc") {
     MutableDocument doc("foo");
     ExpectingExceptions x;
-    CBLError error;
-    REQUIRE(!CBLDatabase_DeleteDocumentWithConcurrencyControl(db.ref(), doc.ref(), kCBLConcurrencyControlLastWriteWins, &error));
-    CHECK(error.domain == kCBLDomain);
-    CHECK(error.code == kCBLErrorNotFound);
+    bool threw = false;
+    try {
+        db.deleteDocument(doc);
+    } catch (CBLError& e) {
+        threw = true;
+        CHECK(e.code == kCBLErrorNotFound);
+    }
+    CHECK(true);
 }
 
 

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -28,6 +28,8 @@
 using namespace std;
 using namespace fleece;
 
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
 
 class QueryTest : public CBLTest {
 public:
@@ -399,6 +401,7 @@ TEST_CASE_METHOD(QueryTest, "Query Listener", "[Query][LiveQuery]") {
     
     cerr << "Deleting a doc...\n";
     state.reset();
+    
     const CBLDocument *doc = CBLDatabase_GetDocument(db, "0000012"_sl, &error);
     REQUIRE(doc);
     CHECK(CBLDatabase_DeleteDocument(db, doc, &error));
@@ -523,6 +526,7 @@ TEST_CASE_METHOD(QueryTest, "Multiple Query Listeners", "[Query][LiveQuery]") {
     cerr << "Deleting a doc...\n";
     state1.reset();
     state2.reset();
+    
     const CBLDocument *doc = CBLDatabase_GetDocument(db, "0000012"_sl, &error);
     REQUIRE(doc);
     CHECK(CBLDatabase_DeleteDocument(db, doc, &error));
@@ -756,3 +760,5 @@ TEST_CASE_METHOD(QueryTest_Cpp, "Query Listener C++ API", "[Query]") {
     cerr << "Sleeping to ensure async cleanup ..." << endl;
     this_thread::sleep_for(500ms);
 }
+
+CBL_STOP_WARNINGS_SUPPRESSION

--- a/test/ReplicatorTest.cc
+++ b/test/ReplicatorTest.cc
@@ -20,6 +20,8 @@
 
 using namespace fleece;
 
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
 
 #pragma mark - BASIC TESTS:
 
@@ -328,3 +330,5 @@ TEST_CASE_METHOD(ClientServerReplicatorTest, "Pull itunes from SG w/TLS", "[Repl
         CHECK(db.count() == 12189);
     }
 }
+
+CBL_STOP_WARNINGS_SUPPRESSION

--- a/test/ReplicatorTest.hh
+++ b/test/ReplicatorTest.hh
@@ -6,7 +6,6 @@
 
 #pragma once
 #include "CBLTest_Cpp.hh"
-#include "cbl++/CouchbaseLite.hh"
 #include <chrono>
 #include <iostream>
 #include <thread>
@@ -16,6 +15,9 @@
 using namespace std;
 using namespace fleece;
 using namespace cbl;
+
+CBL_START_WARNINGS_SUPPRESSION
+CBL_IGNORE_DEPRECATED_API
 
 class ReplicatorTest : public CBLTest_Cpp {
 public:
@@ -188,3 +190,5 @@ public:
     }
 
 };
+
+CBL_STOP_WARNINGS_SUPPRESSION


### PR DESCRIPTION
* Deprecate pre-collection APIs 
* Added `CBLCompat.h` for ignoring deprecated warning messages occurred in implementation and tests.
* No ignore warning on Windows as it doesn't fail to compile.
* Note: When deprecating the struct's members in `CBLReplicator.h`, ignoring the warning message when including the header is needed.
* Note: The branch name has a wrong ticket number.