### PR TITLE
CBL-3685 : Fix pointer leak in CPP's bufferNotifications()

### DIFF
--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -312,7 +312,7 @@ typedef void (*CBLNotificationsReadyCallback)(void* _cbl_nullable context,
     @param callback  The function to be called when a notification is available.
     @param context  An arbitrary value that will be passed to the callback. */
 void CBLDatabase_BufferNotifications(CBLDatabase *db,
-                                     CBLNotificationsReadyCallback callback,
+                                     CBLNotificationsReadyCallback _cbl_nullable callback,
                                      void* _cbl_nullable context) CBLAPI;
 
 /** Immediately issues all pending notifications for this database, by calling their listener

--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -177,7 +177,7 @@ public:
         _notificationQueue.notifyAll();
     }
 
-    void bufferNotifications(CBLNotificationsReadyCallback callback, void *context) {
+    void bufferNotifications(CBLNotificationsReadyCallback _cbl_nullable callback, void* _cbl_nullable context) {
         _notificationQueue.setCallback(callback, context);
     }
 

--- a/src/Listener.hh
+++ b/src/Listener.hh
@@ -193,7 +193,7 @@ namespace cbl_internal {
         NotificationQueue(CBLDatabase*);
 
         /** Sets or clears the client callback. */
-        void setCallback(CBLNotificationsReadyCallback callback, void* _cbl_nullable context);
+        void setCallback(CBLNotificationsReadyCallback _cbl_nullable callback, void* _cbl_nullable context);
 
         /** If there is a callback, this adds a notification to the queue, and if the queue was
             empty, invokes the callback to tell the client.


### PR DESCRIPTION
* Created NotificationsReadyCallbackAccess class for keeping and calling the callback function thread safely.

* Instead of simply creating and using NotificationsReadyCallback pointer which is leaking, use a share pointer of NotificationsReadyCallbackAccess to the Database class so that it can shared among the copied of the Database objects and can be freed when all copied of the Database objects are gone.