### PR TITLE
Enable verbose log in flaky tests

### DIFF
--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -85,6 +85,10 @@ CBLTest::~CBLTest() {
             WARN("Failed to close database: " << error.domain << "/" << error.code);
         CBLDatabase_Release(db);
     }
+    
+    // Reset to the default warning level:
+    CBLLog_SetConsoleLevel(kCBLLogWarning);
+    
     if (CBL_InstanceCount() > 0)
         CBL_DumpInstances();
     CHECK(CBL_InstanceCount() == 0);

--- a/test/DatabaseTest.cc
+++ b/test/DatabaseTest.cc
@@ -1664,6 +1664,8 @@ TEST_CASE_METHOD(DatabaseTest, "Get blob", "[Blob]") {
 #ifdef COUCHBASE_ENTERPRISE
 
 TEST_CASE_METHOD(DatabaseTest, "Close Database with Active Replicator") {
+    CBLLog_SetConsoleLevel(kCBLLogVerbose);
+    
     CBLError error;
     otherDB = CBLDatabase_Open(kOtherDBName, &kDatabaseConfiguration, &error);
     REQUIRE(otherDB);
@@ -1699,6 +1701,8 @@ TEST_CASE_METHOD(DatabaseTest, "Close Database with Active Replicator") {
 }
 
 TEST_CASE_METHOD(DatabaseTest, "Delete Database with Active Replicator") {
+    CBLLog_SetConsoleLevel(kCBLLogVerbose);
+    
     CBLError error;
     otherDB = CBLDatabase_Open(kOtherDBName, &kDatabaseConfiguration, &error);
     REQUIRE(otherDB);

--- a/test/ReplicatorPropEncTest.cc
+++ b/test/ReplicatorPropEncTest.cc
@@ -624,8 +624,6 @@ TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest, "Skip decryption : ok", "[Rep
 
 
 TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest, "Encryption error", "[Replicator][Encryptable]") {
-    CBLLog_SetConsoleLevel(kCBLLogVerbose);
-    
     auto doc = CBLDocument_CreateWithID("doc1"_sl);
     auto props = CBLDocument_MutableProperties(doc);
     


### PR DESCRIPTION
* Enabled verbose logging "Close Database with Active Replicator" and "Delete Database with Active Replicator" which currently failed on Jenkins's Debian 10 for investigation. The issue cannot be reproduced locally and on the other platforms.

* Changes are in the test code only.