### PR TITLE
CBL-3258 : Allow scope to be detached

### DIFF
--- a/src/CBLCollection_Internal.hh
+++ b/src/CBLCollection_Internal.hh
@@ -36,6 +36,11 @@ public:
     {
         _name = c4col->getName();
         _scope = database->getScope(c4col->getScope());
+        if (!_scope) {
+            // The collection & its scope might be deleted using a different database
+            // on a different thread. For this case, create a detached scope object.
+            _scope = new CBLScope(_name, database, true);
+        }
     }
     
 #pragma mark - ACCESSORS:
@@ -239,7 +244,7 @@ private:
         ,_db(database)
         {
             _sentry = [this](C4Collection* c4col) {
-                if (!_db || !c4col->isValid()) {
+                if (!_db) {
                     C4Error::raise(LiteCoreDomain, kC4ErrorNotOpen,
                                    "Invalid collection: either deleted, or db closed");
                 }


### PR DESCRIPTION
* Allow scope to be in detached mode when it is removed from cache. In this mode, it will retain the database object and will continue to work until the database is closed or released.

* Opposite to the scope, when removing collection from cache, close the collection.

* Also, removed isValid() check from C4CollectionAccessLock’s sentry as it’s not necessary.

* Ensured that the scope in the collection will not be null.

* Added tests to test using a deleted collection or deleted scope after closing the database.

* Note : This PR is on top of the change in https://github.com/couchbase/couchbase-lite-C/pull/310 so the base branch is feature/CBL-3231-3232.