### PR TITLE
CBL-2397: CBL-C CMake build takes longer than it should

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
 option(BUILD_ENTERPRISE "Set whether or not to build enterprise edition" OFF)
 option(CODE_COVERAGE_ENABLED "Set whether or not code coverage report should be generated" OFF)
+option(DISABLE_LTO_BUILD "Disable build with Link-time optimization" OFF)
 option(STRIP_SYMBOLS "Set whether or not the private symbols will be stripped" OFF)
 
 if(CODE_COVERAGE_ENABLED)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,5 +17,5 @@ mkdir -p build_cmake
 cd build_cmake
 
 core_count=`getconf _NPROCESSORS_ONLN`
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+[ ! -f ../build_cmake/CMakeCache.txt ] && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 make -j `expr $core_count + 1`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,5 +17,5 @@ mkdir -p build_cmake
 cd build_cmake
 
 core_count=`getconf _NPROCESSORS_ONLN`
-[ ! -f ../build_cmake/CMakeCache.txt ] && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 make -j `expr $core_count + 1`


### PR DESCRIPTION
- LTO disabled
- build is running smooth after the first run (first run around 90s) -> change added to the `.sh` in order to only run `cmake` once (i.e. project setup) as afterwards, by itself, it figures out if it should be rerun alongside `make`.


No file changes
```
couchbase-lite-C git:(CBL-2397) time scripts/build.sh
[  0%] Built target CouchbaseSqlite3
[ 10%] Built target SQLite3_UnicodeSN
[ 13%] Built target BLIPObjects
[ 33%] Built target mbedcrypto
[ 40%] Built target cblite-static
[ 42%] Built target mbedx509
[ 56%] Built target FleeceObjects
[ 60%] Built target mbedtls
[ 89%] Built target LiteCoreObjects
[ 89%] Built target LiteCoreStatic
[ 93%] Built target LiteCoreWebSocket
[ 93%] Built target cblite
Consolidate compiler generated dependencies of target CBL_C_Tests
[100%] Built target CBL_C_Tests
scripts/build.sh  0.56s user 0.26s system 111% cpu 0.744 total
```

One file changed
```
[  0%] Built target CouchbaseSqlite3
[ 10%] Built target SQLite3_UnicodeSN
[ 13%] Built target BLIPObjects
[ 33%] Built target mbedcrypto
[ 40%] Built target cblite-static
[ 42%] Built target mbedx509
[ 56%] Built target FleeceObjects
[ 60%] Built target mbedtls
[ 89%] Built target LiteCoreObjects
[ 89%] Built target LiteCoreStatic
[ 93%] Built target LiteCoreWebSocket
[ 93%] Built target cblite
[ 93%] Building CXX object test/CMakeFiles/CBL_C_Tests.dir/CBLTest.cc.o
[ 93%] Linking CXX executable CBL_C_Tests
[100%] Built target CBL_C_Tests
scripts/build.sh  1.71s user 0.33s system 107% cpu 1.898 total
```
