### PR TITLE
CBL-3250 : Make returned Scope and Collection RefCount + 1

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		FC5FBBA62821B3450066157F /* CBLCollection_Internal.hh in Headers */ = {isa = PBXBuildFile; fileRef = FC5FBBA42821B3450066157F /* CBLCollection_Internal.hh */; };
 		FC5FBBB52821CC2E0066157F /* CBLCollection_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = FC5FBBB42821CC2E0066157F /* CBLCollection_CAPI.cc */; };
 		FC5FBBB72821E4970066157F /* CBLDatabase_Internal.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C9B5E021F655110040BC45 /* CBLDatabase_Internal.hh */; };
+		FCC063C928588DA6000C5BD7 /* CBLScope.cc in Sources */ = {isa = PBXBuildFile; fileRef = FCC063C828588DA6000C5BD7 /* CBLScope.cc */; };
 		FCD8298C283591D4004AA814 /* CollectionTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = FCD8298B283591D4004AA814 /* CollectionTest.cc */; };
 		FCD8298D283591D4004AA814 /* CollectionTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = FCD8298B283591D4004AA814 /* CollectionTest.cc */; };
 		FCD8299D2835AC3F004AA814 /* CBLScope_Internal.hh in Headers */ = {isa = PBXBuildFile; fileRef = FCD8299C2835AC20004AA814 /* CBLScope_Internal.hh */; };
@@ -395,6 +396,7 @@
 		FC5FBBA32821B3450066157F /* CBLCollection.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLCollection.cc; sourceTree = "<group>"; };
 		FC5FBBA42821B3450066157F /* CBLCollection_Internal.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CBLCollection_Internal.hh; sourceTree = "<group>"; };
 		FC5FBBB42821CC2E0066157F /* CBLCollection_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLCollection_CAPI.cc; sourceTree = "<group>"; };
+		FCC063C828588DA6000C5BD7 /* CBLScope.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLScope.cc; sourceTree = "<group>"; };
 		FCD8298B283591D4004AA814 /* CollectionTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CollectionTest.cc; sourceTree = "<group>"; };
 		FCD8299C2835AC20004AA814 /* CBLScope_Internal.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CBLScope_Internal.hh; sourceTree = "<group>"; };
 		FCD829B12835ECE0004AA814 /* CBLScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLScope.h; sourceTree = "<group>"; };
@@ -525,6 +527,7 @@
 				27DBCF2E246B4352002FD7A7 /* CBLQuery_Internal.hh */,
 				27D11BFF235140E300C58A70 /* CBLReplicator_Internal.hh */,
 				277FEE7621ED62AA00B60E3C /* CBLReplicatorConfig.hh */,
+				FCC063C828588DA6000C5BD7 /* CBLScope.cc */,
 				FCD8299C2835AC20004AA814 /* CBLScope_Internal.hh */,
 				27D11BEE2351043B00C58A70 /* ConflictResolver.cc */,
 				27D11BED2351043B00C58A70 /* ConflictResolver.hh */,
@@ -1213,6 +1216,7 @@
 				27D11BF02351043B00C58A70 /* ConflictResolver.cc in Sources */,
 				27886C8E21F64C1400069BEA /* Listener.cc in Sources */,
 				271C2A7621CC4BD60045856E /* Internal.cc in Sources */,
