### PR TITLE
CBL-3983: Not allow to delete default collection

### DIFF
--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -184,6 +184,8 @@ public:
     }
 };
 
+#define NOT_DELETE_DEFAULT_COLLECTION
+
 TEST_CASE_METHOD(CollectionTest, "Default Collection", "[Collection]") {
     CBLError error = {};
     CBLCollection* col = CBLDatabase_DefaultCollection(db, &error);
@@ -237,6 +239,8 @@ TEST_CASE_METHOD(CollectionTest, "Default Scope Exists By Default", "[Collection
     FLMutableArray_Release(names);
 }
 
+#ifndef NOT_DELETE_DEFAULT_COLLECTION
+
 TEST_CASE_METHOD(CollectionTest, "Delete Default Collection", "[Collection]") {
     CBLError error = {};
     CBLCollection* col = CBLDatabase_DefaultCollection(db, &error);
@@ -280,6 +284,22 @@ TEST_CASE_METHOD(CollectionTest, "Get Default Scope After Delete Default Collect
     FLMutableArray_Release(names);
 }
 
+#else 
+
+TEST_CASE_METHOD(CollectionTest, "Default Collection Cannot Be Deleted", "[Collection]") {
+    ExpectingExceptions ex;
+    CBLError error = {};
+    CBLCollection* col = CBLDatabase_DefaultCollection(db, &error);
+    REQUIRE(col);
+    
+    // Try delete the default collection - should return false:
+    REQUIRE(!CBLDatabase_DeleteCollection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName, &error));
+    CHECK((error.domain == kCBLDomain && error.code == kCBLErrorInvalidParameter ));
+
+    CBLCollection_Release(col);
+}
+
+#endif
 TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Default Scope", "[Collection]") {
     CBLError error = {};
     CBLCollection* col = CBLDatabase_CreateCollection(db, "colA"_sl, kCBLDefaultScopeName, &error);

--- a/test/CollectionTest_Cpp.cc
+++ b/test/CollectionTest_Cpp.cc
@@ -110,6 +110,7 @@ public:
     }
 };
 
+#define NOT_DELETE_DEFAULT_COLLECTION
 
 TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Collection", "[Collection]") {
     Collection col = db.getDefaultCollection();
@@ -127,6 +128,7 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Collection", "[Collection]") {
     CHECK(names.toJSONString() == R"(["_default"])");
 }
 
+#ifndef NOT_DELETE_DEFAULT_COLLECTION
 TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Delete Default Collection", "[Collection]") {
     Collection col = db.getDefaultCollection();
     CHECK(col);
@@ -165,6 +167,23 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Scope", "[Collection]") {
     REQUIRE(names);
     CHECK(names.toJSONString() == R"(["_default"])");
 }
+#else
+
+TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Collection Cannot Be Deleted", "[Collection]") {
+
+    ExpectingExceptions ex;
+    Collection col = db.getDefaultCollection();
+    REQUIRE(col);
+
+    // Try delete the default collection - should fail and catch error:
+    try {
+        db.deleteCollection(kCBLDefaultCollectionName);
+    } catch (CBLError e){
+        CHECK((e.domain == kCBLDomain && e.code == kCBLErrorInvalidParameter ));
+    }
+}
+
+#endif
 
 TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Create And Get Collection In Default Scope", "[Collection]") {
     Collection col = db.getCollection("colA", kCBLDefaultScopeName);


### PR DESCRIPTION
skipping existing tests and added a new test that checks for error when trying to delete default collection