### PR TITLE
Update version number in xcconfig to 3.0.3

### DIFF
--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -11,7 +11,7 @@
 LITECORE    = vendor/couchbase-lite-core
 FLEECE      = $(LITECORE)/vendor/fleece
 
-CBL_VERSION_STRING                                 = 3.0.2
+CBL_VERSION_STRING                                 = 3.0.3
 CBL_BUILD_NUMBER                                   = 0
 
 IPHONEOS_DEPLOYMENT_TARGET                         = 10.0


### PR DESCRIPTION
Understand that Jenkins will pass the version number when building the xcframework (Need double check). This change is at least for code consistency.