### PR TITLE
CBL-3965 : Update ci_build_android.sh

### DIFF
--- a/jenkins/ci_build_android.sh
+++ b/jenkins/ci_build_android.sh
@@ -60,6 +60,7 @@ function build_variant {
 	    -DANDROID_NATIVE_API_LEVEL=22 \
 	    -DANDROID_ABI=$1 \
 	    -DCMAKE_INSTALL_PREFIX=$(pwd)/../libcblite-$VERSION \
+	    -DCMAKE_BUILD_TYPE=MinSizeRel \
         -DEDITION=$EDITION \
 	    ..
 


### PR DESCRIPTION
* Ported the fix from release/3.1 branch (9997b5d1cc741ebe15458e182f866ff30a73b7a5)

* Add in a missing CMAKE_BUILD_TYPE.  Until now this has been debug builds.