### PR TITLE
CBL-4198 : Make CBLCollection_Scope return a retained pointer

### DIFF
--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -65,7 +65,12 @@ namespace cbl {
         std::string name() const                    {return asString(CBLCollection_Name(ref()));}
         
         /** The scope name. */
-        std::string scopeName() const               {return asString(CBLScope_Name(CBLCollection_Scope(ref())));}
+        std::string scopeName() const {
+            auto scope = CBLCollection_Scope(ref());
+            auto scopeName = asString(CBLScope_Name(scope));
+            CBLScope_Release(scope);
+            return scopeName;
+        }
         
         /** The number of documents in the collection. */
         uint64_t count() const                      {return CBLCollection_Count(ref());}
@@ -312,8 +317,10 @@ namespace cbl {
 template<> struct std::hash<cbl::Collection> {
     std::size_t operator() (cbl::Collection const& col) const {
         auto name = CBLCollection_Name(col.ref());
-        auto scope = CBLScope_Name(CBLCollection_Scope(col.ref()));
-        return fleece::slice(name).hash() ^ fleece::slice(scope).hash();
+        auto scope = CBLCollection_Scope(col.ref());
+        std::size_t hash = fleece::slice(name).hash() ^ fleece::slice(CBLScope_Name(scope)).hash();
+        CBLScope_Release(scope);
+        return hash;
     }
 };
 

--- a/include/cbl/CBLCollection.h
+++ b/include/cbl/CBLCollection.h
@@ -171,11 +171,7 @@ CBLCollection* _cbl_nullable CBLDatabase_DefaultCollection(const CBLDatabase* db
  */
 
 /** Returns the scope of the collection.
-    @note  The returned scope object is a property of the collection object, and therefore
-           its lifetime will depend on the lifetime of the collection object.
-           If the returned scope object needs to keep longer, it needs to be explicitly retain
-           using \ref CBLScope_Retain function, and the object will remain valid until it is
-           explicitly released by using \ref CBLScope_Release function.
+    @note You are responsible for releasing the returned scope.
     @param collection  The collection.
     @return A \ref CBLScope instance. */
 CBLScope* CBLCollection_Scope(const CBLCollection* collection) CBLAPI;

--- a/src/CBLCollection_CAPI.cc
+++ b/src/CBLCollection_CAPI.cc
@@ -95,7 +95,7 @@ CBLCollection* CBLDatabase_DefaultCollection(const CBLDatabase* db, CBLError* ou
 
 CBLScope* CBLCollection_Scope(const CBLCollection* collection) noexcept {
     try {
-        return const_cast<CBLCollection*>(collection)->scope();
+        return const_cast<CBLCollection*>(collection)->scope().detach();
     } catchAndWarn()
 }
 

--- a/src/CBLCollection_Internal.hh
+++ b/src/CBLCollection_Internal.hh
@@ -41,12 +41,12 @@ public:
     
 #pragma mark - ACCESSORS:
     
-    CBLScope* scope() const noexcept        {return _scope;}
-    slice name() const noexcept             {return _name;}
-    C4CollectionSpec spec() const noexcept  {return {_name, _scope->name()};}
-    bool isValid() const noexcept           {return _c4col.isValid();}
-    uint64_t count() const                  {return _c4col.useLocked()->getDocumentCount();}
-    uint64_t lastSequence() const           {return static_cast<uint64_t>(_c4col.useLocked()->getLastSequence());}
+    Retained<CBLScope> scope() const noexcept   {return _scope;}
+    slice name() const noexcept                 {return _name;}
+    C4CollectionSpec spec() const noexcept      {return {_name, _scope->name()};}
+    bool isValid() const noexcept               {return _c4col.isValid();}
+    uint64_t count() const                      {return _c4col.useLocked()->getDocumentCount();}
+    uint64_t lastSequence() const               {return static_cast<uint64_t>(_c4col.useLocked()->getLastSequence());}
     
     /** Throw NotOpen if the collection or database is invalid */
     CBLDatabase* database() const           {return _c4col.database();}

--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -305,8 +305,10 @@ void CreateDoc(CBLCollection *col, std::string docID, std::string jsonContent) {
 }
 
 std::string CollectionPath(CBLCollection* collection) {
-   return slice(CBLScope_Name(CBLCollection_Scope(collection))).asString() + "." +
-          slice(CBLCollection_Name(collection)).asString();
+    CBLScope* scope = CBLCollection_Scope(collection);
+    string name = slice(CBLScope_Name(scope)).asString() + "." + slice(CBLCollection_Name(collection)).asString();
+    CBLScope_Release(scope);
+    return name;
 }
 
 void PurgeAllDocs(CBLCollection* collection) {

--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -63,7 +63,11 @@ public:
         
         // Properties:
         CHECK(CBLCollection_Name(col));
-        CHECK(CBLCollection_Scope(col));
+        
+        CBLScope* scope = CBLCollection_Scope(col);
+        CHECK(scope);
+        CBLScope_Release(scope);
+        
         CHECK(CBLCollection_Count(col) == 0);
         
         // Document Functions:
@@ -205,6 +209,7 @@ TEST_CASE_METHOD(CollectionTest, "Default Collection Exists By Default", "[Colle
     CBLScope* scope = CBLCollection_Scope(col);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLScope_Release(scope);
     CBLCollection_Release(col);
     
     col = CBLDatabase_Collection(db, kCBLDefaultCollectionName, kCBLDefaultScopeName, &error);
@@ -215,6 +220,7 @@ TEST_CASE_METHOD(CollectionTest, "Default Collection Exists By Default", "[Colle
     scope = CBLCollection_Scope(col);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLScope_Release(scope);
     CBLCollection_Release(col);
     
     FLMutableArray names = CBLDatabase_CollectionNames(db, kCBLDefaultScopeName, &error);
@@ -309,6 +315,7 @@ TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Default Scope", "
     CBLScope* scope = CBLCollection_Scope(col);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLScope_Release(scope);
     CBLCollection_Release(col);
     
     col = CBLDatabase_Collection(db, "colA"_sl, kCBLDefaultScopeName, &error);
@@ -328,6 +335,7 @@ TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Default Scope", "
     scope = CBLCollection_Scope(col);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == kCBLDefaultScopeName);
+    CBLScope_Release(scope);
     CBLCollection_Release(col);
     
     col = CBLDatabase_Collection(db, "colA"_sl, kCBLDefaultScopeName, &error);
@@ -349,6 +357,7 @@ TEST_CASE_METHOD(CollectionTest, "Create And Get Collection In Named Scope", "[C
     CBLScope* scope = CBLCollection_Scope(col);
     REQUIRE(scope);
     CHECK(CBLScope_Name(scope) == "scopeA"_sl);
+    CBLScope_Release(scope);
     CBLCollection_Release(col);
     
     col = CBLDatabase_Collection(db, "colA"_sl, "scopeA"_sl, &error);
@@ -844,9 +853,9 @@ TEST_CASE_METHOD(CollectionTest, "Delete Database then Use Scope", "[Collection]
     
     CBLScope* scope = CBLCollection_Scope(col);
     REQUIRE(scope);
-    
     testInvalidScope(scope);
     
+    CBLScope_Release(scope);
     CBLCollection_Release(col);
 }
 
@@ -861,9 +870,9 @@ TEST_CASE_METHOD(CollectionTest, "Close Database then Use Scope", "[Collection]"
     
     CBLScope* scope = CBLCollection_Scope(col);
     REQUIRE(scope);
-    
     testInvalidScope(scope);
     
+    CBLScope_Release(scope);
     CBLCollection_Release(col);
 }
 

--- a/test/ReplicatorCollectionTest.cc
+++ b/test/ReplicatorCollectionTest.cc
@@ -253,8 +253,9 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Use invalid collections", "[Replicat
     
     CBLError error {};
     auto name = CBLCollection_Name(cx[1]);
-    auto scope = CBLScope_Name(CBLCollection_Scope(cx[1]));
-    REQUIRE(CBLDatabase_DeleteCollection(db.ref(), name, scope, &error));
+    auto scope = CBLCollection_Scope(cx[1]);
+    REQUIRE(CBLDatabase_DeleteCollection(db.ref(), name, CBLScope_Name(scope), &error));
+    CBLScope_Release(scope);
     
     CBLReplicator* r = CBLReplicator_Create(&config, &error);
     REQUIRE(!r);


### PR DESCRIPTION
To be consistent with the other APIs that return a scope pointer such as CBLDatabase_Scope(db, name) or CBLDatabase_DefaultScope(db), changed CBLCollection_Scope(col) to return a retained pointer.