### PR TITLE
CBL-3588 : C++ API - Support collections in replicator

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -107,6 +107,8 @@
 		FC5FBBA62821B3450066157F /* CBLCollection_Internal.hh in Headers */ = {isa = PBXBuildFile; fileRef = FC5FBBA42821B3450066157F /* CBLCollection_Internal.hh */; };
 		FC5FBBB52821CC2E0066157F /* CBLCollection_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = FC5FBBB42821CC2E0066157F /* CBLCollection_CAPI.cc */; };
 		FC5FBBB72821E4970066157F /* CBLDatabase_Internal.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C9B5E021F655110040BC45 /* CBLDatabase_Internal.hh */; };
+		FC82CE0528C6E2BD001FA083 /* ReplicatorCollectionTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = FC82CE0428C6E2BD001FA083 /* ReplicatorCollectionTest_Cpp.cc */; };
+		FC82CE1328C6E2FD001FA083 /* ReplicatorCollectionTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = FC82CE0428C6E2BD001FA083 /* ReplicatorCollectionTest_Cpp.cc */; };
 		FC8678E4289C69470023F34F /* ReplicatorCollectionTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = FC8678E3289C69470023F34F /* ReplicatorCollectionTest.cc */; };
 		FC8678F2289C69690023F34F /* ReplicatorCollectionTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = FC8678E3289C69470023F34F /* ReplicatorCollectionTest.cc */; };
 		FCC063C928588DA6000C5BD7 /* CBLScope.cc in Sources */ = {isa = PBXBuildFile; fileRef = FCC063C828588DA6000C5BD7 /* CBLScope.cc */; };
@@ -411,6 +413,7 @@
 		FC5FBBA32821B3450066157F /* CBLCollection.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLCollection.cc; sourceTree = "<group>"; };
 		FC5FBBA42821B3450066157F /* CBLCollection_Internal.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CBLCollection_Internal.hh; sourceTree = "<group>"; };
 		FC5FBBB42821CC2E0066157F /* CBLCollection_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLCollection_CAPI.cc; sourceTree = "<group>"; };
+		FC82CE0428C6E2BD001FA083 /* ReplicatorCollectionTest_Cpp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReplicatorCollectionTest_Cpp.cc; sourceTree = "<group>"; };
 		FC8678E3289C69470023F34F /* ReplicatorCollectionTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReplicatorCollectionTest.cc; sourceTree = "<group>"; };
 		FCC063C828588DA6000C5BD7 /* CBLScope.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLScope.cc; sourceTree = "<group>"; };
 		FCC063F2285BA641000C5BD7 /* DocumentTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DocumentTest.cc; sourceTree = "<group>"; };
@@ -654,6 +657,7 @@
 				2736A625242E5A07002B9D65 /* ReplicatorTest.hh */,
 				277CC99422BC23DE00B245CB /* ReplicatorTest.cc */,
 				FC8678E3289C69470023F34F /* ReplicatorCollectionTest.cc */,
+				FC82CE0428C6E2BD001FA083 /* ReplicatorCollectionTest_Cpp.cc */,
 				2736A633242E5A74002B9D65 /* ReplicatorEETest.cc */,
 				93C70D1626CB334D0093E927 /* ReplicatorPropEncTest.cc */,
 				27D30F9123A2D30500392107 /* PerfTest.cc */,
@@ -1265,6 +1269,7 @@
 				275B358A23481D0C00FE9CF0 /* DatabaseTest.cc in Sources */,
 				93C70D1726CB334D0093E927 /* ReplicatorPropEncTest.cc in Sources */,
 				275B358B23481D0C00FE9CF0 /* DatabaseTest_Cpp.cc in Sources */,
+				FC82CE0528C6E2BD001FA083 /* ReplicatorCollectionTest_Cpp.cc in Sources */,
 				275B358C23481D0C00FE9CF0 /* BlobTest_Cpp.cc in Sources */,
 				27DBD095246C9573002FD7A7 /* LibC++Debug.cc in Sources */,
 				275B359F234D064600FE9CF0 /* QueryTest.cc in Sources */,
@@ -1312,6 +1317,7 @@
 				2736A634242E5A74002B9D65 /* ReplicatorEETest.cc in Sources */,
 				FC09078A28A5F40200201B07 /* CollectionTest_Cpp.cc in Sources */,
 				27D30F9F23A2D30500392107 /* PerfTest.cc in Sources */,
