### PR TITLE
CBL-3187 : Deprecate pre-collection APIs

### DIFF
--- a/include/cbl/CBLCollection.h
+++ b/include/cbl/CBLCollection.h
@@ -161,6 +161,7 @@ bool CBLDatabase_DeleteCollection(CBLDatabase* db,
 /** Returns the default scope.
     @note  The default scope always exist even there are no collections under it.
     @param db  The database.
+    @param outError  On failure, the error will be written here.
     @return  A \ref CBLScope instance, or NULL if an error occurred. */
 CBLScope* CBLDatabase_DefaultScope(const CBLDatabase* db,
                                    CBLError* _cbl_nullable outError) CBLAPI;

--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -226,7 +226,7 @@ _cbl_warn_unused
 FLStringResult CBLDatabase_Path(const CBLDatabase*) CBLAPI;
 
 /** Returns the number of documents in the database, or zero if the database is closed or deleted.
-    @warning  Deprecated : Use CBLCollection_Count on the default collection instead. */
+    @warning  <b>Deprecated :</b> Use CBLCollection_Count on the default collection instead. */
 uint64_t CBLDatabase_Count(const CBLDatabase*) CBLAPI;
 
 /** Returns the database's configuration, as given when it was opened.
@@ -251,7 +251,7 @@ const CBLDatabaseConfiguration CBLDatabase_Config(const CBLDatabase*) CBLAPI;
     @warning  By default, this listener may be called on arbitrary threads. If your code isn't
                     prepared for that, you may want to use \ref CBLDatabase_BufferNotifications
                     so that listeners will be called in a safe context.
-    @warning  Deprecated : CBLCollectionChangeListener instead.
+    @warning  <b>Deprecated :</b> CBLCollectionChangeListener instead.
     @param context  An arbitrary value given when the callback was registered.
     @param db  The database that changed.
     @param numDocs  The number of documents that changed (size of the `docIDs` array)
@@ -263,7 +263,7 @@ typedef void (*CBLDatabaseChangeListener)(void* _cbl_nullable context,
 
 /** Registers a database change listener callback. It will be called after one or more
     documents are changed on disk.
-    @warning  Deprecated : Use CBLCollection_AddChangeListener on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_AddChangeListener on the default collection instead.
     @param db  The database to observe.
     @param listener  The callback to be invoked.
     @param context  An opaque value that will be passed to the callback.

--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -225,7 +225,8 @@ FLString CBLDatabase_Name(const CBLDatabase*) CBLAPI;
 _cbl_warn_unused
 FLStringResult CBLDatabase_Path(const CBLDatabase*) CBLAPI;
 
-/** Returns the number of documents in the database, or zero if the database is closed or deleted. */
+/** Returns the number of documents in the database, or zero if the database is closed or deleted.
+    @warning  Deprecated : Use CBLCollection_Count on the default collection instead. */
 uint64_t CBLDatabase_Count(const CBLDatabase*) CBLAPI;
 
 /** Returns the database's configuration, as given when it was opened.
@@ -250,6 +251,7 @@ const CBLDatabaseConfiguration CBLDatabase_Config(const CBLDatabase*) CBLAPI;
     @warning  By default, this listener may be called on arbitrary threads. If your code isn't
                     prepared for that, you may want to use \ref CBLDatabase_BufferNotifications
                     so that listeners will be called in a safe context.
+    @warning  Deprecated : CBLCollectionChangeListener instead.
     @param context  An arbitrary value given when the callback was registered.
     @param db  The database that changed.
     @param numDocs  The number of documents that changed (size of the `docIDs` array)
@@ -261,11 +263,11 @@ typedef void (*CBLDatabaseChangeListener)(void* _cbl_nullable context,
 
 /** Registers a database change listener callback. It will be called after one or more
     documents are changed on disk.
+    @warning  Deprecated : Use CBLCollection_AddChangeListener on the default collection instead.
     @param db  The database to observe.
     @param listener  The callback to be invoked.
     @param context  An opaque value that will be passed to the callback.
-    @return  A token to be passed to \ref CBLListener_Remove when it's time to remove the
-            listener.*/
+    @return  A token to be passed to \ref CBLListener_Remove when it's time to remove the listener.*/
 _cbl_warn_unused
 CBLListenerToken* CBLDatabase_AddChangeListener(const CBLDatabase* db,
                                                 CBLDatabaseChangeListener listener,

--- a/include/cbl/CBLDocument.h
+++ b/include/cbl/CBLDocument.h
@@ -63,6 +63,7 @@ typedef bool (*CBLConflictHandler)(void* _cbl_nullable context,
     Each call to this function creates a new object (which must later be released.)
     @note  If you are reading the document in order to make changes to it, call
             \ref CBLDatabase_GetMutableDocument instead.
+    @warning  Deprecated : Use CBLCollection_GetDocument on the default collection instead.
     @param database  The database.
     @param docID  The ID of the document.
     @param outError  On failure, the error will be written here. (A nonexistent document is not
@@ -76,10 +77,11 @@ const CBLDocument* _cbl_nullable CBLDatabase_GetDocument(const CBLDatabase* data
 CBL_REFCOUNTED(CBLDocument*, Document);
 
 /** Saves a (mutable) document to the database.
-    \warning If a newer revision has been saved since \p doc was loaded, it will be overwritten by
+    @warning If a newer revision has been saved since \p doc was loaded, it will be overwritten by
             this one. This can lead to data loss! To avoid this, call
             \ref CBLDatabase_SaveDocumentWithConcurrencyControl or
             \ref CBLDatabase_SaveDocumentWithConflictHandler instead.
+    @warning  Deprecated : Use CBLCollection_SaveDocument on the default collection instead.
     @param db  The database to save to.
     @param doc  The mutable document to save.
     @param outError  On failure, the error will be written here.
@@ -93,6 +95,7 @@ bool CBLDatabase_SaveDocument(CBLDatabase* db,
     parameter specifies whether the save should fail, or the conflicting revision should
     be overwritten with the revision being saved.
     If you need finer-grained control, call \ref CBLDatabase_SaveDocumentWithConflictHandler instead.
+    @warning  Deprecated : Use CBLCollection_SaveDocumentWithConcurrencyControl on the default collection instead.
     @param db  The database to save to.
     @param doc  The mutable document to save.
     @param concurrency  Conflict-handling strategy (fail or overwrite).
@@ -110,6 +113,7 @@ bool CBLDatabase_SaveDocumentWithConcurrencyControl(CBLDatabase* db,
     @param conflictHandler  The callback to be invoked if there is a conflict.
     @param context  An arbitrary value to be passed to the \p conflictHandler.
     @param outError  On failure, the error will be written here.
+    @warning  Deprecated : Use CBLCollection_SaveDocumentWithConflictHandler on the default collection instead.
     @return  True on success, false on failure. */
 bool CBLDatabase_SaveDocumentWithConflictHandler(CBLDatabase* db,
                                                  CBLDocument* doc,
@@ -119,6 +123,7 @@ bool CBLDatabase_SaveDocumentWithConflictHandler(CBLDatabase* db,
 
 /** Deletes a document from the database. Deletions are replicated.
     @warning  You are still responsible for releasing the CBLDocument.
+    @warning  Deprecated : Use CBLCollection_DeleteDocument on the default collection instead.
     @param db  The database containing the document.
     @param document  The document to delete.
     @param outError  On failure, the error will be written here.
@@ -129,6 +134,7 @@ bool CBLDatabase_DeleteDocument(CBLDatabase *db,
 
 /** Deletes a document from the database. Deletions are replicated.
     @warning  You are still responsible for releasing the CBLDocument.
+    @warning  Deprecated : Use CBLCollection_DeleteDocumentWithConcurrencyControl on the default collection instead.
     @param db  The database containing the document.
     @param document  The document to delete.
     @param concurrency  Conflict-handling strategy.
@@ -143,6 +149,7 @@ bool CBLDatabase_DeleteDocumentWithConcurrencyControl(CBLDatabase *db,
     Purges are _not_ replicated. If the document is changed on a server, it will be re-created
     when pulled.
     @warning  You are still responsible for releasing the \ref CBLDocument reference.
+    @warning  Deprecated : Use CBLCollection_PurgeDocument on the default collection instead.
     @note If you don't have the document in memory already, \ref CBLDatabase_PurgeDocumentByID is a
           simpler shortcut.
     @param db  The database containing the document.
@@ -156,11 +163,11 @@ bool CBLDatabase_PurgeDocument(CBLDatabase* db,
 /** Purges a document, given only its ID.
     @note  If no document with that ID exists, this function will return false but the error
             code will be zero.
+    @warning  Deprecated : Use CBLCollection_PurgeDocumentByID on the default collection instead.
     @param database  The database.
     @param docID  The document ID to purge.
     @param outError  On failure, the error will be written here.
-    @return  True if the document was purged, false if it doesn't exist or the purge failed.
- */
+    @return  True if the document was purged, false if it doesn't exist or the purge failed. */
 bool CBLDatabase_PurgeDocumentByID(CBLDatabase* database,
                                    FLString docID,
                                    CBLError* _cbl_nullable outError) CBLAPI;
@@ -179,6 +186,7 @@ bool CBLDatabase_PurgeDocumentByID(CBLDatabase* database,
 /** Reads a document from the database, in mutable form that can be updated and saved.
     (This function is otherwise identical to \ref CBLDatabase_GetDocument.)
     @note  You must release the document when you're done with it.
+    @warning  Deprecated : Use CBLCollection_GetMutableDocument on the default collection instead.
     @param database  The database.
     @param docID  The ID of the document.
     @param outError  On failure, the error will be written here. (A nonexistent document is not
@@ -283,6 +291,7 @@ bool CBLDocument_SetJSON(CBLDocument*,
 /** Returns the time, if any, at which a given document will expire and be purged.
     Documents don't normally expire; you have to call \ref CBLDatabase_SetDocumentExpiration
     to set a document's expiration time.
+    @warning  Deprecated : Use CBLCollection_GetDocumentExpiration instead.
     @param db  The database.
     @param docID  The ID of the document.
     @param outError  On failure, an error is written here.
@@ -294,6 +303,7 @@ CBLTimestamp CBLDatabase_GetDocumentExpiration(CBLDatabase* db,
                                                CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Sets or clears the expiration time of a document.
+    @warning  Deprecated : Use CBLCollection_SetDocumentExpiration instead.
     @param db  The database.
     @param docID  The ID of the document.
     @param expiration  The expiration time as a CBLTimestamp (milliseconds since Unix epoch),
@@ -321,6 +331,7 @@ bool CBLDatabase_SetDocumentExpiration(CBLDatabase* db,
     @warning  By default, this listener may be called on arbitrary threads. If your code isn't
                     prepared for that, you may want to use \ref CBLDatabase_BufferNotifications
                     so that listeners will be called in a safe context.
+    @warning  Deprecated : Use CBLCollectionChangeListener instead.
     @param context  An arbitrary value given when the callback was registered.
     @param db  The database containing the document.
     @param docID  The document's ID. */
@@ -330,12 +341,12 @@ typedef void (*CBLDocumentChangeListener)(void *context,
 
 /** Registers a document change listener callback. It will be called after a specific document
     is changed on disk.
+    @warning  Deprecated : Use CBLCollection_AddDocumentChangeListener on the default collection instead.
     @param db  The database to observe.
     @param docID  The ID of the document to observe.
     @param listener  The callback to be invoked.
     @param context  An opaque value that will be passed to the callback.
-    @return  A token to be passed to \ref CBLListener_Remove when it's time to remove the
-            listener.*/
+    @return  A token to be passed to \ref CBLListener_Remove when it's time to remove the listener.*/
 _cbl_warn_unused
 CBLListenerToken* CBLDatabase_AddDocumentChangeListener(const CBLDatabase* db,
                                                         FLString docID,

--- a/include/cbl/CBLDocument.h
+++ b/include/cbl/CBLDocument.h
@@ -63,7 +63,7 @@ typedef bool (*CBLConflictHandler)(void* _cbl_nullable context,
     Each call to this function creates a new object (which must later be released.)
     @note  If you are reading the document in order to make changes to it, call
             \ref CBLDatabase_GetMutableDocument instead.
-    @warning  Deprecated : Use CBLCollection_GetDocument on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_GetDocument on the default collection instead.
     @param database  The database.
     @param docID  The ID of the document.
     @param outError  On failure, the error will be written here. (A nonexistent document is not
@@ -81,7 +81,7 @@ CBL_REFCOUNTED(CBLDocument*, Document);
             this one. This can lead to data loss! To avoid this, call
             \ref CBLDatabase_SaveDocumentWithConcurrencyControl or
             \ref CBLDatabase_SaveDocumentWithConflictHandler instead.
-    @warning  Deprecated : Use CBLCollection_SaveDocument on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_SaveDocument on the default collection instead.
     @param db  The database to save to.
     @param doc  The mutable document to save.
     @param outError  On failure, the error will be written here.
@@ -95,7 +95,7 @@ bool CBLDatabase_SaveDocument(CBLDatabase* db,
     parameter specifies whether the save should fail, or the conflicting revision should
     be overwritten with the revision being saved.
     If you need finer-grained control, call \ref CBLDatabase_SaveDocumentWithConflictHandler instead.
-    @warning  Deprecated : Use CBLCollection_SaveDocumentWithConcurrencyControl on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_SaveDocumentWithConcurrencyControl on the default collection instead.
     @param db  The database to save to.
     @param doc  The mutable document to save.
     @param concurrency  Conflict-handling strategy (fail or overwrite).
@@ -113,7 +113,7 @@ bool CBLDatabase_SaveDocumentWithConcurrencyControl(CBLDatabase* db,
     @param conflictHandler  The callback to be invoked if there is a conflict.
     @param context  An arbitrary value to be passed to the \p conflictHandler.
     @param outError  On failure, the error will be written here.
-    @warning  Deprecated : Use CBLCollection_SaveDocumentWithConflictHandler on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_SaveDocumentWithConflictHandler on the default collection instead.
     @return  True on success, false on failure. */
 bool CBLDatabase_SaveDocumentWithConflictHandler(CBLDatabase* db,
                                                  CBLDocument* doc,
@@ -123,7 +123,7 @@ bool CBLDatabase_SaveDocumentWithConflictHandler(CBLDatabase* db,
 
 /** Deletes a document from the database. Deletions are replicated.
     @warning  You are still responsible for releasing the CBLDocument.
-    @warning  Deprecated : Use CBLCollection_DeleteDocument on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_DeleteDocument on the default collection instead.
     @param db  The database containing the document.
     @param document  The document to delete.
     @param outError  On failure, the error will be written here.
@@ -134,7 +134,7 @@ bool CBLDatabase_DeleteDocument(CBLDatabase *db,
 
 /** Deletes a document from the database. Deletions are replicated.
     @warning  You are still responsible for releasing the CBLDocument.
-    @warning  Deprecated : Use CBLCollection_DeleteDocumentWithConcurrencyControl on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_DeleteDocumentWithConcurrencyControl on the default collection instead.
     @param db  The database containing the document.
     @param document  The document to delete.
     @param concurrency  Conflict-handling strategy.
@@ -149,7 +149,7 @@ bool CBLDatabase_DeleteDocumentWithConcurrencyControl(CBLDatabase *db,
     Purges are _not_ replicated. If the document is changed on a server, it will be re-created
     when pulled.
     @warning  You are still responsible for releasing the \ref CBLDocument reference.
-    @warning  Deprecated : Use CBLCollection_PurgeDocument on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_PurgeDocument on the default collection instead.
     @note If you don't have the document in memory already, \ref CBLDatabase_PurgeDocumentByID is a
           simpler shortcut.
     @param db  The database containing the document.
@@ -163,7 +163,7 @@ bool CBLDatabase_PurgeDocument(CBLDatabase* db,
 /** Purges a document, given only its ID.
     @note  If no document with that ID exists, this function will return false but the error
             code will be zero.
-    @warning  Deprecated : Use CBLCollection_PurgeDocumentByID on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_PurgeDocumentByID on the default collection instead.
     @param database  The database.
     @param docID  The document ID to purge.
     @param outError  On failure, the error will be written here.
@@ -186,7 +186,7 @@ bool CBLDatabase_PurgeDocumentByID(CBLDatabase* database,
 /** Reads a document from the database, in mutable form that can be updated and saved.
     (This function is otherwise identical to \ref CBLDatabase_GetDocument.)
     @note  You must release the document when you're done with it.
-    @warning  Deprecated : Use CBLCollection_GetMutableDocument on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_GetMutableDocument on the default collection instead.
     @param database  The database.
     @param docID  The ID of the document.
     @param outError  On failure, the error will be written here. (A nonexistent document is not
@@ -291,7 +291,7 @@ bool CBLDocument_SetJSON(CBLDocument*,
 /** Returns the time, if any, at which a given document will expire and be purged.
     Documents don't normally expire; you have to call \ref CBLDatabase_SetDocumentExpiration
     to set a document's expiration time.
-    @warning  Deprecated : Use CBLCollection_GetDocumentExpiration instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_GetDocumentExpiration instead.
     @param db  The database.
     @param docID  The ID of the document.
     @param outError  On failure, an error is written here.
@@ -303,7 +303,7 @@ CBLTimestamp CBLDatabase_GetDocumentExpiration(CBLDatabase* db,
                                                CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Sets or clears the expiration time of a document.
-    @warning  Deprecated : Use CBLCollection_SetDocumentExpiration instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_SetDocumentExpiration instead.
     @param db  The database.
     @param docID  The ID of the document.
     @param expiration  The expiration time as a CBLTimestamp (milliseconds since Unix epoch),
@@ -331,7 +331,7 @@ bool CBLDatabase_SetDocumentExpiration(CBLDatabase* db,
     @warning  By default, this listener may be called on arbitrary threads. If your code isn't
                     prepared for that, you may want to use \ref CBLDatabase_BufferNotifications
                     so that listeners will be called in a safe context.
-    @warning  Deprecated : Use CBLCollectionChangeListener instead.
+    @warning  <b>Deprecated :</b> Use CBLCollectionChangeListener instead.
     @param context  An arbitrary value given when the callback was registered.
     @param db  The database containing the document.
     @param docID  The document's ID. */
@@ -341,7 +341,7 @@ typedef void (*CBLDocumentChangeListener)(void *context,
 
 /** Registers a document change listener callback. It will be called after a specific document
     is changed on disk.
-    @warning  Deprecated : Use CBLCollection_AddDocumentChangeListener on the default collection instead.
+    @warning  <b>Deprecated :</b> Use CBLCollection_AddDocumentChangeListener on the default collection instead.
     @param db  The database to observe.
     @param docID  The ID of the document to observe.
     @param listener  The callback to be invoked.

--- a/include/cbl/CBLQuery.h
+++ b/include/cbl/CBLQuery.h
@@ -277,7 +277,7 @@ typedef struct {
     Indexes are persistent.
     If an identical index with that name already exists, nothing happens (and no error is returned.)
     If a non-identical index with that name already exists, it is deleted and re-created.
-    @warning  Deprecated : Use CBLCollection_CreateValueIndex on the default collection instead. */
+    @warning  <b>Deprecated :</b> Use CBLCollection_CreateValueIndex on the default collection instead. */
 bool CBLDatabase_CreateValueIndex(CBLDatabase *db,
                                   FLString name,
                                   CBLValueIndexConfiguration config,
@@ -315,21 +315,21 @@ typedef struct {
     Indexes are persistent.
     If an identical index with that name already exists, nothing happens (and no error is returned.)
     If a non-identical index with that name already exists, it is deleted and re-created.
-    @warning  Deprecated : Use CBLCollection_CreateFullTextIndex on the default collection instead. */
+    @warning  <b>Deprecated :</b> Use CBLCollection_CreateFullTextIndex on the default collection instead. */
 bool CBLDatabase_CreateFullTextIndex(CBLDatabase *db,
                                      FLString name,
                                      CBLFullTextIndexConfiguration config,
                                      CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Deletes an index given its name.
-    @warning  Deprecated : Use CBLCollection_DeleteIndex on the default collection instead. */
+    @warning  <b>Deprecated :</b> Use CBLCollection_DeleteIndex on the default collection instead. */
 bool CBLDatabase_DeleteIndex(CBLDatabase *db,
                              FLString name,
                              CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns the names of the indexes on this database, as a Fleece array of strings.
     @note  You are responsible for releasing the returned Fleece array.
-    @warning  Deprecated : Use CBLCollection_GetIndexNames on the default collection instead. */
+    @warning  <b>Deprecated :</b> Use CBLCollection_GetIndexNames on the default collection instead. */
 _cbl_warn_unused
 FLArray CBLDatabase_GetIndexNames(CBLDatabase *db) CBLAPI;
 

--- a/include/cbl/CBLQuery.h
+++ b/include/cbl/CBLQuery.h
@@ -276,7 +276,8 @@ typedef struct {
 /** Creates a value index.
     Indexes are persistent.
     If an identical index with that name already exists, nothing happens (and no error is returned.)
-    If a non-identical index with that name already exists, it is deleted and re-created. */
+    If a non-identical index with that name already exists, it is deleted and re-created.
+    @warning  Deprecated : Use CBLCollection_CreateValueIndex on the default collection instead. */
 bool CBLDatabase_CreateValueIndex(CBLDatabase *db,
                                   FLString name,
                                   CBLValueIndexConfiguration config,
@@ -313,19 +314,22 @@ typedef struct {
 /** Creates a full-text index.
     Indexes are persistent.
     If an identical index with that name already exists, nothing happens (and no error is returned.)
-    If a non-identical index with that name already exists, it is deleted and re-created. */
+    If a non-identical index with that name already exists, it is deleted and re-created.
+    @warning  Deprecated : Use CBLCollection_CreateFullTextIndex on the default collection instead. */
 bool CBLDatabase_CreateFullTextIndex(CBLDatabase *db,
                                      FLString name,
                                      CBLFullTextIndexConfiguration config,
                                      CBLError* _cbl_nullable outError) CBLAPI;
 
-/** Deletes an index given its name. */
+/** Deletes an index given its name.
+    @warning  Deprecated : Use CBLCollection_DeleteIndex on the default collection instead. */
 bool CBLDatabase_DeleteIndex(CBLDatabase *db,
                              FLString name,
                              CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns the names of the indexes on this database, as a Fleece array of strings.
-    @note  You are responsible for releasing the returned Fleece array. */
+    @note  You are responsible for releasing the returned Fleece array.
+    @warning  Deprecated : Use CBLCollection_GetIndexNames on the default collection instead. */
 _cbl_warn_unused
 FLArray CBLDatabase_GetIndexNames(CBLDatabase *db) CBLAPI;
 

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -153,9 +153,10 @@ typedef struct {
 
 /** Callback that encrypts \ref CBLEncryptable properties in documents of the default collection,
     pushed by the replicator.
-    \note   If a null \ref FLSliceResult or an error is returned, the document will be failed to
+    @note   If a null \ref FLSliceResult or an error is returned, the document will be failed to
             replicate with the \ref kCBLErrorCrypto error when. For security reason, the encryption
-            cannot be skipped. */
+            cannot be skipped.
+    @warning  Deprecated : Use CBLDocumentPropertyEncryptor instead. */
 typedef FLSliceResult (*CBLPropertyEncryptor) (
     void* context,              ///< Replicator’s context
     FLString documentID,        ///< Document ID
@@ -169,9 +170,10 @@ typedef FLSliceResult (*CBLPropertyEncryptor) (
 
 /** Callback that decrypts encrypted \ref CBLEncryptable properties in documents of the default collection,
     pulled by the replicator.
-    \note   The decryption will be skipped (the encrypted data will be kept) when a null \ref FLSliceResult
-            without an error is returned. If an error is returned, the document will be failed to replicate
-            with the \ref kCBLErrorCrypto error. */
+    @note   The decryption will be skipped (the encrypted data will be kept) when a null
+            \ref FLSliceResult without an error is returned. If an error is returned,
+            the document will be failed to replicate with the \ref kCBLErrorCrypto error.
+    @warning  Deprecated : Use CBLDocumentPropertyDecryptor instead. */
 typedef FLSliceResult (*CBLPropertyDecryptor) (
     void* context,              ///< Replicator’s context
     FLString documentID,        ///< Document ID
@@ -234,21 +236,25 @@ typedef struct {
 
 /** The configuration of a replicator. */
 typedef struct {
-    CBLDatabase* database;                  ///< The database to replicate
+    /** The database to replicate
+        @warning  Deprecated : Use collections instead. */
+    CBLDatabase* database;
     CBLEndpoint* endpoint;                  ///< The address of the other database to replicate with
+    
+    //-- Types:
     CBLReplicatorType replicatorType;       ///< Push, pull or both
     bool continuous;                        ///< Continuous replication?
+    
     //-- Auto Purge:
-    /**
-    If auto purge is active, then the library will automatically purge any documents that the replicating
-    user loses access to via the Sync Function on Sync Gateway.  If disableAutoPurge is true, this behavior
-    is disabled and an access removed event will be sent to any document listeners that are active on the
-    replicator.
-
-    IMPORTANT: For performance reasons, the document listeners must be added *before* the replicator is started
-    or they will not receive the events.
-    */
-    bool disableAutoPurge;              
+    /** If auto purge is active, then the library will automatically purge any documents that
+        the replicating user loses access to via the Sync Function on Sync Gateway.
+        If disableAutoPurge is true, this behavior is disabled and an access removed
+        event will be sent to any document listeners that are active on the replicator.
+     
+        IMPORTANT: For performance reasons, the document listeners must be
+        added *before* the replicator is started or they will not receive the events. */
+    bool disableAutoPurge;
+    
     //-- Retry Logic:
     unsigned maxAttempts;               ///< Max retry attempts where the initial connect to replicate counts toward the given value.
                                         ///< Specify 0 to use the default value, 10 times for a non-continuous replicator and max-int time for a continuous replicator. Specify 1 means there will be no retry after the first attempt.
@@ -262,21 +268,48 @@ typedef struct {
     CBLAuthenticator* _cbl_nullable authenticator;    ///< Authentication credentials, if needed
     const CBLProxySettings* _cbl_nullable proxy;      ///< HTTP client proxy settings
     FLDict _cbl_nullable headers;                     ///< Extra HTTP headers to add to the WebSocket request
+    
     //-- TLS settings:
     FLSlice pinnedServerCertificate;    ///< An X.509 cert to "pin" TLS connections to (PEM or DER)
     FLSlice trustedRootCertificates;    ///< Set of anchor certs (PEM format)
+    
     //-- Filtering:
-    FLArray _cbl_nullable channels;                   ///< Optional set of channels to pull from
-    FLArray _cbl_nullable documentIDs;                ///< Optional set of document IDs to replicate
-    CBLReplicationFilter _cbl_nullable pushFilter;    ///< Optional callback to filter which docs are pushed
-    CBLReplicationFilter _cbl_nullable pullFilter;    ///< Optional callback to validate incoming docs
-    CBLConflictResolver _cbl_nullable conflictResolver;///< Optional conflict-resolver callback
+    /** Optional set of channels to pull from
+        @warning  Deprecated : Use CBLReplicationCollection.channels instead. */
+    FLArray _cbl_nullable channels;
+    
+    /** Optional set of document IDs to replicate
+        @warning  Deprecated : Use CBLReplicationCollection.documentIDs instead. */
+    FLArray _cbl_nullable documentIDs;
+    
+    /** Optional callback to filter which docs are pushed.
+        @warning  Deprecated : Use CBLReplicationCollection.pushFilter instead. */
+    CBLReplicationFilter _cbl_nullable pushFilter;
+    
+    /** Optional callback to validate incoming docs.
+        @warning  Deprecated : Use CBLReplicationCollection.pullFilter instead. */
+    CBLReplicationFilter _cbl_nullable pullFilter;
+    
+    /** Optional conflict-resolver callback.
+        @warning  Deprecated : Use CBLReplicationCollection.conflictResolver instead. */
+    CBLConflictResolver _cbl_nullable conflictResolver;
+    
+    //-- Context:
     void* _cbl_nullable context;                      ///< Arbitrary value that will be passed to callbacks
     
 #ifdef COUCHBASE_ENTERPRISE
     //-- Property Encryption
-    CBLPropertyEncryptor propertyEncryptor;           ///< Optional callback to encrypt \ref CBLEncryptable values of the documents in the default collection. If the default collection is not part of the replication, the replicator will fail to create with an error.
-    CBLPropertyDecryptor propertyDecryptor;           ///< Optional callback to decrypt encrypted \ref CBLEncryptable values of the documents in the default collection. If the default collection is not part of the replication, the replicator will fail to create with an error.
+    /** Optional callback to encrypt \ref CBLEncryptable values of the documents in
+        the default collection. If the default collection is not part of the replication,
+        the replicator will fail to create with an error.
+        @warning  Deprecated : Use documentPropertyEncryptor instead. */
+    CBLPropertyEncryptor propertyEncryptor;
+    
+    /** Optional callback to decrypt encrypted \ref CBLEncryptable values of the documents in
+        the default collection. If the default collection is not part of the replication,
+        the replicator will fail to create with an error.
+        @warning  Deprecated : Use documentPropertyDecryptor instead. */
+    CBLPropertyDecryptor propertyDecryptor;
     
     CBLDocumentPropertyEncryptor documentPropertyEncryptor;   ///< Optional callback to encrypt \ref CBLEncryptable values.
     CBLDocumentPropertyDecryptor documentPropertyDecryptor;   ///< Optional callback to decrypt encrypted \ref CBLEncryptable values.
@@ -381,7 +414,9 @@ CBLReplicatorStatus CBLReplicator_Status(CBLReplicator*) CBLAPI;
     @note  Documents that would never be pushed by this replicator, due to its configuration's
            `pushFilter` or `docIDs`, are ignored.
     @warning  You are responsible for releasing the returned array via \ref FLValue_Release.
-    @warning  If the default collection is not part of the replication, a NULL with an error will be returned. */
+    @warning  If the default collection is not part of the replication, a NULL with an error
+              will be returned.
+    @warning  Deprecated : Use CBLReplicator_PendingDocumentIDs2 instead. */
 _cbl_warn_unused
 FLDict _cbl_nullable CBLReplicator_PendingDocumentIDs(CBLReplicator*, CBLError* _cbl_nullable outError) CBLAPI;
 
@@ -393,7 +428,9 @@ FLDict _cbl_nullable CBLReplicator_PendingDocumentIDs(CBLReplicator*, CBLError* 
 
     @note  A `false` result means the document is not pending, _or_ there was an error.
            To tell the difference, compare the error code to zero.
-    @warning  If the default collection is not part of the replication, a NULL with an error will be returned. */
+    @warning  If the default collection is not part of the replication, a NULL with an error
+              will be returned.
+    @warning  Deprecated : Use CBLReplicator_IsDocumentPending2 instead. */
 bool CBLReplicator_IsDocumentPending(CBLReplicator *repl,
                                      FLString docID,
                                      CBLError* _cbl_nullable outError) CBLAPI;

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -156,7 +156,7 @@ typedef struct {
     @note   If a null \ref FLSliceResult or an error is returned, the document will be failed to
             replicate with the \ref kCBLErrorCrypto error when. For security reason, the encryption
             cannot be skipped.
-    @warning  Deprecated : Use CBLDocumentPropertyEncryptor instead. */
+    @warning  <b>Deprecated :</b> Use CBLDocumentPropertyEncryptor instead. */
 typedef FLSliceResult (*CBLPropertyEncryptor) (
     void* context,              ///< Replicator’s context
     FLString documentID,        ///< Document ID
@@ -173,7 +173,7 @@ typedef FLSliceResult (*CBLPropertyEncryptor) (
     @note   The decryption will be skipped (the encrypted data will be kept) when a null
             \ref FLSliceResult without an error is returned. If an error is returned,
             the document will be failed to replicate with the \ref kCBLErrorCrypto error.
-    @warning  Deprecated : Use CBLDocumentPropertyDecryptor instead. */
+    @warning  <b>Deprecated :</b> Use CBLDocumentPropertyDecryptor instead. */
 typedef FLSliceResult (*CBLPropertyDecryptor) (
     void* context,              ///< Replicator’s context
     FLString documentID,        ///< Document ID
@@ -237,7 +237,7 @@ typedef struct {
 /** The configuration of a replicator. */
 typedef struct {
     /** The database to replicate
-        @warning  Deprecated : Use collections instead. */
+        @warning  <b>Deprecated :</b> Use collections instead. */
     CBLDatabase* database;
     CBLEndpoint* endpoint;                  ///< The address of the other database to replicate with
     
@@ -275,23 +275,23 @@ typedef struct {
     
     //-- Filtering:
     /** Optional set of channels to pull from
-        @warning  Deprecated : Use CBLReplicationCollection.channels instead. */
+        @warning  <b>Deprecated :</b> Use CBLReplicationCollection.channels instead. */
     FLArray _cbl_nullable channels;
     
     /** Optional set of document IDs to replicate
-        @warning  Deprecated : Use CBLReplicationCollection.documentIDs instead. */
+        @warning  <b>Deprecated :</b> Use CBLReplicationCollection.documentIDs instead. */
     FLArray _cbl_nullable documentIDs;
     
     /** Optional callback to filter which docs are pushed.
-        @warning  Deprecated : Use CBLReplicationCollection.pushFilter instead. */
+        @warning  <b>Deprecated :</b> Use CBLReplicationCollection.pushFilter instead. */
     CBLReplicationFilter _cbl_nullable pushFilter;
     
     /** Optional callback to validate incoming docs.
-        @warning  Deprecated : Use CBLReplicationCollection.pullFilter instead. */
+        @warning  <b>Deprecated :</b> Use CBLReplicationCollection.pullFilter instead. */
     CBLReplicationFilter _cbl_nullable pullFilter;
     
     /** Optional conflict-resolver callback.
-        @warning  Deprecated : Use CBLReplicationCollection.conflictResolver instead. */
+        @warning  <b>Deprecated :</b> Use CBLReplicationCollection.conflictResolver instead. */
     CBLConflictResolver _cbl_nullable conflictResolver;
     
     //-- Context:
@@ -302,13 +302,13 @@ typedef struct {
     /** Optional callback to encrypt \ref CBLEncryptable values of the documents in
         the default collection. If the default collection is not part of the replication,
         the replicator will fail to create with an error.
-        @warning  Deprecated : Use documentPropertyEncryptor instead. */
+        @warning  <b>Deprecated :</b> Use documentPropertyEncryptor instead. */
     CBLPropertyEncryptor propertyEncryptor;
     
     /** Optional callback to decrypt encrypted \ref CBLEncryptable values of the documents in
         the default collection. If the default collection is not part of the replication,
         the replicator will fail to create with an error.
-        @warning  Deprecated : Use documentPropertyDecryptor instead. */
+        @warning  <b>Deprecated :</b> Use documentPropertyDecryptor instead. */
     CBLPropertyDecryptor propertyDecryptor;
     
     CBLDocumentPropertyEncryptor documentPropertyEncryptor;   ///< Optional callback to encrypt \ref CBLEncryptable values.
@@ -416,7 +416,7 @@ CBLReplicatorStatus CBLReplicator_Status(CBLReplicator*) CBLAPI;
     @warning  You are responsible for releasing the returned array via \ref FLValue_Release.
     @warning  If the default collection is not part of the replication, a NULL with an error
               will be returned.
-    @warning  Deprecated : Use CBLReplicator_PendingDocumentIDs2 instead. */
+    @warning  <b>Deprecated :</b> Use CBLReplicator_PendingDocumentIDs2 instead. */
 _cbl_warn_unused
 FLDict _cbl_nullable CBLReplicator_PendingDocumentIDs(CBLReplicator*, CBLError* _cbl_nullable outError) CBLAPI;
 
@@ -430,7 +430,7 @@ FLDict _cbl_nullable CBLReplicator_PendingDocumentIDs(CBLReplicator*, CBLError* 
            To tell the difference, compare the error code to zero.
     @warning  If the default collection is not part of the replication, a NULL with an error
               will be returned.
-    @warning  Deprecated : Use CBLReplicator_IsDocumentPending2 instead. */
+    @warning  <b>Deprecated :</b> Use CBLReplicator_IsDocumentPending2 instead. */
 bool CBLReplicator_IsDocumentPending(CBLReplicator *repl,
                                      FLString docID,
                                      CBLError* _cbl_nullable outError) CBLAPI;

--- a/include/cbl/CBL_Compat.h
+++ b/include/cbl/CBL_Compat.h
@@ -35,11 +35,9 @@
     #define CBLINLINE               __forceinline
     #define _cbl_nonnull            _In_
     #define _cbl_warn_unused        _Check_return_
-    #define _cbl_deprecated
 #else
     #define CBLINLINE               inline
     #define _cbl_warn_unused        __attribute__((warn_unused_result))
-    #define _cbl_deprecated         __attribute__((deprecated()))
 #endif
 
 // Macros for defining typed enumerations and option flags.


### PR DESCRIPTION
* Deprecated pre-collection APIs that use default collection.

* Use @warning in the API comment for the deprecation instead of deprecation attribute.

* The decision to use @warning for deprecation to avoid the deprecation warning error when #include CBLReplicator.h which contain deprecation on structs’ members in the source code. This problem was found at least when using clang on XCode.