### PR TITLE
CBL-3986 : Not specify VS version in wins build script

### DIFF
--- a/jenkins/ci_build_win_desktop.ps1
+++ b/jenkins/ci_build_win_desktop.ps1
@@ -62,7 +62,7 @@ function Build() {
     New-Item -ItemType Directory -ErrorAction Ignore $directory
     Push-Location $directory
 
-    & "C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 15 2017" -A "${Architecture}" -DEDITION="$Edition" -DCMAKE_INSTALL_PREFIX="$pwd/libcblite-${Version}" ..
+    & "C:\Program Files\CMake\bin\cmake.exe" -A "${Architecture}" -DEDITION="$Edition" -DCMAKE_INSTALL_PREFIX="$pwd/libcblite-${Version}" ..
     if($LASTEXITCODE -ne 0) {
         throw "CMake failed"
     }


### PR DESCRIPTION
* Removed visual studio version from cmake platform generator to use the latest visual studio installed on the machine.

* This has been tested by doing the toy build (3.1.0-50551).