+				FC82CE1328C6E2FD001FA083 /* ReplicatorCollectionTest_Cpp.cc in Sources */,
 				27DBCF42246B81EE002FD7A7 /* LibC++Debug.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -95,13 +95,9 @@ namespace cbl {
     };
 
 // Internal use only: Copy/move ctors and assignment ops that have to be declared in subclasses
-#define CBL_REFCOUNTED_BOILERPLATE(CLASS, SUPER, C_TYPE) \
+#define CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE(CLASS, SUPER, C_TYPE) \
 public: \
     CLASS() noexcept                              :SUPER() { } \
-    CLASS(const CLASS &other) noexcept            :SUPER(other) { } \
-    CLASS(CLASS &&other) noexcept                 :SUPER((CLASS&&)other) { } \
-    CLASS& operator=(const CLASS &other) noexcept {SUPER::operator=(other); return *this;} \
-    CLASS& operator=(CLASS &&other) noexcept      {SUPER::operator=((SUPER&&)other); return *this;}\
     CLASS& operator=(std::nullptr_t)              {clear(); return *this;} \
     bool valid() const                            {return RefCounted::valid();} \
     explicit operator bool() const                {return valid();} \
@@ -109,9 +105,15 @@ public: \
     bool operator!=(const CLASS &other) const     {return _ref != other._ref;} \
     C_TYPE* _cbl_nullable ref() const             {return (C_TYPE*)_ref;}\
 protected: \
-    explicit CLASS(C_TYPE* ref)                   :SUPER((CBLRefCounted*)ref) { }
+    explicit CLASS(C_TYPE* _cbl_nullable ref)     :SUPER((CBLRefCounted*)ref) { }
 
-
+#define CBL_REFCOUNTED_BOILERPLATE(CLASS, SUPER, C_TYPE) \
+CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE(CLASS, SUPER, C_TYPE) \
+public: \
+    CLASS(const CLASS &other) noexcept            :SUPER(other) { } \
+    CLASS(CLASS &&other) noexcept                 :SUPER((SUPER&&)other) { } \
+    CLASS& operator=(const CLASS &other) noexcept {SUPER::operator=(other); return *this;} \
+    CLASS& operator=(CLASS &&other) noexcept      {SUPER::operator=((SUPER&&)other); return *this;}
 
     /** A token representing a registered listener; instances are returned from the various
         methods that register listeners, such as \ref Database::addListener.

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -202,4 +202,13 @@ namespace cbl {
     };
 }
 
+/** Hash function for Collection. */
+template<> struct std::hash<cbl::Collection> {
+    std::size_t operator() (cbl::Collection const& col) const {
+        auto name = CBLCollection_Name(col.ref());
+        auto scope = CBLScope_Name(CBLCollection_Scope(col.ref()));
+        return fleece::slice(name).hash() ^ fleece::slice(scope).hash();
+    }
+};
+
 CBL_ASSUME_NONNULL_END

--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -138,6 +138,24 @@ void CBLTest_Cpp::createNumberedDocs(cbl::Collection& collection, unsigned n, un
     }
 }
 
