### PR TITLE
CBL-4183 : Replace deprecated LiteCore API calls

### DIFF
--- a/src/CBLDatabase_CAPI.cc
+++ b/src/CBLDatabase_CAPI.cc
@@ -142,14 +142,16 @@ const CBLDatabaseConfiguration CBLDatabase_Config(const CBLDatabase* db) noexcep
 
 uint64_t CBLDatabase_Count(const CBLDatabase* db) noexcept {
     try {
-        return db->count();
+        auto col = const_cast<CBLDatabase*>(db)->getDefaultCollection(true);
+        return col->count();
     } catchAndWarn();
 }
 
 /** Private API */
 uint64_t CBLDatabase_LastSequence(const CBLDatabase* db) noexcept {
     try {
-        return db->lastSequence();
+        auto col = const_cast<CBLDatabase*>(db)->getDefaultCollection(true);
+        return col->lastSequence();
     } catchAndWarn()
 }
 


### PR DESCRIPTION
Replaced C4Database::getDocumentCount and getLastSequence with the C4Collection:: getDocumentCount and getLastSequence.