### PR TITLE
CBL-2783 : Add more C++ Replicator Tests and Fix bug

### DIFF
--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -429,7 +429,6 @@ namespace cbl {
             CBLError error;
             fleece::Dict result = CBLReplicator_PendingDocumentIDs(ref(), &error);
             check(result != nullptr, error);
-            FLDict_Release(result);  // remove the extra ref the C function returned with
             return result;
         }
 
@@ -461,7 +460,6 @@ namespace cbl {
             CBLError error;
             fleece::Dict result = CBLReplicator_PendingDocumentIDs2(ref(), collection.ref(), &error);
             check(result != nullptr, error);
-            FLDict_Release(result);  // remove the extra ref the C function returned with
             return result;
         }
         

--- a/src/CBLReplicator_CAPI.cc
+++ b/src/CBLReplicator_CAPI.cc
@@ -95,8 +95,10 @@ FLDict _cbl_nullable CBLReplicator_PendingDocumentIDs2(CBLReplicator* repl,
                                                        CBLError* _cbl_nullable outError) noexcept {
     try {
         auto result = FLDict_Retain(repl->pendingDocumentIDs(collection));
-        if (!result)
+        if (!result) {
+            result = FLMutableDict_New();
             if (outError) outError->code = 0;
+        }
         return result;
     } catchAndBridge(outError)
 }

--- a/test/ReplicatorCollectionTest.cc
+++ b/test/ReplicatorCollectionTest.cc
@@ -950,6 +950,21 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Collection Document Pending", "[Repl
     expectedDocumentCount = 5;
     replicate();
     
+    // Check Pending Docs:
+    pending1 = CBLReplicator_PendingDocumentIDs2(repl, cx[0], &error);
+    REQUIRE(pending1);
+    CHECK(FLDict_Count(pending1) == 0);
+    FLDict_Release(pending1);
+    
+    CHECK(!CBLReplicator_IsDocumentPending2(repl, "foo2"_sl, cx[0], &error));
+    
+    pending2 = CBLReplicator_PendingDocumentIDs2(repl, cx[1], &error);
+    REQUIRE(pending2);
+    CHECK(FLDict_Count(pending2) == 0);
+    FLDict_Release(pending2);
+    
+    CHECK(!CBLReplicator_IsDocumentPending2(repl, "bar1"_sl, cx[1], &error));
+    
     // Upadate Docs:
     auto foo2 = CBLCollection_GetMutableDocument(cx[0], "foo2"_sl, &error);
     REQUIRE(foo2);


### PR DESCRIPTION
* Added more C++ Replicator Tests

* Fixed bug that an empty dict should be returned when there is no pending doc ids instead of NULL.

* Fixed crash from returned released pending doc ids dictionary.