### PR TITLE
CBL-3191 : Setup C4ReplicationCollection(s) for CBLReplicatorConfiguration

### DIFF
--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -238,7 +238,7 @@ typedef struct {
 typedef struct {
     /** The database to replicate
         @warning  <b>Deprecated :</b> Use collections instead. */
-    CBLDatabase* database;
+    CBLDatabase* _cbl_nullable database;
     CBLEndpoint* endpoint;                  ///< The address of the other database to replicate with
     
     //-- Types:
@@ -311,12 +311,12 @@ typedef struct {
         @warning  <b>Deprecated :</b> Use documentPropertyDecryptor instead. */
     CBLPropertyDecryptor propertyDecryptor;
     
-    CBLDocumentPropertyEncryptor documentPropertyEncryptor;   ///< Optional callback to encrypt \ref CBLEncryptable values.
-    CBLDocumentPropertyDecryptor documentPropertyDecryptor;   ///< Optional callback to decrypt encrypted \ref CBLEncryptable values.
+    CBLDocumentPropertyEncryptor documentPropertyEncryptor;     ///< Optional callback to encrypt \ref CBLEncryptable values.
+    CBLDocumentPropertyDecryptor documentPropertyDecryptor;     ///< Optional callback to decrypt encrypted \ref CBLEncryptable values.
 #endif
     
-    CBLReplicationCollection* collections;  ///< The collections to replicate with the target's endpoint
-    size_t collectionCount;                 ///< The number of collections
+    CBLReplicationCollection* _cbl_nullable collections;        ///< The collections to replicate with the target's endpoint
+    size_t collectionCount;                                     ///< The number of collections
 } CBLReplicatorConfiguration;
 
 

--- a/src/CBLCollection_Internal.hh
+++ b/src/CBLCollection_Internal.hh
@@ -25,6 +25,8 @@
 
 CBL_ASSUME_NONNULL_BEGIN
 
+using CollectionSpec = C4Database::CollectionSpec;
+
 struct CBLCollection final : public CBLRefCounted {
     
 public:
@@ -39,8 +41,9 @@ public:
     
 #pragma mark - ACCESSORS:
     
-    CBLScope* scope() noexcept              {return _scope;}
+    CBLScope* scope() const noexcept        {return _scope;}
     slice name() const noexcept             {return _name;}
+    CollectionSpec spec() const noexcept    {return CollectionSpec(_name, _scope->name());}
     bool isValid() const noexcept           {return _c4col.isValid();}
     uint64_t count() const                  {return _c4col.useLocked()->getDocumentCount();}
     uint64_t lastSequence() const           {return static_cast<uint64_t>(_c4col.useLocked()->getLastSequence());}

--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -20,6 +20,7 @@
 
 #include "CBLReplicator.h"
 #include "CBLDatabase_Internal.hh"
+#include "CBLCollection_Internal.hh"
 #include "Internal.hh"
 #include "c4ReplicatorTypes.h"
 #include "c4Private.h"
@@ -177,6 +178,17 @@ namespace cbl_internal {
             retain(database);
             if (endpoint)
                 endpoint = endpoint->clone();
+            
+            if (collections) {
+                // Copy collections and retain the collection object inside:
+                auto cols = new CBLReplicationCollection[collectionCount];
+                for (int i = 0; i < collectionCount; i++) {
+                    cols[i] = collections[i];
+                    retain(cols[i].collection);
+                }
+                collections = cols;
+            }
+            
             authenticator = authenticator ? authenticator->clone() : nullptr;
             headers = FLDict_MutableCopy(headers, kFLDeepCopyImmutables);
             channels = FLArray_MutableCopy(channels, kFLDeepCopyImmutables);
@@ -196,6 +208,14 @@ namespace cbl_internal {
 
         ~ReplicatorConfiguration() {
             release(database);
+            
+            if (collections) {
+                for (int i = 0; i < collectionCount; i++) {
+                    release(collections[i].collection);
+                }
+                delete [] collections;
+            }
+            
             CBLEndpoint_Free(endpoint);
             CBLAuth_Free(authenticator);
             FLDict_Release(headers);
@@ -206,7 +226,13 @@ namespace cbl_internal {
 
         void validate() const {
             const char *problem = nullptr;
-            if (!database || !endpoint || replicatorType > kCBLReplicatorTypePull)
+            if (!database && !collections)
+                problem = "Invalid replicator config: missing both database and collections";
+            else if (database && collections)
+                problem = "Invalid replicator config: both database and collections are set at same time";
+            else if (collections && collectionCount == 0)
+                problem = "Invalid replicator config: collectionCount is zero";
+            else if (!endpoint || replicatorType > kCBLReplicatorTypePull)
                 problem = "Invalid replicator config: missing endpoints or bad type";
             else if (!endpoint->valid())
                 problem = "Invalid endpoint";
@@ -222,8 +248,14 @@ namespace cbl_internal {
         // Writes a LiteCore replicator optionsDict
         void writeOptions(Encoder &enc) const {
             writeOptionalKey(enc, kC4ReplicatorOptionExtraHeaders,  Dict(headers));
+            
+            // TODO:
+            // When collection is supported in LiteCore Replicator,
+            // remove the code that encodes documentIDs and channels here as it will be
+            // set using CBLReplicationCollection.
             writeOptionalKey(enc, kC4ReplicatorOptionDocIDs,        Array(documentIDs));
             writeOptionalKey(enc, kC4ReplicatorOptionChannels,      Array(channels));
+            
             if (pinnedServerCertificate.buf) {
                 enc.writeKey(slice(kC4ReplicatorOptionPinnedServerCert));
                 enc.writeData(pinnedServerCertificate);
@@ -276,6 +308,11 @@ namespace cbl_internal {
                 enc.writeKey(slice(kC4SocketOptionNetworkInterface));
                 enc.writeString(networkInterface);
             }
+        }
+        
+        void writeCollectionOptions(CBLReplicationCollection& collection, Encoder &enc) const {
+            writeOptionalKey(enc, kC4ReplicatorOptionDocIDs,        Array(collection.documentIDs));
+            writeOptionalKey(enc, kC4ReplicatorOptionChannels,      Array(collection.channels));
         }
 
         ReplicatorConfiguration(const ReplicatorConfiguration&) =delete;

--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -83,7 +83,6 @@ public:
             _defaultCollection = _conf.database->getDefaultCollection(true);
         }
 
-        // Validate:
         _conf.validate();
         
         // Set up the LiteCore replicator parameters:

--- a/src/ConflictResolver.hh
+++ b/src/ConflictResolver.hh
@@ -20,13 +20,13 @@ namespace cbl_internal {
     class ConflictResolver {
     public:
         /// Basic constructor.
-        ConflictResolver(CBLDatabase *db,
+        ConflictResolver(CBLCollection *collection,
                          CBLConflictResolver _cbl_nullable customResolver,
                          void* _cbl_nullable context,
                          alloc_slice docID,
                          alloc_slice revID = nullslice);
 
-        ConflictResolver(CBLDatabase*,
+        ConflictResolver(CBLCollection*,
                          CBLConflictResolver _cbl_nullable,
                          void* _cbl_nullable context,
                          const C4DocumentEnded&);
@@ -50,7 +50,7 @@ namespace cbl_internal {
         bool defaultResolve(CBLDocument *conflict);
         bool customResolve(CBLDocument *conflict);
 
-        Retained<CBLDatabase>   _db;
+        Retained<CBLCollection>  _collection;
         CBLConflictResolver _cbl_nullable _clientResolver;
         void* _cbl_nullable     _clientResolverContext;
         alloc_slice const       _docID;
@@ -65,7 +65,7 @@ namespace cbl_internal {
     /** Scans the database for all unresolved conflicts and resolves them. */
     class AllConflictsResolver {
     public:
-        explicit AllConflictsResolver(CBLDatabase*,
+        explicit AllConflictsResolver(CBLCollection*,
                                       CBLConflictResolver,
                                       void* _cbl_nullable context);
         void runNow();
@@ -73,7 +73,7 @@ namespace cbl_internal {
     private:
         bool next();
         
-        Retained<CBLDatabase>               _db;
+        Retained<CBLCollection>             _collection;
         CBLConflictResolver                 _clientResolver;
         void* _cbl_nullable                 _clientResolverContext;
         std::unique_ptr<C4DocEnumerator>    _enum;


### PR DESCRIPTION
* Made database and collections in CBLReplicatorConfiguration nullable. The config will be validated in the Replicator's constructor as both cannot be NULL.

* Copied CBLReplicatorConfiguration’s collections and retained each collections inside.

* Setup C4ReplicationCollection(s) from CBLReplicatorConfiguration’s collections. If the CBLReplicatorConfiguration’s database is used, create a C4ReplicationCollection with the default collection, outer filters, and outer conflict resolver. There are TODO marks that will need to be done when the collection support have been implemented in LiteCore's Replicator. Now, only the default collection via CBLReplicatorConfiguration’s database is supported.

* Made changes to ConflictResolver classes to use collection instead of database.

* Still throw kC4ErrorUnimplemented if CBLReplicatorConfiguration’s collections is used.

* The existing tests that use database still passes. The new tests with collections will be in the separate commit / PR.