### PR TITLE
Wait for listener callbacks to finish when removing listener

### DIFF
--- a/src/CBLCollection.cc
+++ b/src/CBLCollection.cc
@@ -52,16 +52,15 @@ namespace cbl_internal {
         }
 
         CBLCollectionDocumentChangeListener callback() const {
-            return (CBLCollectionDocumentChangeListener)_callback.load();
+            return (CBLCollectionDocumentChangeListener)_callback;
         }
 
         // this is called indirectly by CBLDatabase::sendNotifications
         void call(CBLDocumentChange change) {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
             auto cb = callback();
             if (cb) {
-                willRunCallback();
                 cb(_context, &change);
-                didRunCallback();
             }
         }
 

--- a/src/CBLQuery_Internal.hh
+++ b/src/CBLQuery_Internal.hh
@@ -201,16 +201,14 @@ namespace cbl_internal {
         void setEnabled(bool enabled);
 
         CBLQueryChangeListener callback() const {
-            return (CBLQueryChangeListener)_callback.load();
+            return (CBLQueryChangeListener)_callback;
         }
 
         void call() {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
             CBLQueryChangeListener cb = callback();
-            if (cb) {
-                willRunCallback();
+            if (cb)
                 cb(_context, _query, this);
-                didRunCallback();
-            }
         }
 
         Retained<CBLResultSet> resultSet() {

--- a/src/CBLQuery_Internal.hh
+++ b/src/CBLQuery_Internal.hh
@@ -184,7 +184,7 @@ namespace cbl_internal {
                 _c4obs = c4query->observe([this](C4QueryObserver*) { this->queryChanged(); });
             });
         }
-        
+
         ~ListenerToken() {
             // Note:
             // When calling CBLListener_Remove(CBLListenerToken*), the ListenerToken object
@@ -206,20 +206,23 @@ namespace cbl_internal {
 
         void call() {
             CBLQueryChangeListener cb = callback();
-            if (cb)
+            if (cb) {
+                willRunCallback();
                 cb(_context, _query, this);
+                didRunCallback();
+            }
         }
 
         Retained<CBLResultSet> resultSet() {
             return new CBLResultSet(_query, _c4obs->getEnumerator(false));
         }
-        
+
         // CBLStoppable :
-        
+
         void stop() override {
             setEnabled(false);
         }
-        
+
     private:
         void queryChanged();    // defn is in CBLDatabase.cc, to prevent circular hdr dependency
 

--- a/src/Listener.cc
+++ b/src/Listener.cc
@@ -20,21 +20,12 @@
 
 using namespace std;
 
-thread_local bool CBLListenerToken::_inCallback = false;
 
 void CBLListenerToken::remove() {
     auto oldOwner = _owner;
     if (oldOwner) {
-        _callback = nullptr;
-        _owner = nullptr;
+        removed();
         oldOwner->remove(this);
-
-        // If the listener is removed from within its callback, don't wait for it to finish.
-        // Otherwise the callback would deadlock waiting for itself to finish.
-        if (!_inCallback) {
-            std::unique_lock lock(_mutex);
-            _cv.wait(lock, [this]{return _runningCallbacks == 0;});
-        }
     }
 }
 

--- a/src/Listener.cc
+++ b/src/Listener.cc
@@ -20,6 +20,7 @@
 
 using namespace std;
 
+thread_local bool CBLListenerToken::_inCallback = false;
 
 void CBLListenerToken::remove() {
     auto oldOwner = _owner;
@@ -27,6 +28,13 @@ void CBLListenerToken::remove() {
         _callback = nullptr;
         _owner = nullptr;
         oldOwner->remove(this);
+
+        // If the listener is removed from within its callback, don't wait for it to finish.
+        // Otherwise the callback would deadlock waiting for itself to finish.
+        if (!_inCallback) {
+            std::unique_lock lock(_mutex);
+            _cv.wait(lock, [this]{return _runningCallbacks == 0;});
+        }
     }
 }
 


### PR DESCRIPTION
Before this change it was possible that a callback was executing even after the call to remove a listener has returned.

This is a problem if the callback context is immediately destroyed after the listener has been removed. The callback might continue to access the now invalid context.