### PR TITLE
CBL-3934 : Fix empty identity is not valid error with XCode 14

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -1861,11 +1861,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27310FD7235F686D0046F8C8 /* CBL_Framework_Debug.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = N2Q372V7W2;
-				ENABLE_HARDENED_RUNTIME = YES;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
 		};
@@ -1873,9 +1868,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27984E492249AF61000FE777 /* CBL_Framework_Release.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Apple Development";
-				DEVELOPMENT_TEAM = N2Q372V7W2;
-				ENABLE_HARDENED_RUNTIME = YES;
 			};
 			name = Release;
 		};
@@ -2034,11 +2026,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27310FD7235F686D0046F8C8 /* CBL_Framework_Debug.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = N2Q372V7W2;
-				ENABLE_HARDENED_RUNTIME = YES;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug_EE;
 		};
@@ -2204,9 +2191,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27984E492249AF61000FE777 /* CBL_Framework_Release.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Apple Development";
-				DEVELOPMENT_TEAM = N2Q372V7W2;
-				ENABLE_HARDENED_RUNTIME = YES;
 			};
 			name = Release_EE;
 		};

--- a/Xcode/xcconfigs/CBL_Framework.xcconfig
+++ b/Xcode/xcconfigs/CBL_Framework.xcconfig
@@ -20,7 +20,9 @@
 
 INSTALL_PATH            = $(LOCAL_LIBRARY_DIR)/Frameworks
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_path/Frameworks
+CODE_SIGN_IDENTITY      = Apple Development
 DEFINES_MODULE          = YES
+DEVELOPMENT_TEAM        = N2Q372V7W2
 EXECUTABLE_PREFIX       =
 FRAMEWORK_VERSION       = A
 INFOPLIST_FILE          = Xcode/Framework-Info.plist

--- a/Xcode/xcconfigs/CBL_Tests.xcconfig
+++ b/Xcode/xcconfigs/CBL_Tests.xcconfig
@@ -18,5 +18,6 @@
 
 HEADER_SEARCH_PATHS     = include Xcode/generated_headers/public/cbl $(FLEECE)/API  $(FLEECE)/Fleece/Support  $(FLEECE)/vendor/catch
 PRODUCT_NAME            = cbl_tests
-
-LLVM_LTO                    = NO    // LTO makes tests very slow to link and confuses Instruments
+CODE_SIGN_IDENTITY      = Apple Development
+DEVELOPMENT_TEAM        = N2Q372V7W2
+LLVM_LTO                = NO    // LTO makes tests very slow to link and confuses Instruments

--- a/Xcode/xcconfigs/CBL_dylib.xcconfig
+++ b/Xcode/xcconfigs/CBL_dylib.xcconfig
@@ -20,3 +20,5 @@
 
 PRODUCT_NAME            = cblite
 EXPORTED_SYMBOLS_FILE   = $(DERIVED_FILE_DIR)/CBL.exp  // output of src/exports/generate_exports.sh
+CODE_SIGN_IDENTITY      = Apple Development
+DEVELOPMENT_TEAM        = N2Q372V7W2


### PR DESCRIPTION
* Problem : XCode 14 starts to require code signing for command line app and dynamic lib.

* Explicitly set the code sign identity and development team to CBL_Tests and CBL_dylib target.

* Moved code signing related configs from CBL_Framework to xcconfig files.

* Removed ENABLE_HARDENED_RUNTIME and PROVISIONING_PROFILE_SPECIFIER settings to use the default values which is NO (config for app not framework) and empty respectively.