### PR TITLE
Fix XCode CouchbaseLiteTests target

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -825,6 +825,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 275B3584234812C800FE9CF0 /* Build configuration list for PBXNativeTarget "CouchbaseLiteTests" */;
 			buildPhases = (
+				FCB96EC5290341B2001C4DED /* Generate CBL_Edition.h */,
 				275B3578234812C700FE9CF0 /* Sources */,
 				275B3579234812C700FE9CF0 /* Frameworks */,
 				275B357A234812C700FE9CF0 /* Resources */,
@@ -1225,6 +1226,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\ncp \"$SCRIPT_INPUT_FILE_0\" \"$SCRIPT_OUTPUT_FILE_0\"\n";
+		};
+		FCB96EC5290341B2001C4DED /* Generate CBL_Edition.h */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Xcode/generate_edition_header.sh",
+			);
+			name = "Generate CBL_Edition.h";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/CBL_Edition.h",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "source \"$SCRIPT_INPUT_FILE_0\" \"$SCRIPT_OUTPUT_FILE_0\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Xcode/xcconfigs/XCTests.xcconfig
+++ b/Xcode/xcconfigs/XCTests.xcconfig
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Couchbase. All rights reserved.
 //
 
-HEADER_SEARCH_PATHS     = include  Xcode/generated_headers  $(FLEECE)/API  $(FLEECE)/Fleece/Support  $(FLEECE)/vendor/catch
+HEADER_SEARCH_PATHS     = include  Xcode/generated_headers/public/cbl  $(FLEECE)/API  $(FLEECE)/Fleece/Support  $(FLEECE)/vendor/catch
 
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/.. @loader_path/..
 


### PR DESCRIPTION
* Added Generate Header Build phrase script to CouchbaseLiteTests target so that it can be built and run.

* Note: CouchbaseLiteTests target allows to run Catch2 tests as an XCTest test on macOS. This is very useful for using XCode to profile tests.