### PR TITLE
Fix nullable warning in CBLListenerToken

### DIFF
--- a/src/Listener.hh
+++ b/src/Listener.hh
@@ -73,7 +73,7 @@ protected:
     /** Must be held when accessing _callback and while running it.
         https://github.com/couchbase/couchbase-lite-C/pull/372 */
     std::recursive_mutex                       _mutex;
-    const void*                                _callback;          // Really a C fn pointer
+    const void*  _cbl_nullable                 _callback;          // Really a C fn pointer
     void* const  _cbl_nullable                 _context;
     C4ExtraInfo                                _extraInfo = {};
 


### PR DESCRIPTION
Added _cbl_nullable to the _callback as it could be null (e.g. after the token is removed).