### PR TITLE
CBL-3611 : Fix pending conflicts not being called to resolve (Port)

### DIFF
--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -88,7 +88,7 @@ public:
 
     uint64_t sequence() const {
         auto c4doc = _c4doc.useLocked();
-        return c4doc ? c4doc->sequence() : 0;
+        return c4doc ? static_cast<uint64_t>(c4doc->selectedRev().sequence) : 0;
     }
 
 
@@ -233,8 +233,10 @@ public:
         _properties = nullptr;
         _fromJSON = nullptr;
         while (c4doc->selectNextLeafRevision(true, true))
-            if (c4doc->selectedRev().flags & kRevIsConflict)
+            if (c4doc->selectedRev().flags & kRevIsConflict) {
+                _revID = c4doc->selectedRev().revID;
                 return true;
+            }
         return false;
     }
 

--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -312,7 +312,7 @@ private:
         
         for (size_t i = 0; i < numDocs; ++i) {
             auto src = *c4Docs[i];
-            if (!pushing && src.flags & kRevIsConflict) {
+            if (!pushing && src.error.code == kC4ErrorConflict && src.error.domain == LiteCoreDomain) {
                 // Conflict -- start an async resolver task:
                 auto r = new ConflictResolver(_db, _conf.conflictResolver, _conf.context, src);
                 bumpConflictResolverCount(1);

--- a/src/ConflictResolver.hh
+++ b/src/ConflictResolver.hh
@@ -23,8 +23,7 @@ namespace cbl_internal {
         ConflictResolver(CBLDatabase *db,
                          CBLConflictResolver _cbl_nullable customResolver,
                          void* _cbl_nullable context,
-                         alloc_slice docID,
-                         alloc_slice revID = nullslice);
+                         alloc_slice docID);
 
         ConflictResolver(CBLDatabase*,
                          CBLConflictResolver _cbl_nullable,
@@ -54,7 +53,6 @@ namespace cbl_internal {
         CBLConflictResolver _cbl_nullable _clientResolver;
         void* _cbl_nullable     _clientResolverContext;
         alloc_slice const       _docID;
-        alloc_slice             _revID;
         C4RevisionFlags         _flags {};
         CompletionHandler       _completionHandler;
         CBLError                _error {};


### PR DESCRIPTION
* Port fix (b8f77dde64b241399fc3fa0f2cc89d4ebf8f3771) from master branch (Original issue CBL-3609)

* Changed the conflict detection and conflict revision to be the same as the logic in the other platforms so that the code doesn’t use inaccurate revision flags and revID from the DocumentEnded (CBL-3610).

* With the new logic, no needs to pass revID from DocumentEnded to ConflictResolver class so removing _revID from the class.

* Fixed a bug in ConflictResolver::runNow() that doesn’t reset inConflict to false when resolving is successful.

* Fixed bugs in CBLDocument that doesn’t use revID and sequence from selected revision (e.g. when conflicting revision is selected).

* Added "Resolve Pending Conflicts" Test.