### PR TITLE
Fix a bug where the temp directory cannot be deleted

### DIFF
--- a/jenkins/ci_cross_build.py
+++ b/jenkins/ci_cross_build.py
@@ -7,7 +7,7 @@
 from genericpath import isdir
 from pathlib import Path
 from progressbar import ProgressBar
-from tempfile import TemporaryDirectory
+from tempfile import mkdtemp
 import json
 import argparse
 import urllib.request
@@ -88,23 +88,24 @@ def check_toolchain(name: str):
         # For now, assume that the toolchain is tar.gz
         print(f'Downloading {name} toolchain...')
         urllib.request.urlretrieve(json_data[name]['toolchain'], "toolchain.tar.gz", show_download_progress)
-        with TemporaryDirectory() as tmpdir:
-            tmppath = Path(tmpdir)
-            print(f'Extracting {name} toolchain to {toolchain_path}...')
-            with tarfile.open('toolchain.tar.gz', 'r:gz') as tar:
-                safe_extract(tar, tmpdir, members=tar_extract_callback(tar))
+        tmpdir = mkdtemp()
+        tmppath = Path(tmpdir)
+        print(f'Extracting {name} toolchain to {toolchain_path}...')
+        with tarfile.open('toolchain.tar.gz', 'r:gz') as tar:
+            safe_extract(tar, tmpdir, members=tar_extract_callback(tar))
 
-            outer_dir = tmppath / os.listdir(tmpdir)[0]
-            files_to_move = outer_dir.glob("**/*")
-            for file in files_to_move:
-                relative = file.relative_to(outer_dir)
-                os.makedirs(tmppath / relative.parent, 0o755, True)
-                shutil.move(str(file), tmppath / relative.parent)
+        outer_dir = tmppath / os.listdir(tmpdir)[0]
+        files_to_move = outer_dir.glob("**/*")
+        for file in files_to_move:
+            relative = file.relative_to(outer_dir)
+            os.makedirs(tmppath / relative.parent, 0o755, True)
+            shutil.move(str(file), tmppath / relative.parent)
 
-            os.rmdir(outer_dir)
-            os.remove("toolchain.tar.gz")
-            if not toolchain_path.exists():
-                shutil.move(tmpdir, toolchain_path)
+        os.rmdir(outer_dir)
+        os.remove("toolchain.tar.gz")
+        if not toolchain_path.exists():
+            shutil.move(tmpdir, toolchain_path)
+            
         return toolchain_path
     else:
         print("No toolchain specified, using generic installed...")
@@ -124,36 +125,36 @@ def check_sysroot(name: str):
     print(f'Downloading {name} sysroot...')
     sysroot_name=json_data[name]['sysroot']
     urllib.request.urlretrieve(f'http://downloads.build.couchbase.com/mobile/sysroot/{sysroot_name}', f'{sysroot_name}', show_download_progress)
-    with TemporaryDirectory() as tmpdir:
-        print(f'Extracting {name} sysroot to {sysroot_path}...')
-        if sysroot_name.endswith("zip"):
-            with zipfile.ZipFile('sysroot.zip', 'r') as zip:
-                # Python doesn't have support for zipped symlinks?!
-                SYMLINK_TYPE  = 0xA
-                zip_total = len(zip.infolist())
-                zip_done = 0
-                pbar = ProgressBar(maxval=zip_total)
-                pbar.start()
-                for zipinfo in zip.infolist():
-                    if (zipinfo.external_attr >> 28) == SYMLINK_TYPE:
-                        linkpath = zip.read(zipinfo.filename).decode('utf-8')
-                        destpath = os.path.join(tmpdir, zipinfo.filename)
-                        os.symlink(linkpath, destpath)
-                    else:
-                        zip.extract(zipinfo, tmpdir)
+    tmpdir = mkdtemp()
+    print(f'Extracting {name} sysroot to {sysroot_path}...')
+    if sysroot_name.endswith("zip"):
+        with zipfile.ZipFile('sysroot.zip', 'r') as zip:
+            # Python doesn't have support for zipped symlinks?!
+            SYMLINK_TYPE  = 0xA
+            zip_total = len(zip.infolist())
+            zip_done = 0
+            pbar = ProgressBar(maxval=zip_total)
+            pbar.start()
+            for zipinfo in zip.infolist():
+                if (zipinfo.external_attr >> 28) == SYMLINK_TYPE:
+                    linkpath = zip.read(zipinfo.filename).decode('utf-8')
+                    destpath = os.path.join(tmpdir, zipinfo.filename)
+                    os.symlink(linkpath, destpath)
+                else:
+                    zip.extract(zipinfo, tmpdir)
 
-                    zip_done += 1
-                    pbar.update(zip_done)
-        elif sysroot_name.endswith("tar.gz"):
-            # Eventually let's make them all tarball
-            with tarfile.open(sysroot_name, 'r:gz') as tar:
-                safe_extract(tar, tmpdir, members=tar_extract_callback(tar))
-        else:
-            raise NotImplementedError("Unknown file type for sysroot")
+                zip_done += 1
+                pbar.update(zip_done)
+    elif sysroot_name.endswith("tar.gz"):
+        # Eventually let's make them all tarball
+        with tarfile.open(sysroot_name, 'r:gz') as tar:
+            safe_extract(tar, tmpdir, members=tar_extract_callback(tar))
+    else:
+        raise NotImplementedError("Unknown file type for sysroot")
 
-        os.remove(sysroot_name)
-        if not sysroot_path.exists():
-            shutil.move(tmpdir, sysroot_path)
+    os.remove(sysroot_name)
+    if not sysroot_path.exists():
+        shutil.move(tmpdir, sysroot_path)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Perform a cross compilation of Couchbase Lite C')


### PR DESCRIPTION
It is moved as part of the process, so the implicit delete with TemporaryDirectory is closed fails