### PR TITLE
CBL-3929 : Crash while stopping live query when closing db

### DIFF
--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -428,13 +428,20 @@ private:
         LOCK(_stopMutex);
         if (_stopping)
             return false;
-        _stoppables.insert(stoppable);
+        
+        if (_stoppables.find(stoppable) == _stoppables.end()) {
+            _stoppables.insert(stoppable);
+            stoppable->retain();
+        }
+        
         return true;
     }
     
     void unregisterStoppable(CBLStoppable* stoppable) {
         LOCK(_stopMutex);
-        _stoppables.erase(stoppable);
+        if (_stoppables.erase(stoppable) > 0) {
+            stoppable->release();
+        }
         _stopCond.notify_one();
     }
 

--- a/src/CBLQuery.cc
+++ b/src/CBLQuery.cc
@@ -28,17 +28,23 @@ using namespace fleece;
 
 void ListenerToken<CBLQueryChangeListener>::setEnabled(bool enabled) {
     auto c4query = _query->_c4query.useLocked();
+    
+    if (enabled == _isEnabled)
+        return;
+    
     CBLDatabase* db = const_cast<CBLDatabase*>(_query->database());
     if (enabled) {
-        if (!db->registerStoppable(this)) {
+        if (!db->registerStoppable(_stoppable.get())) {
             CBL_Log(kCBLLogDomainQuery, kCBLLogWarning,
                     "Couldn't enable the Query Listener as the database is closing or closed.");
             return;
         }
     }
+    
     _c4obs->setEnabled(enabled);
+    _isEnabled = enabled;
     if (!enabled)
-        db->unregisterStoppable(this);
+        db->unregisterStoppable(_stoppable.get());
 }
 
 

--- a/src/Internal.hh
+++ b/src/Internal.hh
@@ -43,9 +43,24 @@ protected:
 };
 
 
+/** CBLStoppable objects can be registered / unregisted to / from the database. The registered object will be called
+    to stop() when the database is closed. The object will be unregistered either after the object is called to stop() or
+    when there is an API call to unregister the object. The database will also retain the object when the object is registered,
+    and will release the object when the object is unregistered to ensure that the object is alive until the object is unregistered. */
 struct CBLStoppable {
-    virtual ~CBLStoppable() = default;
-    virtual void stop() = 0;
+public:
+    CBLStoppable(CBLRefCounted* ref)
+    :_ref(ref)
+    {}
+    
+    virtual ~CBLStoppable()                             =default;
+    virtual void stop() const                           =0;
+    
+    void retain()                                       {fleece::retain(_ref);}
+    void release()                                      {fleece::release(_ref);}
+    
+protected:
+    CBLRefCounted* _ref;
 };
 
 

--- a/src/Listener.cc
+++ b/src/Listener.cc
@@ -24,6 +24,7 @@ using namespace std;
 void CBLListenerToken::remove() {
     auto oldOwner = _owner;
     if (oldOwner) {
+        willRemove();
         removed();
         oldOwner->remove(this);
     }

--- a/src/Listener.hh
+++ b/src/Listener.hh
@@ -51,6 +51,11 @@ public:
 
     /** Called by `CBLListener_Remove` */
     void remove();
+    
+    /** Called by the remove() function before removing the token from the owner.
+        Subclasses can override this function to perform any tasks such as
+        stopping the underlinging observer and etc before the token is removed. */
+    virtual void willRemove() { }
 
 protected:
     friend class cbl_internal::ListenersBase;


### PR DESCRIPTION
* Ported the fix from release/3.1 branch (848039e15c9a82684c67b08ae35d9fe944dd6a29) which is the fix for the original issue, CBL-2914.

* PROBLEM : There could be a race b/w explicitly removing the query’s listener token and stopping the live query when closing the database on two different threads. If the listener token is released before the the database calls the live query (a pain CBLStoppable pointer) to stop, crash will happen.

* Fixed the issue by making the database retains the stoppable objects when they are registered and releases the CBLStoppable objects when they are unregistered. This will ensure that objects are alive until they are unregistered.

* Make CBLStoppable wrapping CBLRefCounted so that multiple inheritance with CBLStoppable is not required and the retain / release the stoppable object can be done in a single place at the CBLStopptable class.

* Added new CBLReplicatorStopptable and CBLQueryListenerStoppable class inheriting from CBLStoppable and implementing the virtual stop() function.

* Added a virtual willRemove() function in CBLListenerToken so that its subclasses can implement to perform any tasks before removing the token from its owner.

* In ListenerToken<CBLQueryChangeListener>, implemented willRemove() function to disable the query’s observer instead of doing that in the destructor as now the ListenerToken is also retained by the database so the destructor will not be called to disable the query observer.

* In ListenerToken<CBLQueryChangeListener>’s setEnabled(), ensured to not double enable or disable query’s observer.