### PR TITLE
Give more time for checking object counts in tests

### DIFF
--- a/test/CBLTest.hh
+++ b/test/CBLTest.hh
@@ -106,6 +106,8 @@ void CreateDoc(CBLCollection *col, std::string docID, std::string jsonContent);
 
 void PurgeAllDocs(CBLCollection* collection);
 
+void CheckObjectLeaks();
+
 
 // RAII utility to suppress reporting C++ exceptions (or breaking at them, in the Xcode debugger.)
 // Declare an instance when testing something that's expected to throw an exception internally.


### PR DESCRIPTION
I have seen that we have tests failed due to object leaks mostly in the replicator which could drain all the objects asynchronously. So give some more time by doing sleep and retry when checking the object leaks.