### PR TITLE
CBL-3834 : Wait for listener callbacks to finish when removing listener (Port)

### DIFF
--- a/src/CBLDatabase.cc
+++ b/src/CBLDatabase.cc
@@ -116,11 +116,12 @@ namespace cbl_internal {
         }
 
         CBLDocumentChangeListener callback() const {
-            return (CBLDocumentChangeListener)_callback.load();
+            return (CBLDocumentChangeListener)_callback;
         }
 
         // this is called indirectly by CBLDatabase::sendNotifications
         void call(const CBLDatabase*, FLString) {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
             auto cb = callback();
             if (cb)
                 cb(_context, _db, _docID);

--- a/src/CBLQuery_Internal.hh
+++ b/src/CBLQuery_Internal.hh
@@ -183,7 +183,7 @@ namespace cbl_internal {
                 _c4obs = c4query->observe([this](C4QueryObserver*) { this->queryChanged(); });
             });
         }
-        
+
         ~ListenerToken() {
             // Note:
             // When calling CBLListener_Remove(CBLListenerToken*), the ListenerToken object
@@ -200,10 +200,11 @@ namespace cbl_internal {
         void setEnabled(bool enabled);
 
         CBLQueryChangeListener callback() const {
-            return (CBLQueryChangeListener)_callback.load();
+            return (CBLQueryChangeListener)_callback;
         }
 
         void call() {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
             CBLQueryChangeListener cb = callback();
             if (cb)
                 cb(_context, _query, this);
@@ -212,13 +213,13 @@ namespace cbl_internal {
         Retained<CBLResultSet> resultSet() {
             return new CBLResultSet(_query, _c4obs->getEnumerator(false));
         }
-        
+
         // CBLStoppable :
-        
+
         void stop() override {
             setEnabled(false);
         }
-        
+
     private:
         void queryChanged();    // defn is in CBLDatabase.cc, to prevent circular hdr dependency
 

--- a/src/Listener.cc
+++ b/src/Listener.cc
@@ -24,8 +24,7 @@ using namespace std;
 void CBLListenerToken::remove() {
     auto oldOwner = _owner;
     if (oldOwner) {
-        _callback = nullptr;
-        _owner = nullptr;
+        removed();
         oldOwner->remove(this);
     }
 }


### PR DESCRIPTION
* Port fix from the master branch (https://github.com/couchbase/couchbase-lite-C/commit/15eb54a93664915e6c400f55528021bed0213c44) for 3.0.6-MR.

* Wait for listener callbacks to finish when removing listener

* Use `recursive_mutex` to lock in CBLListenerToken's removed() and in ListenerToken's call(). 

* In ListenerToken's call(), allow to call the callback under the recursive lock as the lock is not shared and is only per a ListenerToken object.