+				FCC063C928588DA6000C5BD7 /* CBLScope.cc in Sources */,
 				FC5FBBA52821B3450066157F /* CBLCollection.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set(
     src/CBLQuery.cc
     src/CBLQuery_CAPI.cc
     src/CBLReplicator_CAPI.cc
+    src/CBLScope.cc
     src/CBLScope_CAPI.cc
     src/ConflictResolver.cc
     src/Internal.cc

--- a/include/cbl/CBLCollection.h
+++ b/include/cbl/CBLCollection.h
@@ -45,14 +45,11 @@ CBL_CAPI_BEGIN
     - Both scope and collection names are case sensitive.
  
     ## `CBLCollection` Lifespan
-    `CBLCollection` is ref-counted and is owned by the database object that creates it. Hence,
-    most of the time there is no need to retain or release it. A `CBLCollection` object and its
-    reference remain valid until either the database is closed or the collection itself is deleted.
- 
-    If the collection reference needs to be kept longer, the collection object should be retained,
-    and the reference will remain valid until it's released. Most operations on the invalid \ref
-    CBLCollection object will fail with either the \ref kCBLErrorNotOpen error or null/zero/empty
-    result.
+    `CBLCollection` is ref-counted. Same as the CBLDocument, the CBLCollection objects
+    created or retrieved from the database must be released after you are done using them.
+    When the database is closed or released, the collection objects will become invalid,
+    most operations on the invalid \ref CBLCollection object will fail with either the
+    \ref kCBLErrorNotOpen error or null/zero/empty result.
  
     ##Legacy Database and API
     When using the legacy database, the existing documents and indexes in the database will be
@@ -97,11 +94,7 @@ FLMutableArray _cbl_nullable CBLDatabase_CollectionNames(const CBLDatabase* db,
 /** Returns an existing scope with the given name.
     The scope exists when there is at least one collection created under the scope.
     The default scope is exception in that it will always exists even there are no collections under it.
-    @note  CBLScope is ref-counted and is owned by the database object, and it will remain
-           valid until the database is closed, or it has been invalidated as all collections in it have
-           been deleted. Therefore, there is no need to retain or release. However, If the reference
-           needs to be kept longer, the object needs to be retained, and it will remain valid until
-           it is released.
+    @note  You are responsible for releasing the returned scope.
     @param db  The database.
     @param scopeName  The name of the scope.
     @param outError  On failure, the error will be written here.
@@ -111,10 +104,7 @@ CBLScope* _cbl_nullable CBLDatabase_Scope(const CBLDatabase* db,
                                           CBLError* _cbl_nullable outError) CBLAPI;
 
  /** Returns the existing collection with the given name and scope.
-    @note  CBLCollection is ref-counted and is owned by the database object, and it will remain
-           valid until the database is closed, or the collection itself is deleted. Therefore,
-           there is no need to retain or release. However, If the reference needs to be kept longer,
-           the object needs to be retained, and it will remain valid until it is released.
+    @note  You are responsible for releasing the returned collection.
     @param db  The database.
     @param collectionName  The name of the collection.
     @param scopeName  The name of the scope.
@@ -133,10 +123,7 @@ CBLCollection* _cbl_nullable CBLDatabase_Collection(const CBLDatabase* db,
         - Cannot start with _ or %.
         - Both scope and collection names are case sensitive.
     @note  If the collection already exists, the existing collection will be returned.
-    @note  CBLCollection is ref-counted and is owned by the database object, and it will remain
-           valid until the database is closed, or the collection itself is deleted. Therefore,
-           there is no need to retain or release. However, If the reference needs to be kept longer,
-           the object needs to be retained, and it will remain valid until it is released.
+    @note  You are responsible for releasing the returned collection.
     @param db  The database.
     @param collectionName  The name of the collection.
     @param scopeName  The name of the scope.
@@ -160,6 +147,7 @@ bool CBLDatabase_DeleteCollection(CBLDatabase* db,
 
 /** Returns the default scope.
     @note  The default scope always exist even there are no collections under it.
+    @note  You are responsible for releasing the returned scope.
     @param db  The database.
     @param outError  On failure, the error will be written here.
     @return  A \ref CBLScope instance, or NULL if an error occurred. */
