### PR TITLE
Make CBLTest support testing on android platform

### DIFF
--- a/test/CBLTest.hh
+++ b/test/CBLTest.hh
@@ -59,28 +59,40 @@ static inline std::ostream& operator<< (std::ostream &out, CBLError err) {
 
 #include "catch.hpp"
 
+#ifdef __ANDROID__
+struct CBLTestAndroidContext {
+    const char* filesDir;
+    const char* tempDir;
+    const char* assetsDir;
+};
+#endif
 
 class CBLTest {
 public:
-    static const fleece::alloc_slice kDatabaseDir;
     static const fleece::slice kDatabaseName;
-    static const CBLDatabaseConfiguration kDatabaseConfiguration;
-
+    
+#ifdef __ANDROID__
+    /** Initializing android context is required before running tests on Android platform. */
+    static void initAndroidContext(CBLTestAndroidContext context);
+#endif
+    
+    static fleece::alloc_slice databaseDir();
+    
+    static CBLDatabaseConfiguration databaseConfig();
+    
     CBLTest();
     ~CBLTest();
-
-
+    
     CBLDatabase *db {nullptr};
 };
-
 
 std::string GetTestFilePath(const std::string &filename);
 
 bool ReadFileByLines(const std::string &path, const std::function<bool(FLSlice)> &callback);
 
-unsigned ImportJSONLines(std::string &&path, CBLDatabase* database);
+unsigned ImportJSONLines(std::string filename, CBLDatabase* database);
 
-unsigned ImportJSONLines(std::string &&path, CBLCollection* collection);
+unsigned ImportJSONLines(std::string filename, CBLCollection* collection);
 
 void CheckError(CBLError& error, CBLErrorCode expectedCode, CBLErrorDomain expectedDomain = kCBLDomain);
 

--- a/test/CBLTest_Cpp.hh
+++ b/test/CBLTest_Cpp.hh
@@ -39,9 +39,8 @@ namespace cbl {
 
 class CBLTest_Cpp {
 public:
-    static const fleece::alloc_slice kDatabaseDir;
     static const fleece::slice kDatabaseName;
-
+    
     CBLTest_Cpp();
     ~CBLTest_Cpp();
 

--- a/test/CBLTestsMain.cpp
+++ b/test/CBLTestsMain.cpp
@@ -6,8 +6,12 @@
 //  Copyright © 2019 Couchbase. All rights reserved.
 //
 
+#ifndef __ANDROID__
+
 #define CATCH_CONFIG_CONSOLE_WIDTH 120
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
 
 #include "CBLTest.hh"
 #include "CaseListReporter.hh"
+
+#endif

--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -50,7 +50,8 @@ public:
     
     CBLDatabase* openDB() {
         CBLError error = {};
-        CBLDatabase* db = CBLDatabase_Open(kDatabaseName, &kDatabaseConfiguration, &error);
+        auto config = databaseConfig();
+        CBLDatabase* db = CBLDatabase_Open(kDatabaseName, &config, &error);
         REQUIRE(db);
         return db;
     }

--- a/test/DatabaseTest_Cpp.cc
+++ b/test/DatabaseTest_Cpp.cc
@@ -31,13 +31,13 @@ using namespace cbl;
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database") {
     CHECK(db.name() == string(kDatabaseName));
-    CHECK(db.path() == string(kDatabaseDir) + kPathSeparator + string(kDatabaseName) + ".cblite2" + kPathSeparator);
+    CHECK(db.path() == string(CBLTest::databaseDir()) + kPathSeparator + string(kDatabaseName) + ".cblite2" + kPathSeparator);
     CHECK(db.count() == 0);
 }
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database Exist") {
     CHECK(!Database::exists(kDatabaseName, nullptr));
-    CHECK(Database::exists(kDatabaseName, kDatabaseDir));
+    CHECK(Database::exists(kDatabaseName, CBLTest::databaseDir()));
 }
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Copy Database") {
@@ -45,14 +45,17 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Copy Database") {
     doc["greeting"] = "Howdy!";
     db.saveDocument(doc);
     
+    auto dbDir = CBLTest::databaseDir();
+    auto config = CBLTest::databaseConfig();
+    
     const slice copiedDBName = "CBLtest_Copied";
-    Database::deleteDatabase(copiedDBName, kDatabaseDir);
-    REQUIRE(!Database::exists(copiedDBName, kDatabaseDir));
+    Database::deleteDatabase(copiedDBName, dbDir);
+    REQUIRE(!Database::exists(copiedDBName, dbDir));
     
-    Database::copyDatabase(db.path(), copiedDBName, CBLTest::kDatabaseConfiguration);
+    Database::copyDatabase(db.path(), copiedDBName, config);
     
-    CHECK(Database::exists(copiedDBName, kDatabaseDir));
-    auto copiedDB = cbl::Database(copiedDBName, CBLTest::kDatabaseConfiguration);
+    CHECK(Database::exists(copiedDBName, dbDir));
+    auto copiedDB = cbl::Database(copiedDBName, config);
     CHECK(copiedDB.count() == 1);
     
     doc = copiedDB.getMutableDocument("foo");

--- a/test/DocumentTest.cc
+++ b/test/DocumentTest.cc
@@ -932,7 +932,9 @@ TEST_CASE_METHOD(DocumentTest, "Document Expiring After Reopen", "[Document][Exp
     // Close & reopen the database:
     REQUIRE(CBLDatabase_Close(db, &error));
     CBLDatabase_Release(db);
-    db = CBLDatabase_Open(kDatabaseName, &kDatabaseConfiguration, &error);
+    
+    auto config = databaseConfig();
+    db = CBLDatabase_Open(kDatabaseName, &config, &error);
 
     // Now wait for expiration:
     this_thread::sleep_for(3000ms);

--- a/test/LogTest.cc
+++ b/test/LogTest.cc
@@ -83,7 +83,7 @@ public:
     
     void prepareLogDir() {
         // Base:
-        string dir = string(CBLTest::kDatabaseDir) + kSeparatorChar + "CBLLogTest";
+        string dir = string(CBLTest::databaseDir()) + kSeparatorChar + "CBLLogTest";
         createDir(dir);
         
         // Log dir:

--- a/test/PerfTest.cc
+++ b/test/PerfTest.cc
@@ -24,10 +24,8 @@ using namespace std;
 using namespace fleece;
 
 
-// NOTE: This file is large (~30MB) so it isn't checked into the repo.
-//FIXME: Not a portable path.
-static constexpr const char *kJSONFilePath = "../DataSets/travel-sample/travelSample.json";
-
+// NOTE: The "travelSample.json" is large (~30MB) so it isn't checked into the repo.
+// The file should be put int the test assets folder
 
 TEST_CASE_METHOD(CBLTest_Cpp, "Benchmark Import JSON", "[.Perf]") {
     Stopwatch st;
@@ -36,7 +34,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "Benchmark Import JSON", "[.Perf]") {
     db.createValueIndex("locations",  {kCBLJSONLanguage, "[[\".country\"], [\".city\"]]"_sl});
     db.createValueIndex("longitudes", {kCBLJSONLanguage, "[[\".geo.lon\"]]"_sl});
 
-    ImportJSONLines(kJSONFilePath, db.ref());
+    ImportJSONLines("travelSample.json", db.ref());
 
     cout << "Elapsed time: " << st.elapsed() << " sec\n";
 }

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -32,7 +32,7 @@ using namespace fleece;
 class QueryTest : public CBLTest {
 public:
     QueryTest() {
-        ImportJSONLines(GetTestFilePath("names_100.json"), db);
+        ImportJSONLines("names_100.json", db);
     }
 
     ~QueryTest() {
@@ -647,7 +647,7 @@ TEST_CASE_METHOD(QueryTest, "Query Default Collection", "[Query]") {
 
 TEST_CASE_METHOD(QueryTest, "Query Collection in Default Scope", "[.CBL-3538]") {
     auto col = CreateCollection(db, "colA");
-    ImportJSONLines(GetTestFilePath("names_100.json"), col);
+    ImportJSONLines("names_100.json", col);
     CBLCollection_Release(col);
     
     string queryString;
@@ -680,7 +680,7 @@ TEST_CASE_METHOD(QueryTest, "Query Collection in Default Scope", "[.CBL-3538]") 
 
 TEST_CASE_METHOD(QueryTest, "Query Named Collection and Scope", "[Query]") {
     auto col = CreateCollection(db, "colA", "scopeA");
-    ImportJSONLines(GetTestFilePath("names_100.json"), col);
+    ImportJSONLines("names_100.json", col);
     CBLCollection_Release(col);
     
     string queryString = "SELECT name.first FROM scopeA.colA ORDER BY name.first LIMIT 1";
@@ -705,7 +705,7 @@ TEST_CASE_METHOD(QueryTest, "Query Named Collection and Scope", "[Query]") {
 
 TEST_CASE_METHOD(QueryTest, "Create Query with Different Collection Name Cases Failed", "[Query]") {
     auto col = CreateCollection(db, "colA", "scopeA");
-    ImportJSONLines(GetTestFilePath("names_100.json"), col);
+    ImportJSONLines("names_100.json", col);
     CBLCollection_Release(col);
     
     string queryString = "SELECT name.first FROM ScOpEa.CoLa ORDER BY name.first LIMIT 1";

--- a/test/QueryTest_Cpp.cc
+++ b/test/QueryTest_Cpp.cc
@@ -33,7 +33,7 @@ using namespace cbl;
 class QueryTest_Cpp : public CBLTest_Cpp {
 public:
     QueryTest_Cpp() {
-        ImportJSONLines(GetTestFilePath("names_100.json"), db.ref());
+        ImportJSONLines("names_100.json", db.ref());
     }
 };
 

--- a/test/ReplicatorTest.cc
+++ b/test/ReplicatorTest.cc
@@ -69,7 +69,8 @@ TEST_CASE_METHOD(ReplicatorTest, "Bad url", "[Replicator]") {
     CHECK(error.code == kCBLErrorInvalidParameter);
 }
 
-
+#ifndef __ANDROID__
+// On Android emulator, the error returned is kCBLNetErrDNSFailure which is a transient error.
 TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate", "[Replicator]") {
     CBLError error;
     config.endpoint = CBLEndpoint_CreateWithURL("ws://fsdfds.vzcsg/foobar"_sl, &error);
@@ -88,8 +89,10 @@ TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate", "[Replicator]") {
     expectedError = {kCBLNetworkDomain, kCBLNetErrUnknownHost};
     replicate();
 }
+#endif
 
-
+#ifndef __ANDROID__
+// On Android emulator, the error returned is kCBLNetErrDNSFailure which is a transient error.
 TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate with auth and proxy", "[Replicator]") {
     CBLError error;
     config.endpoint = CBLEndpoint_CreateWithURL("ws://fsdfds.vzcsg/foobar"_sl, &error);
@@ -108,8 +111,10 @@ TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate with auth and proxy", "[Replica
     expectedError = {kCBLNetworkDomain, kCBLNetErrUnknownHost};
     replicate();
 }
+#endif
 
-
+#ifndef __ANDROID__
+// On Android emulator, the error returned is kCBLNetErrDNSFailure which is a transient error.
 // CBL-2337
 TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate with freed auth and doc listener", "[Replicator]") {
     CBLError error;
@@ -130,7 +135,7 @@ TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate with freed auth and doc listene
     // Clean up
     config.authenticator = nullptr;
 }
-
+#endif
 
 TEST_CASE_METHOD(ReplicatorTest, "Copy pointer configs", "[Replicator]") {
     CBLReplicatorConfiguration config = {};


### PR DESCRIPTION
* Added CBLTestAndroidContext and initAndroidContext(CBLTestAndroidContext context) function for initializing the android context. Noted that the file paths included in the context cannot be determined natively so they needed to be supplied from the Java code.

* Changed kDatabaseDir and kDatabaseConfiguration from static constants to functions so that they can use the information from the initialized android context for the android platform.

* Change the signature of ImportJSONLines() functions to accept only asset’s file name instead of path. The function will figure out the path by itself.

* Disabled the catch initializing code in CBLTestsMain.cpp for android as it will be done by android directly.

* Disabled fake replicator tests on android platform as they will behave differently according to the different error code returned, and it’s not a bug.

* Updated the test code according to the changes.