### PR TITLE
CBL-3684 : Set default version number in XCode project to 0.0.0

### DIFF
--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -11,8 +11,8 @@
 LITECORE    = vendor/couchbase-lite-core
 FLEECE      = $(LITECORE)/vendor/fleece
 
-CBL_VERSION_STRING                                 = 3.0.0
-CBL_BUILD_NUMBER                                   = 0
+CBL_VERSION_STRING                                 = 0.0.0 // The actual version number will be set by Jenkins Build.
+CBL_BUILD_NUMBER                                   = 0     // The actual build number will be set by Jenkins Build.
 
 IPHONEOS_DEPLOYMENT_TARGET                         = 10.0
 MACOSX_DEPLOYMENT_TARGET                           = 10.14


### PR DESCRIPTION
* The actual Version and Build Number is set by Jenkins when building the iOS frameworks. The version and build number is currently passed from `jenkins/ci_build_ios.sh` to `scripts/build_apple.sh` via `VERSION` and `BLD_NUM` env variable. As it’s already working correctly, there is nothing to fix here.

* To avoid confusion in the future, set the default version number in `Project.xcconfig` to 0.0.0 and added comments.