+void CBLTest_Cpp::createDoc(cbl::Collection& collection, std::string docID, std::string jsonContent) {
+    cbl::MutableDocument doc(docID);
+    doc.setPropertiesAsJSON(jsonContent);
+    collection.saveDocument(doc);
+}
+
+void CBLTest_Cpp::createDocs(cbl::Collection& collection, unsigned n, std::string idprefix) {
+    for (unsigned i = 0; i < n; i++) {
+        string docID = idprefix.append("-").append(to_string(i+1));
+        
+        char content[100];
+        sprintf(content, "This is the document #%03u.", i+1);
+        cbl::MutableDocument doc(docID);
+        doc["content"] = content;
+        collection.saveDocument(doc);
+    }
+}
+
 #pragma mark - Test Utils :
 
 string GetTestFilePath(const std::string &filename) {

--- a/test/CBLTest_Cpp.hh
+++ b/test/CBLTest_Cpp.hh
@@ -50,6 +50,10 @@ public:
     cbl::Database openDatabaseNamed(fleece::slice name);
     
     void createNumberedDocs(cbl::Collection& collection, unsigned n, unsigned start = 1);
+    
+    void createDoc(cbl::Collection& collection, std::string docID, std::string jsonContent);
+    
+    void createDocs(cbl::Collection& collection, unsigned n, std::string idprefix ="doc");
 
     cbl::Database db;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ set(TEST_SRC
     LogTest.cc
     QueryTest.cc
     ReplicatorCollectionTest.cc
+    ReplicatorCollectionTest_Cpp.cc
     ReplicatorEETest.cc
     ReplicatorPropEncTest.cc
     ReplicatorTest.cc

--- a/test/ReplicatorCollectionTest_Cpp.cc
+++ b/test/ReplicatorCollectionTest_Cpp.cc
@@ -1,0 +1,327 @@
+//
+// ReplicatorCollectionTest_Cpp.cc
+//
+// Copyright © 2022 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "CBLTest_Cpp.hh"
+#include "fleece/Fleece.hh"
+#include "fleece/Mutable.hh"
+#include <string>
+#include <chrono>
+//#include <iostream>
+#include <thread>
+
+#include "cbl++/CouchbaseLite.hh"
+
+using namespace std;
+using namespace fleece;
+using namespace cbl;
+
+#ifdef COUCHBASE_ENTERPRISE
+
+class ReplicatorCollectionTest_Cpp : public CBLTest_Cpp {
+public:
+    using clock    = chrono::high_resolution_clock;
+    using time     = clock::time_point;
+    using seconds  = chrono::duration<double, std::ratio<1,1>>;
+    
+    enum class IdleAction {
+        kStopReplicator,    ///< Stop Replicator
+        kContinueMonitor,   ///< Continue checking status
+        kFinishMonitor      ///< Finish checking status
+    };
+    
+    ReplicatorCollectionTest_Cpp()
+    :db2(openEmptyDatabaseNamed("otherDB"))
+    ,config({vector<ReplicationCollection>(), Endpoint()})
+    {
+        cx.push_back(db.createCollection("colA"_sl, "scopeA"_sl));
+        cx.push_back(db.createCollection("colB"_sl, "scopeA"_sl));
+        cx.push_back(db.createCollection("colC"_sl, "scopeA"_sl));
+        
+        cy.push_back(db2.createCollection("colA"_sl, "scopeA"_sl));
+        cy.push_back(db2.createCollection("colB"_sl, "scopeA"_sl));
+        cy.push_back(db2.createCollection("colC"_sl, "scopeA"_sl));
+    }
+    
+    ~ReplicatorCollectionTest_Cpp() { }
+    
+    vector<ReplicationCollection> replicationCollections(vector<Collection>collections) {
+        auto rcols = vector<ReplicationCollection>();
+        for (auto col : collections) {
+            rcols.push_back(ReplicationCollection(col));
+        }
+        return rcols;
+    }
+    
+    void createConfigWithCollections(vector<Collection>collections) {
+        createConfig(replicationCollections(collections));
+    }
+    
+    void createConfig(vector<ReplicationCollection>collections) {
+        Endpoint endpoint;
+        endpoint.setLocalDB(db2);
+        config = ReplicatorConfiguration(collections, endpoint);
+    }
+    
+    vector<CBLReplicationCollection> collectionConfigs(vector<CBLCollection*>collections) {
+        vector<CBLReplicationCollection> configs(collections.size());
+        for (int i = 0; i < collections.size(); i++) {
+            configs[i].collection = collections[i];
+        }
+        return configs;
+    }
+    
+    void replicate(bool reset =false) {
+        CBLReplicatorStatus status;
+        if (!repl) {
+            repl = Replicator(config);
+            status = repl.status();
+            CHECK(status.activity == kCBLReplicatorStopped);
+            CHECK(status.progress.complete == 0.0);
+            CHECK(status.progress.documentCount == 0);
+            CHECK(status.error.code == 0);
+        }
+        REQUIRE(repl);
+        
+        auto listener = repl.addChangeListener([&](Replicator r, const CBLReplicatorStatus& status) {
+            statusChanged(r, status);
+        });
+        
+        using DocumentReplicationListener = cbl::ListenerToken<Replicator, bool,
+            const std::vector<CBLReplicatedDocument>>;
+        
+        auto docListener = repl.addDocumentReplicationListener([&](Replicator r,
+                                                                   bool isPush,
+                                                                   const vector<CBLReplicatedDocument> docs) {
+            docProgress(r, isPush, docs);
+        });
+        
+        repl.start(reset);
+        
+        time start = clock::now();
+        cerr << "Waiting...\n";
+        while (std::chrono::duration_cast<seconds>(clock::now() - start).count() < timeoutSeconds) {
+            status = repl.status();
+            if (config.continuous && status.activity == kCBLReplicatorIdle) {
+                if (idleAction == IdleAction::kStopReplicator) {
+                    cerr << "Stop the continuous replicator...\n";
+                    repl.stop();
+                } else if (idleAction == IdleAction::kFinishMonitor) {
+                    break;
+                }
+            } else if (status.activity == kCBLReplicatorStopped)
+                break;
+            this_thread::sleep_for(100ms);
+        }
+        cerr << "Finished with activity=" << static_cast<int>(status.activity)
+             << ", complete=" << status.progress.complete
+             << ", documentCount=" << status.progress.documentCount
+             << ", error=(" << status.error.domain << "/" << status.error.code << ")\n";
+        
+        if (config.continuous && idleAction == IdleAction::kFinishMonitor)
+            CHECK(status.activity == kCBLReplicatorIdle);
+        else
+            CHECK(status.activity == kCBLReplicatorStopped);
+
+        if (expectedError.code > 0) {
+            CHECK(status.error.code == expectedError.code);
+            CHECK(status.progress.complete < 1.0);
+        } else {
+            CHECK(status.error.code == 0);
+            CHECK(status.progress.complete == 1.0);
+        }
+
+        if (expectedDocumentCount >= 0) {
+            CHECK(status.progress.documentCount == expectedDocumentCount);
+        }
+    }
+    
+    void statusChanged(Replicator& r, const CBLReplicatorStatus& status) {
+        CHECK(r == repl);
+        cerr << "--- PROGRESS: status=" << static_cast<int>(status.activity)
+             << ", fraction=" << status.progress.complete
+             << ", err=" << status.error.domain << "/" << status.error.code << "\n";
+    }
+    
+    void docProgress(Replicator& r, bool isPush, const vector<CBLReplicatedDocument>& docs) {
+        CHECK(r == repl);
+        cerr << "--- " << docs.size() << " docs " << (isPush ? "pushed" : "pulled") << ":";
+        cerr << "\n";
+    }
+    
+    void createDoc(cbl::Collection& collection, std::string docID) {
+        CBLTest_Cpp::createDoc(collection, docID, "{\"greeting\":\"hello\"}");
+    }
+    
+    Database db2;
+    vector<Collection> cx;
+    vector<Collection> cy;
+    
+    ReplicatorConfiguration config;
+    Replicator repl;
+    
+    double timeoutSeconds = 30.0;
+    IdleAction idleAction = IdleAction::kStopReplicator;
+    
+    CBLError expectedError = {};
+    int64_t expectedDocumentCount = -1;
+};
+
+TEST_CASE_METHOD(ReplicatorCollectionTest_Cpp, "C++ Create Replicator with zero collections", "[Replicator]") {
+    createConfigWithCollections({});
+    
+    ExpectingExceptions x;
+    CBLError error {};
+    try { auto r = Replicator(config); } catch (CBLError e) { error = e; }
+    CheckError(error, kCBLErrorInvalidParameter);
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest_Cpp, "C++ Create Replicator with legacy database", "[Replicator]") {
+    Endpoint endpoint;
+    endpoint.setLocalDB(db2);
+    
+    auto c = ReplicatorConfiguration(db, endpoint);
+    
+    auto docIDs = MutableArray::newArray();
+    docIDs.append("doc1"_sl);
+    c.documentIDs = docIDs;
+    
+    auto channels = MutableArray::newArray();
+    channels.append("a"_sl);
+    c.channels = channels;
+    
+    c.pushFilter = [](Document doc, CBLDocumentFlags flags) -> bool { return true; };
+    c.pullFilter = [](Document doc, CBLDocumentFlags flags) -> bool { return true; };
+    
+    c.conflictResolver = [](slice docID, const Document local, const Document remote) -> Document {
+        return remote;
+    };
+    
+    auto r = Replicator(c);
+    CHECK(r);
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest_Cpp, "C++ Single Shot Replication", "[Replicator]") {
+    createDocs(cx[0], 10);
+    createDocs(cx[1], 10);
+    createDocs(cy[0], 20, "doc2");
+    createDocs(cy[1], 20, "doc2");
+    
+    createConfigWithCollections({cx[0], cx[1]});
+    
+    SECTION("PUSH") {
+        config.replicatorType = kCBLReplicatorTypePush;
+        expectedDocumentCount = 20;
+        replicate();
+    }
+    
+    SECTION("PULL") {
+        config.replicatorType = kCBLReplicatorTypePull;
+        expectedDocumentCount = 40;
+        replicate();
+    }
+    
+    SECTION("PUSH-PULL") {
+        config.replicatorType = kCBLReplicatorTypePushAndPull;
+        expectedDocumentCount = 60;
+        replicate();
+    }
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest_Cpp, "C++ Continuous Replication", "[Replicator]") {
+    createDocs(cx[0], 10);
+    createDocs(cx[1], 10);
+    createDocs(cy[0], 20, "doc2");
+    createDocs(cy[1], 20, "doc2");
+    
+    createConfigWithCollections({cx[0], cx[1]});
+    config.continuous = true;
+    
+    SECTION("PUSH") {
+        config.replicatorType = kCBLReplicatorTypePush;
+        expectedDocumentCount = 20;
+        replicate();
+    }
+    
+    SECTION("PULL") {
+        config.replicatorType = kCBLReplicatorTypePull;
+        expectedDocumentCount = 40;
+        replicate();
+    }
+    
+    SECTION("PUSH-PULL") {
+        config.replicatorType = kCBLReplicatorTypePushAndPull;
+        expectedDocumentCount = 60;
+        replicate();
+    }
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest_Cpp, "C++ Collection Push Filters", "[Replicator][Current]") {
+    createDoc(cx[0], "foo1");
+    createDoc(cx[0], "foo2");
+    createDoc(cx[0], "foo3");
+    
+    createDoc(cx[1], "bar1");
+    createDoc(cx[1], "bar2");
+    createDoc(cx[1], "bar3");
+    
+    auto rcol1 = ReplicationCollection(cx[0]);
+    rcol1.pushFilter = [](Document doc, CBLDocumentFlags flags) -> bool {
+        string id = doc.id();
+        CHECK(doc.collection().name() == "colA");
+        CHECK(doc.collection().scopeName() == "scopeA");
+        return id == "foo1" || id == "foo3";
+    };
+    
+    auto rcol2 = ReplicationCollection(cx[1]);
+    rcol2.pushFilter = [](Document doc, CBLDocumentFlags flags) -> bool {
+        string id = doc.id();
+        CHECK(doc.collection().name() == "colB");
+        CHECK(doc.collection().scopeName() == "scopeA");
+        return id == "bar2";
+    };
+    
+    createConfig({rcol1, rcol2});
+    
+    config.replicatorType = kCBLReplicatorTypePush;
+    expectedDocumentCount = 3;
+    replicate();
+    
+    CHECK(cy[0].count() == 2);
+    
+    auto foo1 = cy[0].getDocument("foo1"_sl);
+    REQUIRE(foo1);
+    
+    auto foo2 = cy[0].getDocument("foo2"_sl);
+    REQUIRE(!foo2);
+    
+    auto foo3 = cy[0].getDocument("foo3"_sl);
+    REQUIRE(foo3);
+    
+    CHECK(cy[1].count() == 1);
+    
+    auto bar1 = cy[1].getDocument("bar1"_sl);
+    REQUIRE(!bar1);
+    
+    auto bar2 = cy[1].getDocument("bar2"_sl);
+    REQUIRE(bar2);
+    
+    auto bar3 = cy[1].getDocument("bar3"_sl);
+    REQUIRE(!bar3);
+}
+
+#endif


### PR DESCRIPTION
* Updated ReplicatorConfiguration class to have two constructors that accepts `Database`/`Endpoint` and `vector<ReplicationCollection>`/`Endpoint`. The database, endpoint, and vector of `ReplicationCollection` object will be immutable after the `ReplicatorConfiguration` is created.

* Made `Endpoint` and `Authenticator` class correctly copyable by keeping the C’s `ref` pointer in `shared_ptr.` This (especially for the `Endpoint`) is required otherwise the Endpoint object cannot be passed to the constructor of  the `ReplicatorConfiguration` class.

* When setting the C’s CBLReplicatorConfiguration’s context in the Replicator class, instead of using 'this' which is the Replicator object, use the new collection map which is a pointer to an `unordered_map<Collection, ReplicationCollection>` kept inside the `shared_ptr`. This is necessary because using 'this' will be incorrect as soon as the Replicator object is copied.

* To support the implementation in the Replicator class, added `CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE` preprocessor as the Replicator class needs a custom copy and move constructors / assignments.

* Add some initial tests in `ReplictorCollectionTest_Cpp.cc` to confirm that the implementation of the API is correct. There will be more tests added separately.