### PR TITLE
CBL-4509 : Remove bitcode flag from build script

### DIFF
--- a/scripts/build_apple.sh
+++ b/scripts/build_apple.sh
@@ -73,7 +73,7 @@ function xcarchive
     -destination "${DESTINATION}" \
     ${XCODE_BUILD_VERSION} ${XCODE_BUILD_NUMBER} \
     -archivePath "${ARCHIVE_PATH}/${FRAMEWORK_NAME}.xcarchive" \
-    "ONLY_ACTIVE_ARCH=NO" "BITCODE_GENERATION_MODE=bitcode" \
+    "ONLY_ACTIVE_ARCH=NO" \
     "CODE_SIGNING_REQUIRED=NO" "CODE_SIGN_IDENTITY=" \
     "SKIP_INSTALL=NO" | xcpretty
 


### PR DESCRIPTION
* Apple doesn’t allow to include bitcode in the binary and framework anymore.

* Removed the BITCODE_GENERATION_MODE from the apple build script.