### PR TITLE
Update LiteCore to 3.1.0-249

### DIFF
--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -230,7 +230,7 @@ TEST_CASE_METHOD(QueryTest, "Create and Delete Value Index", "[Query]") {
                                     &errPos, &error);
     
     alloc_slice explanation1(CBLQuery_Explain(query));
-    CHECK(explanation1.find("SCAN TABLE kv_default AS _ USING INDEX index1"_sl));
+    CHECK(explanation1.find("USING INDEX index1"_sl));
     CBLQuery_Release(query);
     
     query = CBLDatabase_CreateQuery(db, kCBLN1QLLanguage,
@@ -238,7 +238,7 @@ TEST_CASE_METHOD(QueryTest, "Create and Delete Value Index", "[Query]") {
                                     &errPos, &error);
     
     alloc_slice explanation2(CBLQuery_Explain(query));
-    CHECK(explanation2.find("SCAN TABLE kv_default AS _ USING INDEX index2"_sl));
+    CHECK(explanation2.find("USING INDEX index2"_sl));
     CBLQuery_Release(query);
     query = nullptr;
     
@@ -277,7 +277,8 @@ TEST_CASE_METHOD(QueryTest, "Create and Delete Full-Text Index", "[Query]") {
                                     &errPos, &error);
     
     alloc_slice explanation1(CBLQuery_Explain(query));
-    CHECK(explanation1.find("SCAN TABLE kv_default::index1 AS fts1"_sl));
+    CHECK(explanation1.find("JOIN \"kv_default::index1\" AS fts1"));
+    CHECK(explanation1.find("SCAN fts1 VIRTUAL TABLE INDEX"_sl));
     CBLQuery_Release(query);
     
     query = CBLDatabase_CreateQuery(db, kCBLN1QLLanguage,
@@ -285,7 +286,8 @@ TEST_CASE_METHOD(QueryTest, "Create and Delete Full-Text Index", "[Query]") {
                                     &errPos, &error);
     
     alloc_slice explanation2(CBLQuery_Explain(query));
-    CHECK(explanation2.find("SCAN TABLE kv_default::index2 AS fts1"_sl));
+    CHECK(explanation2.find("JOIN \"kv_default::index2\" AS fts1"));
+    CHECK(explanation2.find("SCAN fts1 VIRTUAL TABLE INDEX"_sl));
     CBLQuery_Release(query);
     query = nullptr;
     

--- a/test/ReplicatorPropEncTest.cc
+++ b/test/ReplicatorPropEncTest.cc
@@ -782,7 +782,6 @@ TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest, "Key ID and Algorithm", "[Rep
 }
 
 TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest, "Encrypt and decrypt with collections", "[Replicator][Encryptable]") {
-    CBLLog_SetConsoleLevel(kCBLLogVerbose);
     auto c1x = CreateCollection(db.ref(), "colA", "scopeA");
     auto c2x = CreateCollection(db.ref(), "colB", "scopeA");
     

--- a/test/ReplicatorTest.hh
+++ b/test/ReplicatorTest.hh
@@ -219,7 +219,7 @@ public:
         CBLEndpoint_Free(config.endpoint);
         
         // For async clean up in Replicator:
-        this_thread::sleep_for(200ms);
+        this_thread::sleep_for(500ms);
     }
 
     static vector<string> asVector(const set<string> strings) {


### PR DESCRIPTION
* Updated LiteCore to 3.1.0-249
* Update QueryTest’s tests that check explain string as the format has been changed by SQLite.
* Bump async replicator clean up delay to 500ms to avoid flakey failure when checking instance leaks.
* Removed verbose log enabled for debugging from a ReplicatorPropertyEncryptionTest’s test.