### PR TITLE
CBL-3938 : Extract setting test src files into a shared cmake file

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,31 +25,11 @@ include_directories(
     ${PROJECT_BINARY_DIR}/../generated_headers/public/cbl/ # or this
 )
 
-set(TEST_SRC
-    BlobTest.cc
-    BlobTest_Cpp.cc
-    CBLTest.c
-    CBLTest.cc
-    CBLTestsMain.cpp
-    CollectionTest.cc
-    CollectionTest_Cpp.cc
-    DatabaseTest.cc
-    DatabaseTest_Cpp.cc
-    DocumentTest.cc
-    DocumentTest_Cpp.cc
-    LogTest.cc
-    QueryTest.cc
-    QueryTest_Cpp.cc
-    ReplicatorCollectionTest.cc
-    ReplicatorCollectionTest_Cpp.cc
-    ReplicatorEETest.cc
-    ReplicatorPropEncTest.cc
-    ReplicatorTest.cc
-    ${TOP}vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/Backtrace.cc
-    ${TOP}vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/LibC++Debug.cc
-    ${TOP}vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/betterassert.cc
-)
-add_executable(CBL_C_Tests ${TEST_SRC} )
+# Test source files:
+include("cmake/test_source_files.cmake")
+set_test_source_files(DIR ${PROJECT_SOURCE_DIR} RESULT TEST_SRC)
+
+add_executable(CBL_C_Tests ${TEST_SRC})
 
 target_link_libraries(CBL_C_Tests PRIVATE  cblite)
 

--- a/test/cmake/test_source_files.cmake
+++ b/test/cmake/test_source_files.cmake
@@ -1,0 +1,40 @@
+function(set_test_source_files)
+    set(oneValueArgs DIR RESULT)
+    cmake_parse_arguments(T "" ${oneValueArgs} "" ${ARGN})
+
+    if(NOT DEFINED T_DIR)
+        message(FATAL_ERROR Missing DIR which is the directory for the test project)
+    endif()
+
+    if(NOT DEFINED T_RESULT)
+        message(FATAL_ERROR Missing RESULT which is the variable for setting the source files)
+    endif()
+
+    set(
+        ${T_RESULT}
+        ${T_DIR}/
+        ${T_DIR}/BlobTest.cc
+        ${T_DIR}/BlobTest_Cpp.cc
+        ${T_DIR}/CBLTest.c
+        ${T_DIR}/CBLTest.cc
+        ${T_DIR}/CBLTestsMain.cpp
+        ${T_DIR}/CollectionTest.cc
+        ${T_DIR}/CollectionTest_Cpp.cc
+        ${T_DIR}/DatabaseTest.cc
+        ${T_DIR}/DatabaseTest_Cpp.cc
+        ${T_DIR}/DocumentTest.cc
+        ${T_DIR}/DocumentTest_Cpp.cc
+        ${T_DIR}/LogTest.cc
+        ${T_DIR}/QueryTest.cc
+        ${T_DIR}/QueryTest_Cpp.cc
+        ${T_DIR}/ReplicatorCollectionTest.cc
+        ${T_DIR}/ReplicatorCollectionTest_Cpp.cc
+        ${T_DIR}/ReplicatorEETest.cc
+        ${T_DIR}/ReplicatorPropEncTest.cc
+        ${T_DIR}/ReplicatorTest.cc
+        ${T_DIR}/../vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/Backtrace.cc
+        ${T_DIR}/../vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/LibC++Debug.cc
+        ${T_DIR}/../vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/betterassert.cc
+        PARENT_SCOPE
+    )
+endfunction()


### PR DESCRIPTION
For sharing the test source file settings b/w CBL_Tests app and android test app (will be published in a separated PR), extract the setting test source files as a function in `cmake/test-source_files.cmake` file.