### PR TITLE
CBL-3600 : Fix GetDocumentExpiration not return -1 for errors

### DIFF
--- a/src/CBLCollection_CAPI.cc
+++ b/src/CBLCollection_CAPI.cc
@@ -249,7 +249,7 @@ CBLTimestamp CBLCollection_GetDocumentExpiration(CBLCollection* collection,
 {
     try {
         return collection->getDocumentExpiration(docID);
-    } catchAndBridge(outError)
+    } catchAndBridgeReturning(outError, -1)
 }
 
 bool CBLCollection_SetDocumentExpiration(CBLCollection* collection,

--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -103,7 +103,7 @@ public:
         CheckNotOpenError(error);
         
         error = {};
-        CHECK(CBLCollection_GetDocumentExpiration(col, "doc1"_sl, &error) == 0);
+        CHECK(CBLCollection_GetDocumentExpiration(col, "doc1"_sl, &error) == -1);
         CheckNotOpenError(error);
         
         error = {};


### PR DESCRIPTION
Caught exception and returnning -1 instead of 0.