### PR TITLE
CBL-4291 : Fix crash when getting User-Agent on Android

### DIFF
--- a/src/CBLUserAgent.hh
+++ b/src/CBLUserAgent.hh
@@ -106,6 +106,10 @@ static string getDistroInfo() {
 }
 #endif
 
+#ifdef __ANDROID__
+#include <sys/system_properties.h>
+#endif
+
 using stringstream = std::stringstream;
 using alloc_slice = fleece::alloc_slice;
 
@@ -126,8 +130,8 @@ static string createUserAgentHeader(){
     os = "macOS " + getAppleVersion();
 #endif
 #elif __ANDROID__
-        char rel_ver_str[3];
-        char sdk_ver_str[3];
+        char rel_ver_str[PROP_VALUE_MAX];
+        char sdk_ver_str[PROP_VALUE_MAX];
         __system_property_get("ro.build.version.sdk", sdk_ver_str);
         __system_property_get("ro.build.version.release", rel_ver_str);
         os = "Android " + std::string(rel_ver_str) + " - API " + std::string(sdk_ver_str);


### PR DESCRIPTION
* Ported the fix from release/lithium branch (dcbdf3df9660eada92586a97b6cd0ad6bfbb1532); original issue is CBL-4275.

* The crash could happen as the buffer size is too small when getting the Android SDK version with 3 digits such as 7.1.1.

* Used PROP_VALUE_MAX defined in system_properties.h instead of a fixed number for the buffer size.