### PR TITLE
Fix another nullable return function warnings

### DIFF
--- a/src/CBLCollection.cc
+++ b/src/CBLCollection.cc
@@ -51,7 +51,7 @@ namespace cbl_internal {
             }
         }
 
-        CBLCollectionDocumentChangeListener callback() const {
+        CBLCollectionDocumentChangeListener _cbl_nullable callback() const {
             return (CBLCollectionDocumentChangeListener)_callback;
         }
 

--- a/src/CBLQuery_Internal.hh
+++ b/src/CBLQuery_Internal.hh
@@ -200,7 +200,7 @@ namespace cbl_internal {
 
         void setEnabled(bool enabled);
 
-        CBLQueryChangeListener callback() const {
+        CBLQueryChangeListener _cbl_nullable callback() const {
             return (CBLQueryChangeListener)_callback;
         }
 

--- a/src/Listener.hh
+++ b/src/Listener.hh
@@ -91,7 +91,7 @@ namespace cbl_internal {
         :CBLListenerToken((const void*)callback, context)
         { }
 
-        LISTENER callback() const           {return (LISTENER)_callback;}
+        LISTENER _cbl_nullable callback() const {return (LISTENER)_callback;}
 
         template <class... Args>
         void call(Args... args) {


### PR DESCRIPTION
Tagged all ListenerToken’s callback() functions as nullable.