### PR TITLE
CBL-3258 : Detach scope when removing the scope from cache

### DIFF
--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -221,11 +221,11 @@ bool CBLDatabase_PerformMaintenance(CBLDatabase* db,
 /** Returns the database's name. */
 FLString CBLDatabase_Name(const CBLDatabase*) CBLAPI;
 
-/** Returns the database's full filesystem path. */
+/** Returns the database's full filesystem path, or null slice if the database is closed or deleted. */
 _cbl_warn_unused
 FLStringResult CBLDatabase_Path(const CBLDatabase*) CBLAPI;
 
-/** Returns the number of documents in the database. */
+/** Returns the number of documents in the database, or zero if the database is closed or deleted. */
 uint64_t CBLDatabase_Count(const CBLDatabase*) CBLAPI;
 
 /** Returns the database's configuration, as given when it was opened.

--- a/src/CBLCollection_Internal.hh
+++ b/src/CBLCollection_Internal.hh
@@ -36,6 +36,11 @@ public:
     {
         _name = c4col->getName();
         _scope = database->getScope(c4col->getScope());
+        if (!_scope) {
+            // The collection & its scope might be deleted using a different database
+            // on a different thread. For this case, create a detached scope object.
+            _scope = new CBLScope(_name, database, true);
+        }
     }
     
 #pragma mark - ACCESSORS:
@@ -239,7 +244,7 @@ private:
         ,_db(database)
         {
             _sentry = [this](C4Collection* c4col) {
-                if (!_db || !c4col->isValid()) {
+                if (!_db) {
                     C4Error::raise(LiteCoreDomain, kC4ErrorNotOpen,
                                    "Invalid collection: either deleted, or db closed");
                 }

--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -78,6 +78,7 @@ CBLTest::CBLTest() {
 
 CBLTest::~CBLTest() {
     if (db) {
+        ExpectingExceptions x; // Database might have been closed by the test:
         CBLError error;
         if (!CBLDatabase_Close(db, &error))
             WARN("Failed to close database: " << error.domain << "/" << error.code);
@@ -86,6 +87,15 @@ CBLTest::~CBLTest() {
     if (CBL_InstanceCount() > 0)
         CBL_DumpInstances();
     CHECK(CBL_InstanceCount() == 0);
+}
+
+void CBLTest::checkError(CBLError& error, CBLErrorCode expectedCode, CBLErrorDomain expectedDomain) {
+    CHECK(error.domain == expectedDomain);
+    CHECK(error.code == expectedCode);
+}
+
+void CBLTest::checkNotOpenError(CBLError& error) {
+    checkError(error, kCBLErrorNotOpen);
 }
 
 

--- a/test/CBLTest.hh
+++ b/test/CBLTest.hh
@@ -71,6 +71,9 @@ public:
 
 
     CBLDatabase *db {nullptr};
+    
+    void checkError(CBLError& error, CBLErrorCode expectedCode, CBLErrorDomain expectedDomain = kCBLDomain);
+    void checkNotOpenError(CBLError& error);
 };
 
 

--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -53,15 +53,6 @@ public:
         return db;
     }
     
-    void checkError(CBLError& error, CBLErrorCode expectedCode, CBLErrorDomain expectedDomain = kCBLDomain) {
-        CHECK(error.domain == expectedDomain);
-        CHECK(error.code == expectedCode);
-    }
-    
-    void checkNotOpenError(CBLError& error) {
-        checkError(error, kCBLErrorNotOpen);
-    }
-    
     void testInvalidCollection(CBLCollection* col) {
         REQUIRE(col);
         


### PR DESCRIPTION
* Allow scope to be in detached mode when it is removed from cache. In this mode, it will retain the database object and will continue to work until the database is closed or released.

* Opposite to the scope, when removing collection from cache, close the collection.

* Also, removed isValid() check from C4CollectionAccessLock’s sentry as it’s not necessary.

* Ensured that the scope in the collection will not be null.

* Added tests to test using a deleted collection or deleted scope after closing the database.

* NOTE : This PR is the change on top of https://github.com/couchbase/couchbase-lite-C/pull/310 so there will be some rebase before merge.