### PR TITLE
Add maxRevTreeDepth to SaveDocument functions

### DIFF
--- a/include/cbl/CBLCollection.h
+++ b/include/cbl/CBLCollection.h
@@ -217,7 +217,8 @@ const CBLDocument* _cbl_nullable CBLCollection_GetDocument(const CBLCollection* 
     @return  True on success, false on failure. */
 bool CBLCollection_SaveDocument(CBLCollection* collection,
                                 CBLDocument* doc,
-                                CBLError* _cbl_nullable outError) CBLAPI;
+                                CBLError* _cbl_nullable outError,
+                                uint32_t maxRevTreeDepth = 0) CBLAPI;
 
 /** Saves a (mutable) document to the collection.
     If a conflicting revision has been saved since \p doc was loaded, the \p concurrency
@@ -232,7 +233,8 @@ bool CBLCollection_SaveDocument(CBLCollection* collection,
 bool CBLCollection_SaveDocumentWithConcurrencyControl(CBLCollection* collection,
                                                       CBLDocument* doc,
                                                       CBLConcurrencyControl concurrency,
-                                                      CBLError* _cbl_nullable outError) CBLAPI;
+                                                      CBLError* _cbl_nullable outError,
+                                                      uint32_t maxRevTreeDepth = 0) CBLAPI;
 
 /** Saves a (mutable) document to the collection, allowing for custom conflict handling in the event
     that the document has been updated since \p doc was loaded.
@@ -246,7 +248,8 @@ bool CBLCollection_SaveDocumentWithConflictHandler(CBLCollection* collection,
                                                    CBLDocument* doc,
                                                    CBLConflictHandler conflictHandler,
                                                    void* _cbl_nullable context,
-                                                   CBLError* _cbl_nullable outError) CBLAPI;
+                                                   CBLError* _cbl_nullable outError,
+                                                   uint32_t maxRevTreeDepth = 0) CBLAPI;
 
 /** Deletes a document from the collection. Deletions are replicated.
     @warning  You are still responsible for releasing the CBLDocument.

--- a/include/cbl/CBLDocument.h
+++ b/include/cbl/CBLDocument.h
@@ -87,7 +87,8 @@ CBL_REFCOUNTED(CBLDocument*, Document);
     @return  True on success, false on failure. */
 bool CBLDatabase_SaveDocument(CBLDatabase* db,
                               CBLDocument* doc,
-                              CBLError* _cbl_nullable outError) CBLAPI;
+                              CBLError* _cbl_nullable outError,
+                              uint32_t maxRevTreeDepth = 0) CBLAPI;
 
 /** Saves a (mutable) document to the default collection.
     If a conflicting revision has been saved since \p doc was loaded, the \p concurrency
@@ -103,7 +104,8 @@ bool CBLDatabase_SaveDocument(CBLDatabase* db,
 bool CBLDatabase_SaveDocumentWithConcurrencyControl(CBLDatabase* db,
                                                     CBLDocument* doc,
                                                     CBLConcurrencyControl concurrency,
-                                                    CBLError* _cbl_nullable outError) CBLAPI;
+                                                    CBLError* _cbl_nullable outError,
+                                                    uint32_t maxRevTreeDepth = 0) CBLAPI;
 
 /** Saves a (mutable) document to the default collection, allowing for custom conflict handling in the event
     that the document has been updated since \p doc was loaded.
@@ -118,7 +120,8 @@ bool CBLDatabase_SaveDocumentWithConflictHandler(CBLDatabase* db,
                                                  CBLDocument* doc,
                                                  CBLConflictHandler conflictHandler,
                                                  void* _cbl_nullable context,
-                                                 CBLError* _cbl_nullable outError) CBLAPI;
+                                                 CBLError* _cbl_nullable outError,
+                                                 uint32_t maxRevTreeDepth = 0) CBLAPI;
 
 /** Deletes a document from the default collection. Deletions are replicated.
     @warning  You are still responsible for releasing the CBLDocument.

--- a/src/CBLCollection_CAPI.cc
+++ b/src/CBLCollection_CAPI.cc
@@ -153,20 +153,22 @@ CBLDocument* CBLCollection_GetMutableDocument(CBLCollection* collection, FLStrin
 
 bool CBLCollection_SaveDocument(CBLCollection* collection,
                                 CBLDocument* doc,
-                                CBLError* outError) noexcept
+                                CBLError* outError,
+                                uint32_t maxRevTreeDepth = 0) noexcept
 {
     return CBLCollection_SaveDocumentWithConcurrencyControl(collection, doc,
                                                             kCBLConcurrencyControlLastWriteWins,
-                                                            outError);
+                                                            outError, maxRevTreeDepth);
 }
 
 bool CBLCollection_SaveDocumentWithConcurrencyControl(CBLCollection* collection,
                                                       CBLDocument* doc,
                                                       CBLConcurrencyControl concurrency,
-                                                      CBLError* outError) noexcept
+                                                      CBLError* outError,
+                                                      uint32_t maxRevTreeDepth = 0) noexcept
 {
     try {
-        if (doc->save(collection, {concurrency}))
+        if (doc->save(collection, {concurrency}, maxRevTreeDepth))
             return true;
         C4Error::set(LiteCoreDomain, kC4ErrorConflict, {}, internal(outError));
         return false;
@@ -177,10 +179,11 @@ bool CBLCollection_SaveDocumentWithConflictHandler(CBLCollection* collection,
                                                    CBLDocument* doc,
                                                    CBLConflictHandler conflictHandler,
                                                    void *context,
-                                                   CBLError* outError) noexcept
+                                                   CBLError* outError,
+                                                   uint32_t maxRevTreeDepth = 0) noexcept
 {
     try {
-        if (doc->save(collection, {conflictHandler, context}))
+        if (doc->save(collection, {conflictHandler, context}, maxRevTreeDepth))
             return true;
         C4Error::set(LiteCoreDomain, kC4ErrorConflict, {}, internal(outError));
         return false;

--- a/src/CBLDatabase_CAPI.cc
+++ b/src/CBLDatabase_CAPI.cc
@@ -181,20 +181,22 @@ CBLDocument* CBLDatabase_GetMutableDocument(CBLDatabase* db, FLString docID,
 
 bool CBLDatabase_SaveDocument(CBLDatabase* db,
                               CBLDocument* doc,
-                              CBLError* outError) noexcept
+                              CBLError* outError,
+                              uint32_t maxRevTreeDepth = 0) noexcept
 {
     return CBLDatabase_SaveDocumentWithConcurrencyControl
-        (db, doc, kCBLConcurrencyControlLastWriteWins, outError);
+        (db, doc, kCBLConcurrencyControlLastWriteWins, outError, maxRevTreeDepth);
 }
 
 bool CBLDatabase_SaveDocumentWithConcurrencyControl(CBLDatabase* db,
                                                     CBLDocument* doc,
                                                     CBLConcurrencyControl concurrency,
-                                                    CBLError* outError) noexcept
+                                                    CBLError* outError,
+                                                    uint32_t maxRevTreeDepth = 0) noexcept
 {
     try {
         auto col = db->getDefaultCollection(true);
-        return CBLCollection_SaveDocumentWithConcurrencyControl(col, doc, concurrency, outError);
+        return CBLCollection_SaveDocumentWithConcurrencyControl(col, doc, concurrency, outError, maxRevTreeDepth);
     } catchAndBridge(outError)
 }
 
@@ -202,12 +204,13 @@ bool CBLDatabase_SaveDocumentWithConflictHandler(CBLDatabase* db,
                                                  CBLDocument* doc,
                                                  CBLConflictHandler conflictHandler,
                                                  void *context,
-                                                 CBLError* outError) noexcept
+                                                 CBLError* outError,
+                                                 uint32_t maxRevTreeDepth = 0) noexcept
 {
     try {
         auto col = db->getDefaultCollection(true);
         return CBLCollection_SaveDocumentWithConflictHandler(col, doc, conflictHandler,
-                                                             context, outError);
+                                                             context, outError, maxRevTreeDepth);
     } catchAndBridge(outError)
 }
 

--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -76,7 +76,7 @@ CBLDatabase* _cbl_nullable CBLDocument::database() const {
 #pragma mark - SAVING:
 
 
-bool CBLDocument::save(CBLCollection* collection, const SaveOptions &opt) {
+bool CBLDocument::save(CBLCollection* collection, const SaveOptions &opt, uint32_t maxRevTreeDepth = 0) {
     Retained<C4Document> orignalDoc = nullptr, savingDoc = nullptr;
     bool success = false, retrying = false;
     
@@ -125,7 +125,7 @@ bool CBLDocument::save(CBLCollection* collection, const SaveOptions &opt) {
             
             if (savingDoc) {
                 // Update existing doc:
-                newDoc = savingDoc->update(body, revFlags);
+                newDoc = savingDoc->update(body, revFlags, maxRevTreeDepth);
             } else {
                 // Create new doc:
                 C4DocPutRequest rq = {};

--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -210,7 +210,7 @@ public:
         bool deleting = false;
     };
     
-    bool save(CBLCollection* collection, const SaveOptions &opt);
+    bool save(CBLCollection* collection, const SaveOptions &opt, uint32_t maxRevTreeDepth = 0);
     
 
 #pragma mark - Conflict resolution:


### PR DESCRIPTION
This pull request is an example for support ticket https://support.couchbase.com/hc/en-us/requests/55614

It is a feature that is requested by Doctolib, to be able to cleanup old revisions by saving the document with only 1 revision locally.

It is linked to another pull request in couchbase-lite-core: https://github.com/couchbase/couchbase-lite-core/pull/1892