### PR TITLE
CBD-5234: Naming change for couchbase-lite-c .tar.gz packages

### DIFF
--- a/jenkins/couchbase-lite-c-linux-build.sh
+++ b/jenkins/couchbase-lite-c-linux-build.sh
@@ -36,13 +36,13 @@ curl -LO https://raw.githubusercontent.com/couchbase/product-metadata/master/${P
 
 # Cross-compile based on desired ARCH
 BUILD_OS=$(cfgvar .build_arch_config.${ARCH}.build_os)
-TARGET_OSNAME=$(cfgvar .build_arch-config.${ARCH}.target_osname)
+TARGET_OSNAME=$(cfgvar .build_arch_config.${ARCH}.target_osname)
 STRIP_PREFIX=$(cfgvar .build_arch_config.${ARCH}.strip_prefix)
 TOOLCHAIN=$(cfgvar .build_arch_config.${ARCH}.toolchain)
 
 python3 -u ${script_dir}/ci_cross_build.py \
     ${PRODUCT} ${BLD_NUM} ${VERSION} ${EDITION} \
-    ${BUILD_OS} ${STRIP_PREFIX} \
+    ${BUILD_OS} ${TARGET_OSNAME} ${STRIP_PREFIX} \
     ${script_dir}/../cmake/${TOOLCHAIN}.cmake \
 || exit 1
 

--- a/jenkins/couchbase-lite-c-linux-build.sh
+++ b/jenkins/couchbase-lite-c-linux-build.sh
@@ -36,6 +36,7 @@ curl -LO https://raw.githubusercontent.com/couchbase/product-metadata/master/${P
 
 # Cross-compile based on desired ARCH
 BUILD_OS=$(cfgvar .build_arch_config.${ARCH}.build_os)
+TARGET_OSNAME=$(cfgvar .build_arch-config.${ARCH}.target_osname)
 STRIP_PREFIX=$(cfgvar .build_arch_config.${ARCH}.strip_prefix)
 TOOLCHAIN=$(cfgvar .build_arch_config.${ARCH}.toolchain)
 
@@ -57,15 +58,15 @@ else
     EDITION_INFIX="-community"
 fi
 
-for TARGET_OS in $(cfgvar ".build_arch_config.${ARCH}.target_os[]"); do
-    EXTRA_DEPS=$(cfgvar .package_distro_config.\"${TARGET_OS}\".extra_deps)
+for TARGET_DEB in $(cfgvar ".build_arch_config.${ARCH}.target_debs[]"); do
+    EXTRA_DEPS=$(cfgvar .package_distro_config.\"${TARGET_DEB}\".extra_deps)
     DEPENDENCIES="${BASE_DEPS},${EXTRA_DEPS}"
 
     ./package-deb.rb ${WORKSPACE}/build_release/libcblite-${VERSION} libcblite ${EDITION} ${VERSION}-${BLD_NUM} ${ARCH} ${DEPENDENCIES}
-    cp build/deb/libcblite${EDITION_INFIX}_${VERSION}-${BLD_NUM}_${ARCH}.deb ${WORKSPACE}/libcblite-${EDITION}_${VERSION}-${BLD_NUM}-${TARGET_OS}_${ARCH}.deb
+    cp build/deb/libcblite${EDITION_INFIX}_${VERSION}-${BLD_NUM}_${ARCH}.deb ${WORKSPACE}/libcblite-${EDITION}_${VERSION}-${BLD_NUM}-${TARGET_DEB}_${ARCH}.deb
     rm -rf build
 
     ./package-deb.rb ${WORKSPACE}/build_release/libcblite-${VERSION} libcblite-dev ${EDITION} ${VERSION}-${BLD_NUM} ${ARCH}
-    cp build/deb/libcblite-dev${EDITION_INFIX}_${VERSION}-${BLD_NUM}_${ARCH}.deb ${WORKSPACE}/libcblite-dev-${EDITION}_${VERSION}-${BLD_NUM}-${TARGET_OS}_${ARCH}.deb
+    cp build/deb/libcblite-dev${EDITION_INFIX}_${VERSION}-${BLD_NUM}_${ARCH}.deb ${WORKSPACE}/libcblite-dev-${EDITION}_${VERSION}-${BLD_NUM}-${TARGET_DEB}_${ARCH}.deb
     rm -rf build
 done

--- a/jenkins/linux-package-config.json
+++ b/jenkins/linux-package-config.json
@@ -4,19 +4,22 @@
       "build_os": "debian9-x86_64",
       "strip_prefix": "x86_64-linux-gnu-",
       "toolchain": "Toolchain-cross-x64",
-      "target_os": [ "debian9", "debian10", "debian11", "ubuntu20.04", "ubuntu22.04" ]
+      "target_osname": "linux-x86_64",
+      "target_debs": [ "debian9", "debian10", "debian11", "ubuntu20.04", "ubuntu22.04" ]
     },
     "arm64": {
       "build_os": "raspios10-arm64",
       "strip_prefix": "aarch64-linux-gnu-",
       "toolchain": "Toolchain-pi64",
-      "target_os": [ "debian10", "debian11", "ubuntu20.04", "ubuntu22.04" ]
+      "target_osname": "linux-arm64",
+      "target_debs": [ "debian10", "debian11", "ubuntu20.04", "ubuntu22.04" ]
     },
     "armhf": {
         "build_os": "raspbian9",
         "strip_prefix": "arm-linux-gnueabihf-",
         "toolchain": "Toolchain-pi",
-        "target_os": [ "debian9", "debian10", "debian11", "ubuntu20.04", "ubuntu22.04" ]
+        "target_osname": "linux-armhf",
+        "target_debs": [ "debian9", "debian10", "debian11", "ubuntu20.04", "ubuntu22.04" ]
     }
   },
   "package_distro_config": {


### PR DESCRIPTION
Final deliverable packages should be named just "linux-$ARCH".

The scripts and linux-package-config.json file now differentiate:

* build_os - the OS to cross-compile for, per architecture
* target_osname - the OS name to use in deliverables (linux-$ARCH)
* target_debs - OS distributions to create specific .debs for