@@ -168,6 +156,8 @@ CBLScope* CBLDatabase_DefaultScope(const CBLDatabase* db,
 
 /** Returns the default collection.
     @note  The default collection may not exist if it was deleted.
+           Also, the default collection cannot be recreated after being deleted.
+    @note  You are responsible for releasing the returned scope.
     @param db  The database.
     @param outError  On failure, the error will be written here.
     @return  A \ref CBLCollection instance, or NULL if the default collection doesn't exist or an error occurred. */
@@ -182,11 +172,11 @@ CBLCollection* _cbl_nullable CBLDatabase_DefaultCollection(const CBLDatabase* db
  */
 
 /** Returns the scope of the collection.
-    @note  CBLScope is ref-counted and is owned by the database object. Therefore,
-           most of the time there is no need to retain or release it. However if the reference
-           needs to be kept longer, the reference needs to be retained, and it will remain
-           valid until it is released. Most operations on the invalid \ref CBLScope object will
-           fail with null/zero/empty result.
+    @note  The returned scope object is a property of the collection object, and therefore
+           its lifetime will depend on the lifetime of the collection object.
+           If the returned scope object needs to keep longer, it needs to be explicitly retain
+           using \ref CBLScope_Retain function, and the object will remain valid until it is
+           explicitly released by using \ref CBLScope_Release function.
     @param collection  The collection.
     @return A \ref CBLScope instance. */
 CBLScope* CBLCollection_Scope(const CBLCollection* collection) CBLAPI;

--- a/include/cbl/CBLScope.h
+++ b/include/cbl/CBLScope.h
@@ -31,15 +31,11 @@ CBL_CAPI_BEGIN
     under it.
  
     ## `CBLScope` Lifespan
-    `CBLScope` is ref-counted and is owned by the database object that creates it. Hence,
-    most of the time there is no need to retain or release it. A `CBLScope` object and its
-    reference remain valid until either the database is closed or the scope itself is invalidated
-    as all collections in the scope have been deleted.
-
-    If the scope reference needs to be kept longer, the scope object should be retained,
-    and the reference will remain valid until it's released. Most operations on the invalid
-    CBLScope object will fail with null or empty result.
- */
+    `CBLScope` is ref-counted. Same as the CBLCollection, the CBLScope objects
+    retrieved from the database must be released after you are done using them.
+    When the database is closed or released, the scope objects will become invalid,
+    most operations on the invalid \ref CBLCollection object will fail with
+    \ref kCBLErrorNotOpen error result. */
 
 CBL_REFCOUNTED(CBLScope*, Scope);
 
@@ -79,10 +75,7 @@ FLMutableArray _cbl_nullable CBLScope_CollectionNames(const CBLScope* scope,
                                                       CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns an existing collection in the scope with the given name.
-    @note  CBLCollection is ref-counted and is owned by the database object, and it will remain
-           valid until the database is closed, or the collection itself is deleted. Therefore, there
-           is no need to retain or release it. However if the reference needs to be kept longer,
-           the object needs to be retained, and it will remain valid until it is released.
+    @note  You are responsible for releasing the returned collection.
     @param scope  The scope.
     @param collectionName  The name of the collection.
     @param outError  On failure, the error will be written here.

--- a/src/CBLCollection_CAPI.cc
+++ b/src/CBLCollection_CAPI.cc
@@ -45,7 +45,7 @@ FLMutableArray CBLDatabase_CollectionNames(const CBLDatabase* db,
 
 CBLScope* CBLDatabase_Scope(const CBLDatabase* db, FLString scopeName, CBLError* outError) noexcept {
     try {
-        return const_cast<CBLDatabase*>(db)->getScope(scopeName);
+        return const_cast<CBLDatabase*>(db)->getScope(scopeName).detach();
     } catchAndBridge(outError)
 }
 
@@ -55,7 +55,7 @@ CBLCollection* CBLDatabase_Collection(const CBLDatabase* db,
                                       CBLError* outError) noexcept
 {
     try {
-        return const_cast<CBLDatabase*>(db)->getCollection(collectionName, scopeName);
+        return const_cast<CBLDatabase*>(db)->getCollection(collectionName, scopeName).detach();
     } catchAndBridge(outError)
 }
 
@@ -65,7 +65,7 @@ CBLCollection* CBLDatabase_CreateCollection(CBLDatabase* db,
                                             CBLError* outError) noexcept
 {
     try {
-        return db->createCollection(collectionName, scopeName);
+        return db->createCollection(collectionName, scopeName).detach();
     } catchAndBridge(outError)
 }
 
@@ -81,13 +81,13 @@ bool CBLDatabase_DeleteCollection(CBLDatabase* db,
 
 CBLScope* CBLDatabase_DefaultScope(const CBLDatabase* db, CBLError* outError) noexcept {
     try {
-        return const_cast<CBLDatabase*>(db)->getDefaultScope();
+        return const_cast<CBLDatabase*>(db)->getDefaultScope().detach();
     } catchAndBridge(outError)
 }
 
 CBLCollection* CBLDatabase_DefaultCollection(const CBLDatabase* db, CBLError* outError) noexcept {
     try {
-        return const_cast<CBLDatabase*>(db)->getDefaultCollection(false);
+        return const_cast<CBLDatabase*>(db)->getDefaultCollection(false).detach();
     } catchAndBridge(outError)
 }
 

--- a/src/CBLDatabase.cc
+++ b/src/CBLDatabase.cc
@@ -141,7 +141,7 @@ void CBLDatabase::_closed() {
 #pragma mark - SCOPES:
 
 
-CBLScope* CBLDatabase::getScope(slice scopeName) {
+Retained<CBLScope> CBLDatabase::getScope(slice scopeName) {
     if (!scopeName)
         scopeName = kC4DefaultScopeID;
     
@@ -171,7 +171,7 @@ CBLScope* CBLDatabase::getScope(slice scopeName) {
 #pragma mark - COLLECTIONS:
 
 
-CBLCollection* CBLDatabase::getCollection(slice collectionName, slice scopeName) {
+Retained<CBLCollection> CBLDatabase::getCollection(slice collectionName, slice scopeName) {
     if (!scopeName)
         scopeName = kC4DefaultScopeID;
     
@@ -201,13 +201,13 @@ CBLCollection* CBLDatabase::getCollection(slice collectionName, slice scopeName)
 }
 
 
-CBLCollection* CBLDatabase::createCollection(slice collectionName, slice scopeName) {
+Retained<CBLCollection> CBLDatabase::createCollection(slice collectionName, slice scopeName) {
     if (!scopeName)
         scopeName = kC4DefaultScopeID;
     
     auto c4db = _c4db->useLocked();
     
-    CBLCollection* col = getCollection(collectionName, scopeName);
+    auto col = getCollection(collectionName, scopeName);
     if (col) {
         return col;
     }
@@ -231,7 +231,13 @@ bool CBLDatabase::deleteCollection(slice collectionName, slice scopeName) {
 }
 
 
-CBLCollection* CBLDatabase::getDefaultCollection(bool mustExist) {
+Retained<CBLScope> CBLDatabase::getDefaultScope() {
+    _c4db->useLocked();
+    return getScope(kC4DefaultScopeID);
+}
+
+
+Retained<CBLCollection> CBLDatabase::getDefaultCollection(bool mustExist) {
     auto db = _c4db->useLocked();
     
     if (_defaultCollection &&
@@ -248,7 +254,7 @@ CBLCollection* CBLDatabase::getDefaultCollection(bool mustExist) {
 }
 
 
-CBLCollection* CBLDatabase::createCBLCollection(C4Collection* c4col) {
+Retained<CBLCollection> CBLDatabase::createCBLCollection(C4Collection* c4col) {
     auto retainedCollection = make_retained<CBLCollection>(c4col, const_cast<CBLDatabase*>(this));
     auto collection = retainedCollection.get();
     _collections.insert({C4Database::CollectionSpec(c4col->getSpec()), move(retainedCollection)});

--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -145,26 +145,21 @@ public:
         return names;
     }
     
-    CBLScope* _cbl_nullable getScope(slice scopeName);
+    Retained<CBLScope> getScope(slice scopeName);
     
-    CBLCollection* _cbl_nullable getCollection(slice collectionName, slice scopeName);
+    Retained<CBLCollection> getCollection(slice collectionName, slice scopeName);
     
-    CBLCollection* createCollection(slice collectionName, slice scopeName);
+    Retained<CBLCollection> createCollection(slice collectionName, slice scopeName);
     
     bool deleteCollection(slice collectionName, slice scopeName);
     
-    CBLScope* getDefaultScope() {
-        _c4db->useLocked();
-        auto scope = getScope(kC4DefaultScopeID);
-        assert(scope);
-        return scope;
-    }
+    Retained<CBLScope> getDefaultScope();
     
     /**
      * Returned the default collection retained by the database. It will be used for any database's operations
      * that refer to the default collection. If the default collection doesn't exist when getting from the database,
      * the method will throw kC4ErrorNotOpen exception. */
-    CBLCollection* _cbl_nullable getDefaultCollection(bool mustExist);
+    Retained<CBLCollection> getDefaultCollection(bool mustExist);
     
 
 #pragma mark - Queries & Indexes:
@@ -325,7 +320,7 @@ private:
     /**
      Create a CBLCollection from the C4Collection.
      The created CBLCollection will be retained and cached in the _collections map. */
-    CBLCollection* createCBLCollection(C4Collection* c4col);
+    Retained<CBLCollection> createCBLCollection(C4Collection* c4col);
     
     /** Remove and release the CBLCollection from the _collections map */
     void removeCBLCollection(C4Database::CollectionSpec spec);

--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -359,8 +359,8 @@ private:
         // CBL-3191:
         // As now LiteCore doesn't send the correct colSpec and has no
         // collections supported, call to get the default collection:
-        CBLCollection *col = _conf.database->getDefaultCollection(false);
-        Retained<CBLDocument> doc = new CBLDocument(col, docID, revID, flags, body);
+        auto col = _conf.database->getDefaultCollection(false);
+        Retained<CBLDocument> doc = new CBLDocument(col.get(), docID, revID, flags, body);
         CBLReplicationFilter filter = pushing ? _conf.pushFilter : _conf.pullFilter;
         
         CBLDocumentFlags docFlags = 0;

--- a/src/CBLScope.cc
+++ b/src/CBLScope.cc
@@ -1,0 +1,28 @@
+//
+//  CBLScope.cc
+//
+// Copyright (c) 2019 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "CBLScope_Internal.hh"
+#include "CBLCollection_Internal.hh"
+
+using namespace fleece;
+
+Retained<CBLCollection> CBLScope::getCollection(slice collectionName) const {
+    LOCK(_mutex);
+    checkOpen();
+    return _database->getCollection(collectionName, _name);
+}

--- a/src/CBLScope_CAPI.cc
+++ b/src/CBLScope_CAPI.cc
@@ -17,6 +17,7 @@
 //
 
 #include "CBLScope_Internal.hh"
+#include "CBLCollection_Internal.hh"
 
 #pragma mark - CONSTANTS
 
@@ -43,6 +44,6 @@ CBLCollection* CBLScope_Collection(const CBLScope* scope,
                                    CBLError* outError) noexcept
 {
     try {
-        return scope->getCollection(collectionName);
+        return scope->getCollection(collectionName).detach();
     } catchAndBridge(outError)
 }

--- a/src/CBLScope_Internal.hh
+++ b/src/CBLScope_Internal.hh
@@ -46,11 +46,7 @@ public:
         return _database->collectionNames(_name);
     }
     
-    CBLCollection* _cbl_nullable getCollection(slice collectionName) const {
-        LOCK(_mutex);
-        checkOpen();
-        return _database->getCollection(collectionName, _name);
-    }
+    Retained<CBLCollection> getCollection(slice collectionName) const;
     
 protected:
     

--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -187,6 +187,7 @@ TEST_CASE_METHOD(CollectionTest, "Default Collection", "[Collection]") {
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == kCBLDefaultCollectionName);
     CHECK(CBLCollection_Count(col) == 0);
+    CBLCollection_Release(col);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Default Collection Exists By Default", "[Collection]") {
@@ -199,6 +200,7 @@ TEST_CASE_METHOD(CollectionTest, "Default Collection Exists By Default", "[Colle
     CBLScope* scope = CBLCollection_Scope(col);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLCollection_Release(col);
     
     col = CBLDatabase_Collection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName, &error);
     REQUIRE(col);
@@ -208,6 +210,7 @@ TEST_CASE_METHOD(CollectionTest, "Default Collection Exists By Default", "[Colle
     scope = CBLCollection_Scope(col);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLCollection_Release(col);
     
     FLMutableArray names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName, &error);
     CHECK(Array(names).toJSONString() == R"(["_default"])");
@@ -219,10 +222,12 @@ TEST_CASE_METHOD(CollectionTest, "Default Scope Exists By Default", "[Collection
     CBLScope* scope = CBLDatabase_DefaultScope(db, &error);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLScope_Release(scope);
     
     scope = CBLDatabase_Scope(db, kCBLDefaultScopeName, &error);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLScope_Release(scope);
     
     FLMutableArray names = CBLDatabase_ScopeNames(db, &error);
     CHECK(Array(names).toJSONString() == R"(["_default"])");
@@ -237,6 +242,7 @@ TEST_CASE_METHOD(CollectionTest, "Delete Default Collection", "[Collection]") {
     // Add some docs:
     createNumberedDocs(col, 100);
     CHECK(CBLCollection_Count(col) == 100);
+    CBLCollection_Release(col);
     
     // Delete the default collection:
     REQUIRE(CBLDatabase_DeleteCollection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName, &error));
@@ -254,7 +260,9 @@ TEST_CASE_METHOD(CollectionTest, "Delete Default Collection", "[Collection]") {
 
 TEST_CASE_METHOD(CollectionTest, "Get Default Scope After Delete Default Collection", "[Collection]") {
     CBLError error = {};
-    REQUIRE(CBLDatabase_DefaultCollection(db, &error));
+    CBLCollection* col = CBLDatabase_DefaultCollection(db, &error);
+    REQUIRE(col);
+    CBLCollection_Release(col);
     
     // Delete the default collection:
     REQUIRE(CBLDatabase_DeleteCollection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName, &error));
@@ -262,6 +270,7 @@ TEST_CASE_METHOD(CollectionTest, "Get Default Scope After Delete Default Collect
     CBLScope* scope = CBLDatabase_DefaultScope(db, &error);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLScope_Release(scope);
     
     FLMutableArray names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName, &error);
     CHECK(FLArray_Count(names) == 0);
@@ -277,10 +286,12 @@ TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Default Scope", "
     CBLScope* scope = CBLCollection_Scope(col);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLCollection_Release(col);
     
     col = CBLDatabase_Collection(db, "colA"_sl, kCBLDefaultScopeName, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
+    CBLCollection_Release(col);
     
     FLMutableArray names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName, &error);
     CHECK(Array(names).toJSONString() == R"(["_default","colA"])");
@@ -294,10 +305,12 @@ TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Default Scope", "
     scope = CBLCollection_Scope(col);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLCollection_Release(col);
     
     col = CBLDatabase_Collection(db, "colA"_sl, kCBLDefaultScopeName, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
+    CBLCollection_Release(col);
     
     names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName, &error);
     CHECK(Array(names).toJSONString() == R"(["_default","colA","colB"])");
@@ -313,10 +326,12 @@ TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Named Scope", "[C
     CBLScope* scope = CBLCollection_Scope(col);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == "scopeA"_sl);
+    CBLCollection_Release(col);
     
     col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
+    CBLCollection_Release(col);
     
     FLMutableArray names = CBLDatabase_CollectionNames(db, "scopeA"_sl, &error);
     CHECK(Array(names).toJSONString() == R"(["colA"])");
@@ -326,6 +341,7 @@ TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Named Scope", "[C
     scope = CBLDatabase_Scope(db, "scopeA"_sl, &error);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == "scopeA"_sl);
+    CBLScope_Release(scope);
     
     FLMutableArray scopeNames = CBLDatabase_ScopeNames(db, &error);
     CHECK(Array(scopeNames).toJSONString() == R"(["_default","scopeA"])");
@@ -343,6 +359,9 @@ TEST_CASE_METHOD(CollectionTest, "Create Existing Collection", "[Collection]") {
     CHECK(CBLCollection_Name(col2) == "colA"_sl);
     
     CHECK(col1 == col2);
+    
+    CBLCollection_Release(col1);
+    CBLCollection_Release(col2);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Get Non Existing Collection", "[Collection]") {
@@ -357,6 +376,7 @@ TEST_CASE_METHOD(CollectionTest, "Delete Collection", "[.CBL-3142]") {
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
+    CBLCollection_Release(col);
     
     col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
@@ -365,6 +385,7 @@ TEST_CASE_METHOD(CollectionTest, "Delete Collection", "[.CBL-3142]") {
     // Add some docs:
     createNumberedDocs(col, 100);
     CHECK(CBLCollection_Count(col) == 100);
+    CBLCollection_Release(col);
     
     // Delete:
     REQUIRE(CBLDatabase_DeleteCollection(db, "colA"_sl, "scopeA"_sl, &error));
@@ -378,11 +399,13 @@ TEST_CASE_METHOD(CollectionTest, "Delete Collection", "[.CBL-3142]") {
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
     CHECK(CBLCollection_Count(col) == 0);
-
+    CBLCollection_Release(col);
+    
     col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     CHECK(CBLCollection_Name(col) == "colA"_sl);
     CHECK(CBLCollection_Count(col) == 0);
+    CBLCollection_Release(col);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Get Collections from Scope", "[Collection]") {
@@ -397,14 +420,24 @@ TEST_CASE_METHOD(CollectionTest, "Get Collections from Scope", "[Collection]") {
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == "scopeA"_sl);
     
-    CHECK(CBLScope_Collection(scope, "colA"_sl, &error) == colA);
-    CHECK(CBLScope_Collection(scope, "colB"_sl, &error) == colB);
+    CBLCollection* colA2 = CBLScope_Collection(scope, "colA"_sl, &error);
+    CHECK(colA == colA2);
+    
+    CBLCollection* colB2 = CBLScope_Collection(scope, "colB"_sl, &error);
+    CHECK(colB == colB2);
+    
     CHECK(!CBLScope_Collection(scope, "colC"_sl, &error));
     CHECK(error.code == 0);
     
     FLMutableArray colNames = CBLScope_CollectionNames(scope, &error);
     CHECK(Array(colNames).toJSONString() == R"(["colA","colB"])");
     FLMutableArray_Release(colNames);
+    
+    CBLScope_Release(scope);
+    CBLCollection_Release(colA);
+    CBLCollection_Release(colB);
+    CBLCollection_Release(colA2);
+    CBLCollection_Release(colB2);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Delete All Collections in Scope", "[Collection]") {
@@ -432,8 +465,10 @@ TEST_CASE_METHOD(CollectionTest, "Delete All Collections in Scope", "[Collection
     // Get collections from the scope object:
     CHECK(!CBLScope_Collection(scope, "colA"_sl, &error));
     CHECK(error.code == 0);
+    
     CHECK(!CBLScope_Collection(scope, "colB"_sl, &error));
     CHECK(error.code == 0);
+    
     colNames = CBLScope_CollectionNames(scope, &error);
     CHECK(Array(colNames).toJSONString() == R"([])");
     FLMutableArray_Release(colNames);
@@ -444,6 +479,10 @@ TEST_CASE_METHOD(CollectionTest, "Delete All Collections in Scope", "[Collection
     scopeNames = CBLDatabase_ScopeNames(db, &error);
     CHECK(Array(scopeNames).toJSONString() == R"(["_default"])");
     FLMutableArray_Release(scopeNames);
+    
+    CBLScope_Release(scope);
+    CBLCollection_Release(colA);
+    CBLCollection_Release(colB);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Valid Collection and Scope Names", "[Collection]") {
@@ -454,10 +493,16 @@ TEST_CASE_METHOD(CollectionTest, "Valid Collection and Scope Names", "[Collectio
 
     for (auto name : names) {
         CBLError error = {};
-        CBLCollection* col = CBLDatabase_CreateCollection(db, slice(name), slice(name), &error);
-        REQUIRE(col);
-        col = CBLDatabase_Collection(db, slice(name), slice(name), &error);
-        CHECK(col == col);
+        CBLCollection* col1 = CBLDatabase_CreateCollection(db, slice(name), slice(name), &error);
+        REQUIRE(col1);
+        
+        CBLCollection* col2 = CBLDatabase_Collection(db, slice(name), slice(name), &error);
+        REQUIRE(col2);
+        
+        CHECK(col1 == col2);
+        
+        CBLCollection_Release(col1);
+        CBLCollection_Release(col2);
     }
 }
 
@@ -479,6 +524,7 @@ TEST_CASE_METHOD(CollectionTest, "Invalid Collection and Scope Names", "[Collect
         REQUIRE(!col);
         CHECK(error.domain == kCBLDomain);
         CHECK(error.code == kCBLErrorInvalidParameter);
+        CBLCollection_Release(col);
         
         col = CBLDatabase_CreateCollection(db, "colA"_sl, slice(name), &error);
         REQUIRE(!col);
@@ -496,6 +542,7 @@ TEST_CASE_METHOD(CollectionTest, "Overflow Collection and Scope Names", "[Collec
     CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, slice(name), slice(name), &error);
     REQUIRE(col);
+    CBLCollection_Release(col);
     
     ExpectingExceptions x;
     
@@ -524,6 +571,9 @@ TEST_CASE_METHOD(CollectionTest, "Collection Name Case Sensitive", "[.CBL-3195]"
     FLMutableArray colNames = CBLDatabase_CollectionNames(db, "scopeA"_sl, &error);
     CHECK(Array(colNames).toJSONString() == R"(["_default",COL1","col1"])");
     FLMutableArray_Release(colNames);
+    
+    CBLCollection_Release(col1a);
+    CBLCollection_Release(col1b);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Scope Name Case Sensitive", "[.CBL-3195]") {
@@ -539,6 +589,9 @@ TEST_CASE_METHOD(CollectionTest, "Scope Name Case Sensitive", "[.CBL-3195]") {
     FLMutableArray scopeNames = CBLDatabase_ScopeNames(db, &error);
     CHECK(Array(scopeNames).toJSONString() == R"(["_default",SCOPEA","scopea"])");
     FLMutableArray_Release(scopeNames);
+    
+    CBLCollection_Release(col1a);
+    CBLCollection_Release(col1b);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Create then Get Collection using Different DB Instances", "[Collection]") {
@@ -561,6 +614,9 @@ TEST_CASE_METHOD(CollectionTest, "Create then Get Collection using Different DB 
     CHECK(CBLCollection_Count(col1a) == 20);
     
     CBLDatabase_Release(db2);
+    
+    CBLCollection_Release(col1a);
+    CBLCollection_Release(col1b);
 }
 
 TEST_CASE_METHOD(CollectionTest, "Create then Create Collection using Different DB Instances", "[Collection]") {
@@ -582,6 +638,8 @@ TEST_CASE_METHOD(CollectionTest, "Create then Create Collection using Different 
     CHECK(CBLCollection_Count(col1b) == 20);
     CHECK(CBLCollection_Count(col1a) == 20);
     
+    CBLCollection_Release(col1a);
+    CBLCollection_Release(col1b);
     CBLDatabase_Release(db2);
 }
 
@@ -607,6 +665,8 @@ TEST_CASE_METHOD(CollectionTest, "Delete then Get Collection from Different DB I
     CHECK(!CBLDatabase_Collection(db2, "colA"_sl, "scopeA"_sl, &error));
     CHECK(error.code == 0);
     
+    CBLCollection_Release(col1a);
+    CBLCollection_Release(col1b);
     CBLDatabase_Release(db2);
 }
 
@@ -638,6 +698,10 @@ TEST_CASE_METHOD(CollectionTest, "Delete and Recreate then Get Collection from D
     REQUIRE(col1d);
     CHECK(col1d != col1b);
     
+    CBLCollection_Release(col1a);
+    CBLCollection_Release(col1b);
+    CBLCollection_Release(col1c);
+    CBLCollection_Release(col1d);
     CBLDatabase_Release(db2);
 }
 
@@ -645,8 +709,6 @@ TEST_CASE_METHOD(CollectionTest, "Delete Collection then Use Collection", "[Coll
     CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
-    
-    CBLCollection_Retain(col);
     
     REQUIRE(CBLDatabase_DeleteCollection(db, "colA"_sl, "scopeA"_sl, &error));
     
@@ -659,8 +721,6 @@ TEST_CASE_METHOD(CollectionTest, "Close Database then Use Collection", "[Collect
     CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
-    
-    CBLCollection_Retain(col);
     
     REQUIRE(CBLDatabase_Close(db, &error));
     CBLDatabase_Release(db);
@@ -675,8 +735,6 @@ TEST_CASE_METHOD(CollectionTest, "Delete Database then Use Scope", "[Collection]
     CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
-    
-    CBLCollection_Retain(col);
     
     REQUIRE(CBLDatabase_Delete(db, &error));
     CBLDatabase_Release(db);
@@ -695,8 +753,6 @@ TEST_CASE_METHOD(CollectionTest, "Close Database then Use Scope", "[Collection]"
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
     REQUIRE(col);
     
-    CBLCollection_Retain(col);
-    
     REQUIRE(CBLDatabase_Close(db, &error));
     CBLDatabase_Release(db);
     db = nullptr;
@@ -711,12 +767,11 @@ TEST_CASE_METHOD(CollectionTest, "Close Database then Use Scope", "[Collection]"
 
 TEST_CASE_METHOD(CollectionTest, "Close Database then Create Or Get Collections and Scopes", "[Collection]") {
     CBLError error = {};
-    CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
+    CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, "scopeA"_sl, &error);
+    REQUIRE(col);
+    CBLCollection_Release(col);
     
     REQUIRE(CBLDatabase_Close(db, &error));
     
     testInvalidDatabase(db);
-    
-    CBLDatabase_Release(db);
-    db = nullptr;
 }


### PR DESCRIPTION
* To make the API consistent with the others, the returned scopes and collections from the database will have RefCount + 1. This means that users will need to release it after they are done using it. This also means that if the collection is deleted from the database or the database is closed or released, the collection pointer (also scope pointer) will remain valid until it is being released.

* Noted that as the scope returned by CBLCollection_Scope() is a property of the collection, its lifetime will depend on the lifetime of the collection object.  If the object needs to be kept longer than the collection, users will need to explicitly retained.

* Updated the tests accordingly.

* Updated the API doc accordingly.