### PR TITLE
CBL-4203 : Fix incorrect User-Agent key

### DIFF
--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -165,7 +165,7 @@ namespace cbl_internal {
 
 #pragma mark - CONFIGURATION:
 
-#define kCBLReplicatorUserAgent "kCBLReplicatorUserAgent"
+#define kCBLReplicatorUserAgent "User-Agent"
 
 namespace cbl_internal
 {


### PR DESCRIPTION
The key is set to "kCBLReplicatorUserAgent" which is wrong. It needs to be "User-Agent".