### PR TITLE
CBL-4201 : Fix incorrect User-Agent key

### DIFF
--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -163,7 +163,7 @@ namespace cbl_internal {
 
 #pragma mark - CONFIGURATION:
 
-#define kCBLReplicatorUserAgent "kCBLReplicatorUserAgent"
+#define kCBLReplicatorUserAgent "User-Agent"
 
 namespace cbl_internal {
     // Managed config object that retains/releases its properties.


### PR DESCRIPTION
The key is set to "kCBLReplicatorUserAgent" which is accidentally incorrect. It should be "User-Agent".