### PR TITLE
Close collection or detach scope and handle NULL scope cases

### DIFF
--- a/src/CBLCollection_Internal.hh
+++ b/src/CBLCollection_Internal.hh
@@ -31,12 +31,11 @@ public:
     
 #pragma mark - CONSTRUCTORS:
     
-    CBLCollection(C4Collection* c4col, CBLDatabase* database)
+    CBLCollection(C4Collection* c4col, CBLScope* scope, CBLDatabase* database)
     :_c4col(c4col, database)
-    {
-        _name = c4col->getName();
-        _scope = database->getScope(c4col->getScope());
-    }
+    ,_scope(scope)
+    ,_name(c4col->getName())
+    { }
     
 #pragma mark - ACCESSORS:
     

--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -320,10 +320,13 @@ private:
     /**
      Create a CBLCollection from the C4Collection.
      The created CBLCollection will be retained and cached in the _collections map. */
-    Retained<CBLCollection> createCBLCollection(C4Collection* c4col);
+    Retained<CBLCollection> createCBLCollection(C4Collection* c4col, CBLScope* scope, bool cache= true);
     
-    /** Remove and release the CBLCollection from the _collections map */
+    /** Remove and close the collection from the _collections map */
     void removeCBLCollection(C4Database::CollectionSpec spec);
+    
+    /** Remove and close all collections in the specify scope the _collections map */
+    void removeCBLCollections(slice scopeName);
 
     void callDocListeners();
     


### PR DESCRIPTION
* This PR fixed two issues, CBL-3304 and CBL-3317, at the same time as the fix of both issues are done at the same or related location in the code.

* [CBL-3304] When a collection is removed from the cache as the collection was deleted, the close() call on the collection is needed to invalidate its database pointer. Otherwise, the collection could have a dangle database pointer when the database is laster released.

* [CBL-3304] Similarly thing needs to be done on the scope. When a scope is removed from the cache as there are no collections in the scope anymore, the scope should be called to detach (not close) from the database. When the scope is detached, the scope will start to retain the database so that the scope can be continually used as normal and will not have the situation that the database pointer is dangled. Also, if later there are new collections added to the scope (by name), the detached scope will be able to return the collections when using getCollection() or getCollection() as defined in the API spec.

  - Note: After remove the scope from the cache, all collections of the scope will be removed from the cache as all collections in the scope were deleted. However, this is also technically required to avoid circular references b/w database and collection via the detached scope (db->collection->scope-db).

* [CBL-3304] New tests that cover the issue and the fix.

* [CBL-3317] In CBLDatabase’s getCollection() and createCollection(), the operations to get the C4Collection and to get CBLScope object to create a CBLCollection are not atomic. This means that technically in an edge case, after getting a C4Collection returned from LiteCore, the collection and its sibling collections in the same scope might be deleted from another thread using a different db connection. In the code, we will need to handle this edge case as follows:

  - In this commit, instead of letting the CBLCollection get the scope object in its constructor, the scope object will be passed into instead.

  - In CBLDatabase’s getCollection(), after getting a C4Collection from LiteCore, the code will get the CBLScope object in order to create a new CBLCollection. If the returned CBLScope object turns out to be NULL, the getCollection() will simply return NULL as no collection found.

  - Similarly, in CBLDatabase’s createCollection(), after getting a C4Collection from LiteCore, the code will get the CBLScope object in order to create a new CBLCollection. However as the createCollection() is expected to return a (non-null) collection, the code will create a detached CBLScope object for creating a CBLCollection object; both the detached CBLSCope object and CBLCollection object are not placed in cache.