### PR TITLE
Enable disabled tests

### DIFF
--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -558,7 +558,7 @@ TEST_CASE_METHOD(CollectionTest, "Overflow Collection and Scope Names", "[Collec
     CHECK(error.code == kCBLErrorInvalidParameter);
 }
 
-TEST_CASE_METHOD(CollectionTest, "Collection Name Case Sensitive", "[.CBL-3195]") {
+TEST_CASE_METHOD(CollectionTest, "Collection Name Case Sensitive", "[Collection]") {
     CBLError error = {};
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "COL1"_sl, "scopeA"_sl, &error);
     REQUIRE(col1a);
@@ -569,14 +569,14 @@ TEST_CASE_METHOD(CollectionTest, "Collection Name Case Sensitive", "[.CBL-3195]"
     CHECK(col1a != col1b);
     
     FLMutableArray colNames = CBLDatabase_CollectionNames(db, "scopeA"_sl, &error);
-    CHECK(Array(colNames).toJSONString() == R"(["_default",COL1","col1"])");
+    CHECK(Array(colNames).toJSONString() == R"(["COL1","col1"])");
     FLMutableArray_Release(colNames);
     
     CBLCollection_Release(col1a);
     CBLCollection_Release(col1b);
 }
 
-TEST_CASE_METHOD(CollectionTest, "Scope Name Case Sensitive", "[.CBL-3195]") {
+TEST_CASE_METHOD(CollectionTest, "Scope Name Case Sensitive", "[Collection]") {
     CBLError error = {};
     CBLCollection* col1a = CBLDatabase_CreateCollection(db, "col1"_sl, "SCOPEA"_sl, &error);
     REQUIRE(col1a);
@@ -587,7 +587,7 @@ TEST_CASE_METHOD(CollectionTest, "Scope Name Case Sensitive", "[.CBL-3195]") {
     CHECK(col1a != col1b);
     
     FLMutableArray scopeNames = CBLDatabase_ScopeNames(db, &error);
-    CHECK(Array(scopeNames).toJSONString() == R"(["_default",SCOPEA","scopea"])");
+    CHECK(Array(scopeNames).toJSONString() == R"(["_default","SCOPEA","scopea"])");
     FLMutableArray_Release(scopeNames);
     
     CBLCollection_Release(col1a);

--- a/test/DatabaseTest.cc
+++ b/test/DatabaseTest.cc
@@ -1708,7 +1708,7 @@ TEST_CASE_METHOD(DatabaseTest, "Get blob", "[Blob]") {
 
 #ifdef COUCHBASE_ENTERPRISE
 
-TEST_CASE_METHOD(DatabaseTest, "Close Database with Active Replicator", "[.CBL-3183]") {
+TEST_CASE_METHOD(DatabaseTest, "Close Database with Active Replicator") {
     CBLError error;
     otherDB = CBLDatabase_Open(kOtherDBName, &kDatabaseConfiguration, &error);
     REQUIRE(otherDB);
@@ -1723,12 +1723,13 @@ TEST_CASE_METHOD(DatabaseTest, "Close Database with Active Replicator", "[.CBL-3
     REQUIRE(repl);
     CBLReplicator_Start(repl, false);
     
-    // Wait util the replicator starts to run:
     int count = 0;
-    while (CBLReplicator_Status(repl).activity == kCBLReplicatorStopped && count++ < 100) {
+    while (count++ < 100) {
+        if (CBLReplicator_Status(repl).activity == kCBLReplicatorIdle)
+            break;
         this_thread::sleep_for(100ms);
     }
-    CHECK(CBLReplicator_Status(repl).activity != kCBLReplicatorStopped);
+    CHECK(CBLReplicator_Status(repl).activity == kCBLReplicatorIdle);
     
     // Close Database:
     CHECK(CBLDatabase_Close(db, &error));
@@ -1743,7 +1744,7 @@ TEST_CASE_METHOD(DatabaseTest, "Close Database with Active Replicator", "[.CBL-3
     this_thread::sleep_for(200ms);
 }
 
-TEST_CASE_METHOD(DatabaseTest, "Delete Database with Active Replicator", "[.CBL-3183]") {
+TEST_CASE_METHOD(DatabaseTest, "Delete Database with Active Replicator") {
     CBLError error;
     otherDB = CBLDatabase_Open(kOtherDBName, &kDatabaseConfiguration, &error);
     REQUIRE(otherDB);
@@ -1760,10 +1761,13 @@ TEST_CASE_METHOD(DatabaseTest, "Delete Database with Active Replicator", "[.CBL-
     
     // Wait util the replicator starts to run:
     int count = 0;
-    while (CBLReplicator_Status(repl).activity == kCBLReplicatorStopped && count++ < 100) {
+    while (count++ < 100) {
+        if (CBLReplicator_Status(repl).activity == kCBLReplicatorIdle) {
+            break;
+        }
         this_thread::sleep_for(100ms);
     }
-    CHECK(CBLReplicator_Status(repl).activity != kCBLReplicatorStopped);
+    CHECK(CBLReplicator_Status(repl).activity == kCBLReplicatorIdle);
     
     // Delete Database:
     CHECK(CBLDatabase_Delete(db, &error));

--- a/test/DocumentTest.cc
+++ b/test/DocumentTest.cc
@@ -91,10 +91,6 @@ TEST_CASE_METHOD(DocumentTest, "Missing Document", "[Document]") {
     CBLDocument* mdoc = CBLCollection_GetMutableDocument(col, "foo"_sl, &error);
     CHECK(mdoc == nullptr);
     CHECK(error.code == 0);
-
-    CHECK(!CBLCollection_PurgeDocumentByID(col, "foo"_sl, &error));
-    CHECK(error.domain == kCBLDomain);
-    CHECK(error.code == kCBLErrorNotFound);
 }
 
 TEST_CASE_METHOD(DocumentTest, "New Document", "[Document]") {
@@ -119,7 +115,7 @@ TEST_CASE_METHOD(DocumentTest, "New Document With Auto ID", "[Document]") {
     CBLDocument_Release(doc);
 }
 
-TEST_CASE_METHOD(DocumentTest, "Mutable Copy New Document", "[Document]") {
+TEST_CASE_METHOD(DocumentTest, "Mutable Copy Mutable Document", "[Document]") {
     CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
     CHECK(doc != nullptr);
     MutableDict props = CBLDocument_MutableProperties(doc);
@@ -298,7 +294,7 @@ TEST_CASE_METHOD(DocumentTest, "Access nested collections from a copy of modifie
     CBLDocument_Release(doc);
 }
 
-TEST_CASE_METHOD(DocumentTest, "Set MutableProperties", "[Document]") {
+TEST_CASE_METHOD(DocumentTest, "Set Properties", "[Document]") {
     CBLDocument* doc1 = CBLDocument_Create();
     FLMutableDict prop1 = CBLDocument_MutableProperties(doc1);
     FLMutableDict_SetString(prop1, "greeting"_sl, "hello"_sl);
@@ -312,13 +308,6 @@ TEST_CASE_METHOD(DocumentTest, "Set MutableProperties", "[Document]") {
     CBLDocument_Release(doc1);
     CHECK(FLValue_AsString(FLDict_Get(prop2, "greeting"_sl)) == "hello"_sl );
     CBLDocument_Release(doc2);
-}
-
-TEST_CASE_METHOD(DocumentTest, "Get Non Existing Document", "[Document]") {
-    CBLError error;
-    const CBLDocument* doc = CBLCollection_GetDocument(col, "foo"_sl, &error);
-    REQUIRE(doc == nullptr);
-    CHECK(error.code == 0);
 }
 
 TEST_CASE_METHOD(DocumentTest, "Get Document with Empty ID", "[Document]") {
@@ -348,7 +337,7 @@ TEST_CASE_METHOD(DocumentTest, "Save Empty Document", "[Document]") {
     CBLDocument_Release(doc);
 }
 
-TEST_CASE_METHOD(DocumentTest, "Save Document With Property", "[Document]") {
+TEST_CASE_METHOD(DocumentTest, "Save Document With Properties", "[Document]") {
     CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
     MutableDict props = CBLDocument_MutableProperties(doc);
     props["greeting"_sl] = "Howdy!"_sl;
@@ -911,8 +900,6 @@ TEST_CASE_METHOD(DocumentTest, "Purge Document from Different Collection", "[Doc
 #pragma mark - Document Expiry:
 
 TEST_CASE_METHOD(DocumentTest, "Document Expiration", "[Document][Expiry]") {
-    CBLLog_SetConsoleLevel(kCBLLogVerbose);
-    
     createDocument(col, "doc1", "foo", "bar");
     createDocument(col, "doc2", "foo", "bar");
     createDocument(col, "doc3", "foo", "bar");
@@ -966,7 +953,7 @@ TEST_CASE_METHOD(DocumentTest, "Get and Set Expiration on Non Existing Doc", "[D
     CheckError(error, kCBLErrorNotFound);
 }
 
-#pragma mark - Blobs
+#pragma mark - Blobs:
 
 TEST_CASE_METHOD(DocumentTest, "Set blob in document", "[Document][Blob]") {
     // Create and Save blob:
@@ -1078,7 +1065,7 @@ TEST_CASE_METHOD(DocumentTest, "Save blob and set blob properties in document", 
     CBLDocument_Release(doc);
 }
 
-#pragma mark - LISTENERS:
+#pragma mark - Listeners:
 
 TEST_CASE_METHOD(DocumentTest, "Collection Change Notifications", "[Document]") {
     // Add a listener:


### PR DESCRIPTION
* Enabled failed tests that have been fixed (CBL-3183 and CBL-3195)

* Made Close / Delete Database with Active Replicator less flaky from `Assertion failed: _driver && _driver->_peer` error.

* Removed "Get Non Existing Document" in DocumentTest.cc as duplicated.

* Renamed some tests in DocumentTest.cc