### PR TITLE
CBL-4017 : Remove networkInterface from public API

### DIFF
--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -201,9 +201,13 @@ namespace cbl {
         /** The heartbeat interval in seconds.
             Specify 0 to use the default value of 300 seconds. */
         unsigned heartbeat                  = 0;
+        
+    #ifdef __CBL_REPLICATOR_NETWORK_INTERFACE__
         /** The specific network interface to be used by the replicator to connect to the remote server.
-            If not specified, an active network interface based on the OS's routing table will be used. */
+            If not specified, an active network interface based on the OS's routing table will be used.
+            @NOTE The networkInterface configuration is not supported. */
         std::string networkInterface;
+    #endif
 
         //-- HTTP settings:
         /** Authentication credentials, if needed. */
@@ -265,8 +269,10 @@ namespace cbl {
             conf.proxy = proxy;
             if (!headers.empty())
                 conf.headers = headers;
+        #ifdef __CBL_REPLICATOR_NETWORK_INTERFACE__
             if (!networkInterface.empty())
                 conf.networkInterface = slice(networkInterface);
+        #endif
             if (!pinnedServerCertificate.empty())
                 conf.pinnedServerCertificate = slice(pinnedServerCertificate);
             if (!trustedRootCertificates.empty())

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -281,9 +281,13 @@ typedef struct {
         The default value is \ref kCBLDefaultReplicatorHeartbeat. */
     unsigned heartbeat;
     
+#ifdef __CBL_REPLICATOR_NETWORK_INTERFACE__
     /** The specific network interface to be used by the replicator to connect to the remote server.
-        If not specified, an active network interface based on the OS's routing table will be used. */
+        If not specified, an active network interface based on the OS's routing table will be used.
+        @NOTE The networkInterface configuration is not supported.
+     */
     FLString networkInterface;
+#endif
     
     //-- HTTP settings:
     

--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -198,7 +198,11 @@ namespace cbl_internal
             documentIDs = FLArray_MutableCopy(documentIDs, kFLDeepCopyImmutables);
             pinnedServerCertificate = (_pinnedServerCert = pinnedServerCertificate);
             trustedRootCertificates = (_trustedRootCerts = trustedRootCertificates);
+        
+        #ifdef __CBL_REPLICATOR_NETWORK_INTERFACE__
             networkInterface = (_networkInterface = networkInterface);
+        #endif
+            
             if (proxy) {
                 _proxy = *proxy;
                 proxy = &_proxy;
@@ -325,10 +329,12 @@ namespace cbl_internal
                 enc.writeUInt(kCBLDefaultReplicatorHeartbeat);
             }
             
+        #ifdef __CBL_REPLICATOR_NETWORK_INTERFACE__
             if (networkInterface.buf) {
                 enc.writeKey(slice(kC4SocketOptionNetworkInterface));
                 enc.writeString(networkInterface);
             }
+        #endif
         }
         
         void writeCollectionOptions(CBLReplicationCollection& collection, Encoder &enc) const {
@@ -358,7 +364,9 @@ namespace cbl_internal
         alloc_slice                             _pinnedServerCert, _trustedRootCerts;
         CBLProxySettings                        _proxy;
         alloc_slice                             _proxyHostname, _proxyUsername, _proxyPassword;
+    #ifdef __CBL_REPLICATOR_NETWORK_INTERFACE__
         alloc_slice                             _networkInterface;
+    #endif
     };
 }
 


### PR DESCRIPTION
* Used #ifdef __CBL_REPLICATOR_NETWORK_INTERFACE__ to remove the networkInterface config from the public API.

* As the API is still in the header file, add a specific NOTE that the config is not supported.