### PR TITLE
CBL-2815 : Add default constructor to Query::ChangeListener

### DIFF
--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -216,12 +216,17 @@ namespace cbl {
 
     class Query::ChangeListener : public ListenerToken<Change> {
     public:
+        ChangeListener(): ListenerToken<Change>() { }
+        
         ChangeListener(Query query, Callback cb)
         :ListenerToken<Change>(cb)
         ,_query(std::move(query))
         { }
 
         ResultSet results() {
+            if (!_query) {
+                throw std::runtime_error("Not allowed to call on uninitialized ChangeListeners");
+            }
             return getResults(_query, token());
         }
 

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -949,6 +949,79 @@ TEST_CASE_METHOD(QueryTest_Cpp, "Query Listener C++ API", "[Query]") {
     this_thread::sleep_for(500ms);
 }
 
+TEST_CASE_METHOD(QueryTest_Cpp, "Empty Query Listener C++", "[Query]") {
+    Query::ChangeListener listenerToken;
+    CHECK(!listenerToken.context());
+    CHECK(!listenerToken.token());
+    
+    bool threw = false;
+    try {
+        ExpectingExceptions x;
+        listenerToken.results();
+    } catch(runtime_error &x) {
+        threw = true;
+    }
+    CHECK(threw);
+    
+    listenerToken.remove(); // Noops
+}
+
+TEST_CASE_METHOD(QueryTest_Cpp, "Query Listener C++ Move Operation", "[Query]") {
+    Query query(db, kCBLN1QLLanguage, "SELECT name FROM _ WHERE birthday like '1959-%' ORDER BY birthday");
+    
+    std::atomic_int resultCount{-1};
+    
+    Query::ChangeListener listenerToken;
+    
+    // Move assignment:
+    listenerToken = query.addChangeListener([&](Query::Change change) {
+        ResultSet rs = change.results();
+        resultCount = countResults(rs);
+        CHECK(change.query() == query);
+    });
+    
+    CHECK(listenerToken.context());
+    CHECK(listenerToken.token());
+    
+    // Waiting for the first called:
+    while (resultCount < 0)
+        this_thread::sleep_for(100ms);
+    CHECK(resultCount == 3);
+    resultCount = -1;
+    
+    // Move constructor:
+    Query::ChangeListener listenerToken2 = move(listenerToken);
+    CHECK(listenerToken2.context());
+    CHECK(listenerToken2.token());
+    
+#ifndef __clang_analyzer__ // Exclude the code from being compiled for analyzer
+    CHECK(!listenerToken.context());
+    CHECK(!listenerToken.token());
+    listenerToken.remove(); // Noops
+#endif
+
+    cerr << "Deleting a doc...\n";
+    Document doc = db.getDocument("0000012");
+    REQUIRE(doc);
+    REQUIRE(db.deleteDocument(doc, kCBLConcurrencyControlLastWriteWins));
+
+    cerr << "Waiting for listener again...\n";
+    while (resultCount < 0)
+        this_thread::sleep_for(100ms);
+    CHECK(resultCount == 2);
+    
+    listenerToken2.remove();
+    CHECK(!listenerToken2.context());
+    CHECK(!listenerToken2.token());
+    
+    // https://issues.couchbase.com/browse/CBL-2147
+    // Add a small sleep to ensure async cleanup in LiteCore's LiveQuerier's _stop() when the
+    // listenerToken is destructed is done bfore before checking instance leaking in
+    // CBLTest_Cpp's destructor:
+    cerr << "Sleeping to ensure async cleanup ..." << endl;
+    this_thread::sleep_for(500ms);
+}
+
 TEST_CASE_METHOD(QueryTest_Cpp, "C++ Query Parameters", "[Query]") {
     Query query = Query(db, kCBLN1QLLanguage, "SELECT count(*) AS n FROM _ WHERE contact.address.zip BETWEEN $zip0 AND $zip1");
     CHECK(!query.parameters());


### PR DESCRIPTION
* As part of investigating CBL-2815 issue reported by the user that the `Query::ChangeListener`, a subclass of `ListenerToken` class, is not moveable, I have found that the example given by the user is not working as well because the Query::ChangeListener can not pre-declared as a class member as it doesn’t have the defualt constructor explictly defined.

* This basically makes the `Query::ChangeListener` different from the other listeners such as CollectionChangeListener, which is a direct type of the `ListenerToken` class which does have a default constructor.

* This commit basically adds a default constructor the Query::ChangeListener. Also, for an empy or null QueryListener, do not allow to call results() by throwing a runtime exception as there is no query and token object to use.