### PR TITLE
CBD-4471, add notices.txt to couchbase-lite-c packages

### DIFF
--- a/jenkins/ci_build_android.sh
+++ b/jenkins/ci_build_android.sh
@@ -92,6 +92,11 @@ echo
 
 cd $(pwd)/..
 cp ${WORKSPACE}/product-texts/mobile/couchbase-lite/license/LICENSE_$EDITION.txt libcblite-$VERSION/LICENSE.txt
+#notices.txt is produced by blackduck.
+#It is not part of source tar, it is download to the workspace by a separate curl command by jenkins job.
+if [[ -f ${WORKSPACE}/notices.txt ]]; then
+    cp ${WORKSPACE}/notices.txt libcblite-$VERSION/notices.txt
+fi
 ${PKG_CMD} ${WORKSPACE}/${PACKAGE_NAME} libcblite-$VERSION
 
 cd ${WORKSPACE}

--- a/jenkins/ci_build_ios.sh
+++ b/jenkins/ci_build_ios.sh
@@ -36,7 +36,13 @@ echo
 
 pushd ${WORKSPACE}/couchbase-lite-c/build_apple_out/
 cp ${WORKSPACE}/product-texts/mobile/couchbase-lite/license/LICENSE_${EDITION}.txt LICENSE.txt
-${PKG_CMD} ${WORKSPACE}/${PACKAGE_NAME} CouchbaseLite.xcframework LICENSE.txt
+#notices.txt is produced by blackduck.
+#It is not part of source tar, it is download to the workspace by a separate curl command by jenkins job.
+if [[ -f ${WORKSPACE}/notices.txt ]]; then
+    cp ${WORKSPACE}/notices.txt notices.txt
+fi
+${PKG_CMD} ${WORKSPACE}/${PACKAGE_NAME} CouchbaseLite.xcframework *.txt
+
 RELEASE_IOS_PKG_NAME=${PACKAGE_NAME}
 popd
 

--- a/jenkins/ci_build_unix.sh
+++ b/jenkins/ci_build_unix.sh
@@ -79,16 +79,22 @@ echo
 
 cd ${WORKSPACE}/build_release/
 cp ${WORKSPACE}/product-texts/mobile/couchbase-lite/license/LICENSE_$EDITION.txt libcblite-$VERSION/LICENSE.txt
+#notices.txt is produced by blackduck.
+#It is not part of source tar, it is download to the workspace by a separate curl command by jenkins job.
+if [[ -f ${WORKSPACE}/notices.txt ]]; then
+    cp ${WORKSPACE}/notices.txt libcblite-$VERSION/notices.txt
+fi
 # Create separate symbols pkg
 if [[ "${OS}" == "macos" ]]; then
-    ${PKG_CMD} ${WORKSPACE}/${PACKAGE_NAME} libcblite-$VERSION/LICENSE.txt libcblite-$VERSION/include libcblite-$VERSION/lib
+    ${PKG_CMD} ${WORKSPACE}/${PACKAGE_NAME} libcblite-$VERSION/*.txt libcblite-$VERSION/include libcblite-$VERSION/lib
     SYMBOLS_RELEASE_PKG_NAME=${PRODUCT}-${EDITION}-${VERSION}-${BLD_NUM}-${OS}-'symbols'.${PKG_TYPE}
     ${PKG_CMD} ${WORKSPACE}/${SYMBOLS_RELEASE_PKG_NAME}  libcblite-$VERSION/libcblite.dylib.dSYM
 else # linux
-    ${PKG_CMD} ${WORKSPACE}/${PACKAGE_NAME} libcblite-$VERSION/LICENSE.txt libcblite-$VERSION/include libcblite-$VERSION/lib
+    ${PKG_CMD} ${WORKSPACE}/${PACKAGE_NAME} libcblite-$VERSION/*.txt libcblite-$VERSION/include libcblite-$VERSION/lib
     SYMBOLS_RELEASE_PKG_NAME=${PRODUCT}-${EDITION}-${VERSION}-${BLD_NUM}-${OS}-'symbols'.${PKG_TYPE}
     ${PKG_CMD} ${WORKSPACE}/${SYMBOLS_RELEASE_PKG_NAME} libcblite-$VERSION/libcblite*.sym
 fi
+
 cd ${WORKSPACE}
 
 echo "PRODUCT=${PRODUCT}"  >> ${PROP_FILE}

--- a/jenkins/ci_build_win_desktop.ps1
+++ b/jenkins/ci_build_win_desktop.ps1
@@ -31,8 +31,11 @@ function Make-Package() {
     )
 
     Push-Location $directory
+    if(Test-Path -Path $env:WORKSPACE\notices.txt -PathType Leaf) {
+        Copy-Item $env:WORKSPACE\notices.txt libcblite-$VERSION\notices.txt
+    }
     Copy-Item $env:WORKSPACE\product-texts\mobile\couchbase-lite\license\LICENSE_$EDITION.txt libcblite-$VERSION\LICENSE.txt
-    & 7za a -tzip -mx9 $env:WORKSPACE\$filename libcblite-$VERSION\LICENSE.txt libcblite-$VERSION\include libcblite-$VERSION\lib libcblite-$VERSION\bin
+    & 7za a -tzip -mx9 $env:WORKSPACE\$filename libcblite-$VERSION\*.txt libcblite-$VERSION\include libcblite-$VERSION\lib libcblite-$VERSION\bin
     if($LASTEXITCODE -ne 0) {
         throw "Zip failed"
     }

--- a/jenkins/ci_cross_build.py
+++ b/jenkins/ci_cross_build.py
@@ -198,6 +198,10 @@ if __name__ == '__main__':
     shutil.copy2(workspace_path / 'product-texts' / 'mobile' / 'couchbase-lite' / 'license' / f'LICENSE_{args.edition}.txt',
         f'libcblite-{args.version}/LICENSE.txt')
 
+    #notices.txt is produced by blackduck.
+    #It is not part of source tar, it is download to the workspace by a separate curl command by jenkins job.
+    if os.path.isfile(workspace_path / 'notices.txt'):
+        shutil.copy2(workspace_path / 'notices.txt', f'libcblite-{args.version}/notices.txt')
     pbar = ProgressBar(maxval=3)
     pbar.start()
     with tarfile.open(f'{workspace}/{package_name}', 'w:gz') as tar:
@@ -207,6 +211,11 @@ if __name__ == '__main__':
         pbar.update(2)
         tar.add(f'libcblite-{args.version}/LICENSE.txt')
         pbar.update(3)
+
+        #notices.txt is produced by blackduck.
+        #It is not part of source tar, it is download to the workspace by a separate curl command by jenkins job.
+        if os.path.isfile(f'libcblite-{args.version}/notices.txt'):
+            tar.add(f'libcblite-{args.version}/notices.txt')
         pbar.finish()
 
     symbols_package_name = f'{args.product}-{args.edition}-{args.version}-{args.bld_num}-{args.os}-symbols.tar.gz'


### PR DESCRIPTION
notices.txt is generated by blackduck, contains component license information.  Per CBD-4471, we want to include it in couchbase-lite-c packages.

-Ming Ho