### PR TITLE
Update LiteCore, enable Collections support in Replicator and bugs fixes

### DIFF
--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -236,7 +236,7 @@ typedef struct {
 
 /** The configuration of a replicator. */
 typedef struct {
-    /** The database to replicate
+    /** The database to replicate. When setting the database, ONLY the default collection will be used for replication.
         @warning  <b>Deprecated :</b> Use collections instead. */
     CBLDatabase* _cbl_nullable database;
     CBLEndpoint* endpoint;                  ///< The address of the other database to replicate with
@@ -274,23 +274,28 @@ typedef struct {
     FLSlice trustedRootCertificates;    ///< Set of anchor certs (PEM format)
     
     //-- Filtering:
-    /** Optional set of channels to pull from
+    /** Optional set of channels to pull from when replicating with the default collection.
+        @Note This property can only be used when setting the config object with the database instead of collections.
         @warning  <b>Deprecated :</b> Use CBLReplicationCollection.channels instead. */
     FLArray _cbl_nullable channels;
     
-    /** Optional set of document IDs to replicate
+    /** Optional set of document IDs to replicate when replicating with the default collection.
+        @Note This property can only be used when setting the config object with the database instead of collections.
         @warning  <b>Deprecated :</b> Use CBLReplicationCollection.documentIDs instead. */
     FLArray _cbl_nullable documentIDs;
     
-    /** Optional callback to filter which docs are pushed.
+    /** Optional callback to filter which docs are pushed when replicating with the default collection.
+        @Note This property can only be used when setting the config object with the database instead of collections.
         @warning  <b>Deprecated :</b> Use CBLReplicationCollection.pushFilter instead. */
     CBLReplicationFilter _cbl_nullable pushFilter;
     
-    /** Optional callback to validate incoming docs.
+    /** Optional callback to validate incoming docs when replicating with the default collection.
+        @Note This property can only be used when setting the config object with the database instead of collections.
         @warning  <b>Deprecated :</b> Use CBLReplicationCollection.pullFilter instead. */
     CBLReplicationFilter _cbl_nullable pullFilter;
     
     /** Optional conflict-resolver callback.
+        @Note This property can only be used when setting the config object with the database instead of collections.
         @warning  <b>Deprecated :</b> Use CBLReplicationCollection.conflictResolver instead. */
     CBLConflictResolver _cbl_nullable conflictResolver;
     
@@ -299,15 +304,13 @@ typedef struct {
     
 #ifdef COUCHBASE_ENTERPRISE
     //-- Property Encryption
-    /** Optional callback to encrypt \ref CBLEncryptable values of the documents in
-        the default collection. If the default collection is not part of the replication,
-        the replicator will fail to create with an error.
+    /** Optional callback to encrypt \ref CBLEncryptable values of the documents in the default collection.
+        @Note This property can only be used when setting the config object with the database instead of collections.
         @warning  <b>Deprecated :</b> Use documentPropertyEncryptor instead. */
     CBLPropertyEncryptor propertyEncryptor;
     
-    /** Optional callback to decrypt encrypted \ref CBLEncryptable values of the documents in
-        the default collection. If the default collection is not part of the replication,
-        the replicator will fail to create with an error.
+    /** Optional callback to decrypt encrypted \ref CBLEncryptable values of the documents in the default collection.
+        @Note This property can only be used when setting the config object with the database instead of collections.
         @warning  <b>Deprecated :</b> Use documentPropertyDecryptor instead. */
     CBLPropertyDecryptor propertyDecryptor;
     

--- a/src/CBLCollection_Internal.hh
+++ b/src/CBLCollection_Internal.hh
@@ -43,7 +43,7 @@ public:
     
     CBLScope* scope() const noexcept        {return _scope;}
     slice name() const noexcept             {return _name;}
-    CollectionSpec spec() const noexcept    {return CollectionSpec(_name, _scope->name());}
+    C4CollectionSpec spec() const noexcept  {return {_name, _scope->name()};}
     bool isValid() const noexcept           {return _c4col.isValid();}
     uint64_t count() const                  {return _c4col.useLocked()->getDocumentCount();}
     uint64_t lastSequence() const           {return static_cast<uint64_t>(_c4col.useLocked()->getLastSequence());}
@@ -141,6 +141,18 @@ public:
                                                    CBLCollectionDocumentChangeListener listener,
                                                    void* _cbl_nullable ctx);
         
+#pragma mark - UTILS
+    
+    static alloc_slice collectionSpecToPath(C4CollectionSpec& spec) {
+        alloc_slice ret(spec.scope.size + spec.name.size + 1);
+        void* buf = const_cast<void*>(ret.buf);
+        slice(spec.scope).copyTo(buf);
+        ((uint8_t*)buf)[spec.scope.size] = '.';
+        size_t nameOffset = spec.scope.size + 1;
+        slice(spec.name).copyTo((uint8_t*)buf + nameOffset);
+        return ret;
+    }
+    
 protected:
     
     friend struct CBLDatabase;

--- a/src/CBLReplicator_CAPI.cc
+++ b/src/CBLReplicator_CAPI.cc
@@ -78,39 +78,39 @@ void CBLReplicator_SetSuspended(CBLReplicator* repl, bool sus) noexcept   {repl-
 
 FLDict CBLReplicator_PendingDocumentIDs(CBLReplicator *repl, CBLError *outError) noexcept {
     try {
-        auto result = FLDict_Retain(repl->pendingDocumentIDs());
-        if (!result)
-            if (outError) outError->code = 0;
-        return result;
+        auto col = repl->database()->getDefaultCollection(true);
+        return CBLReplicator_PendingDocumentIDs2(repl, col, outError);
     } catchAndBridge(outError)
 }
 
 bool CBLReplicator_IsDocumentPending(CBLReplicator *repl, FLString docID, CBLError *outError) noexcept {
     try {
-        bool result = repl->isDocumentPending(docID);
-        if (!result)
-            if (outError) outError->code = 0;
-        return result;
+        auto col = repl->database()->getDefaultCollection(true);
+        return CBLReplicator_IsDocumentPending2(repl, docID, col, outError);
     } catchAndBridge(outError)
 }
 
 FLDict _cbl_nullable CBLReplicator_PendingDocumentIDs2(CBLReplicator* repl,
                                                        const CBLCollection* collection,
                                                        CBLError* _cbl_nullable outError) noexcept {
-    if (outError) {
-        *outError = {kCBLDomain, kCBLErrorUnimplemented};
-    }
-    return nullptr;
+    try {
+        auto result = FLDict_Retain(repl->pendingDocumentIDs(collection));
+        if (!result)
+            if (outError) outError->code = 0;
+        return result;
+    } catchAndBridge(outError)
 }
 
 bool CBLReplicator_IsDocumentPending2(CBLReplicator *repl,
                                       FLString docID,
                                       const CBLCollection* collection,
                                       CBLError* _cbl_nullable outError) noexcept {
-    if (outError) {
-        *outError = {kCBLDomain, kCBLErrorUnimplemented};
-    }
-    return false;
+    try {
+        bool result = repl->isDocumentPending(docID, collection);
+        if (!result)
+            if (outError) outError->code = 0;
+        return result;
+    } catchAndBridge(outError)
 }
 
 CBLListenerToken* CBLReplicator_AddChangeListener(CBLReplicator* repl,

--- a/src/ConflictResolver.cc
+++ b/src/ConflictResolver.cc
@@ -251,6 +251,9 @@ namespace cbl_internal {
 
     CBLReplicatedDocument ConflictResolver::result() const {
         CBLReplicatedDocument doc = {};
+        auto spec = _collection->spec();
+        doc.scope = spec.scope;
+        doc.collection = spec.name;
         doc.ID = _docID;
         doc.error = _error;
         if (_flags & kRevDeleted)


### PR DESCRIPTION
* Updated LiteCore to [92b21fd](https://github.com/couchbase/couchbase-lite-core/commit/92b21fdbac70ffe8e91833616874d34a9a3898f7).
 
* Enable collection support in replicator.

* Implemented CBLReplicator_PendingDocumentIDs2 and CBLReplicator_IsDocumentPending2.

* In both filter and conflict resolver, ensure to check the collection spec against the collections in the config. This is for avoid ing unexpected bugs.

* Fixed missing collection info in ReplicatedDocument event after resolving conflicts.

* Fixed property encryption bug that doesn’t use config’s documentPropertyEncryptor and _conf.documentPropertyDecryptor.

* Do not allow to use outer level filters & conflict resolver if database is not set. NOTE: This is different from the other platforms as CBLReplicatorConfiguration is just a struct and cannot automatically links the outer level filters & conflict resolver config with the default collection’s ones in the CBLReplicatorConfiguration.collections.

* Do not allow to use propertyEncryptor and propertyDecryptor if database is not set.

* Replicator Tests with Collections are not included in this PR.