### PR TITLE
CBL-2914 : Crash while stopping live query when closing db

### DIFF
--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -340,7 +340,7 @@ private:
         
         // Call stop outside lock to prevent deadlock:
         for (auto s : stoppables) {
-            s->stopStoppable();
+            s->stop();
         }
         
         std::unique_lock<std::mutex> lock(_stopMutex);
@@ -359,7 +359,7 @@ private:
         
         if (_stoppables.find(stoppable) == _stoppables.end()) {
             _stoppables.insert(stoppable);
-            stoppable->retainStoppable();
+            stoppable->retain();
         }
         
         return true;
@@ -368,7 +368,7 @@ private:
     void unregisterStoppable(CBLStoppable* stoppable) {
         LOCK(_stopMutex);
         if (_stoppables.erase(stoppable) > 0) {
-            stoppable->releaseStoppable();
+            stoppable->release();
         }
         _stopCond.notify_one();
     }

--- a/src/CBLQuery.cc
+++ b/src/CBLQuery.cc
@@ -34,7 +34,7 @@ void ListenerToken<CBLQueryChangeListener>::setEnabled(bool enabled) {
     
     CBLDatabase* db = const_cast<CBLDatabase*>(_query->database());
     if (enabled) {
-        if (!db->registerStoppable(this)) {
+        if (!db->registerStoppable(_stoppable.get())) {
             CBL_Log(kCBLLogDomainQuery, kCBLLogWarning,
                     "Couldn't enable the Query Listener as the database is closing or closed.");
             return;
@@ -44,7 +44,7 @@ void ListenerToken<CBLQueryChangeListener>::setEnabled(bool enabled) {
     _c4obs->setEnabled(enabled);
     _isEnabled = enabled;
     if (!enabled)
-        db->unregisterStoppable(this);
+        db->unregisterStoppable(_stoppable.get());
 }
 
 

--- a/src/CBLQuery.cc
+++ b/src/CBLQuery.cc
@@ -28,6 +28,10 @@ using namespace fleece;
 
 void ListenerToken<CBLQueryChangeListener>::setEnabled(bool enabled) {
     auto c4query = _query->_c4query.useLocked();
+    
+    if (enabled == _isEnabled)
+        return;
+    
     CBLDatabase* db = const_cast<CBLDatabase*>(_query->database());
     if (enabled) {
         if (!db->registerStoppable(this)) {
@@ -36,7 +40,9 @@ void ListenerToken<CBLQueryChangeListener>::setEnabled(bool enabled) {
             return;
         }
     }
+    
     _c4obs->setEnabled(enabled);
+    _isEnabled = enabled;
     if (!enabled)
         db->unregisterStoppable(this);
 }

--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -240,8 +240,7 @@ public:
     CBLDatabase* database() const                           {return _db;}
     void setHostReachable(bool reachable)                   {_c4repl->setHostReachable(reachable);}
     void setSuspended(bool suspended)                       {_c4repl->setSuspended(suspended);}
-    void stop() override                                    {_c4repl->stop();}
-
+    void stop()                                             {_c4repl->stop();}
 
     void start(bool reset) {
         LOCK(_mutex);
@@ -304,6 +303,13 @@ public:
         }
         return _docListeners.add(listener, context);
     }
+    
+    
+    // CBLStoppable :
+    
+    void stopStoppable() override                           {stop();}
+    void retainStoppable() override                         {retain(this);}
+    void releaseStoppable() override                        {release(this);}
 
 private:
 

--- a/src/Internal.hh
+++ b/src/Internal.hh
@@ -48,10 +48,19 @@ protected:
     when there is an API call to unregister the object. The database will also retain the object when the object is registered,
     and will release the object when the object is unregistered to ensure that the object is alive until the object is unregistered. */
 struct CBLStoppable {
-    virtual ~CBLStoppable() = default;
-    virtual void stopStoppable() = 0;
-    virtual void retainStoppable() = 0;
-    virtual void releaseStoppable() = 0;
+public:
+    CBLStoppable(CBLRefCounted* ref)
+    :_ref(ref)
+    {}
+    
+    virtual ~CBLStoppable()                             =default;
+    virtual void stop() const                           =0;
+    
+    void retain()                                       {fleece::retain(_ref);}
+    void release()                                      {fleece::release(_ref);}
+    
+protected:
+    CBLRefCounted* _ref;
 };
 
 

--- a/src/Internal.hh
+++ b/src/Internal.hh
@@ -43,9 +43,15 @@ protected:
 };
 
 
+/** CBLStoppable objects can be registered / unregisted to / from the database. The registered object will be called
+    to stop() when the database is closed. The object will be unregistered either after the object is called to stop() or
+    when there is an API call to unregister the object. The database will also retain the object when the object is registered,
+    and will release the object when the object is unregistered to ensure that the object is alive until the object is unregistered. */
 struct CBLStoppable {
     virtual ~CBLStoppable() = default;
-    virtual void stop() = 0;
+    virtual void stopStoppable() = 0;
+    virtual void retainStoppable() = 0;
+    virtual void releaseStoppable() = 0;
 };
 
 

--- a/src/Listener.cc
+++ b/src/Listener.cc
@@ -24,6 +24,7 @@ using namespace std;
 void CBLListenerToken::remove() {
     auto oldOwner = _owner;
     if (oldOwner) {
+        willRemove();
         removed();
         oldOwner->remove(this);
     }

--- a/src/Listener.hh
+++ b/src/Listener.hh
@@ -55,6 +55,11 @@ public:
 
     /** Called by `CBLListener_Remove` */
     void remove();
+    
+    /** Called by the remove() function before removing the token from the owner.
+        Subclasses can override this function to perform any tasks such as
+        stopping the underlinging observer and etc before the token is removed. */
+    virtual void willRemove() { }
 
     /** For attaching some extra info. For example, use the extraInfo for keeping a listener
         and its context when wrapping the to pass the listener to another listener. */


### PR DESCRIPTION
* PROBLEM : There could be a race b/w explicitly removing the query’s listener token and stopping the live query when closing the database on two different threads. If the listener token is released before the the database calls the live query (a pain CBLStoppable pointer) to stop, crash will happen.

* Fixed the issue by making the database retains the CBLStoppable objects when they are registered and releases the CBLStoppable objects when they are unregistered. This will ensure that objects are alive until they are unregistered.

* Changed CBLStoppable class to have two virtual functions for retaining and releasing the object. Also renaming the stop() function to stopStoppable() for naming consistency.

* Prevented circular call to unregister live query which could lead to a deadlock.