### PR TITLE
Remove scope and collection cache

### DIFF
--- a/include/cbl/CBLCollection.h
+++ b/include/cbl/CBLCollection.h
@@ -155,12 +155,10 @@ CBLScope* CBLDatabase_DefaultScope(const CBLDatabase* db,
                                    CBLError* _cbl_nullable outError) CBLAPI;
 
 /** Returns the default collection.
-    @note  The default collection may not exist if it was deleted.
-           Also, the default collection cannot be recreated after being deleted.
     @note  You are responsible for releasing the returned collection.
     @param db  The database.
     @param outError  On failure, the error will be written here.
-    @return  A \ref CBLCollection instance, or NULL if the default collection doesn't exist or an error occurred. */
+    @return  A \ref CBLCollection instance, or NULL if an error occurred. */
 CBLCollection* _cbl_nullable CBLDatabase_DefaultCollection(const CBLDatabase* db,
                                                            CBLError* _cbl_nullable outError) CBLAPI;
 

--- a/src/CBLCollection.cc
+++ b/src/CBLCollection.cc
@@ -70,18 +70,8 @@ namespace cbl_internal {
             change.collection = _collection;
             change.docID = _docID;
 
-            Retained<CBLDatabase> db;
-            try {
-                db = _collection->database();
-            } catch (...) {
-                C4Error error = C4Error::fromCurrentException();
-                CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
-                        "Document changed notification failed: %s", error.description().c_str());
-            }
-
-            if (db) {
-                db->notify(this, change);
-            }
+            Retained<CBLDatabase> db = _collection->database();
+            db->notify(this, change);
         }
 
         Retained<CBLCollection> _collection;

--- a/src/CBLCollection_CAPI.cc
+++ b/src/CBLCollection_CAPI.cc
@@ -87,7 +87,7 @@ CBLScope* CBLDatabase_DefaultScope(const CBLDatabase* db, CBLError* outError) no
 
 CBLCollection* CBLDatabase_DefaultCollection(const CBLDatabase* db, CBLError* outError) noexcept {
     try {
-        return const_cast<CBLDatabase*>(db)->getDefaultCollection(false).detach();
+        return const_cast<CBLDatabase*>(db)->getDefaultCollection().detach();
     } catchAndBridge(outError)
 }
 
@@ -115,9 +115,7 @@ uint64_t CBLCollection_Count(const CBLCollection* collection) noexcept {
 
 /** Private API */
 CBLDatabase* CBLCollection_Database(const CBLCollection* collection) noexcept {
-    try {
-        return collection->database();
-    } catchAndWarn()
+    return collection->database();
 }
 
 /** Private API */

--- a/src/CBLCollection_Internal.hh
+++ b/src/CBLCollection_Internal.hh
@@ -36,8 +36,16 @@ public:
     CBLCollection(C4Collection* c4col, CBLScope* scope, CBLDatabase* database)
     :_c4col(c4col, database)
     ,_scope(scope)
+    ,_database(retain(database))
     ,_name(c4col->getName())
     { }
+    
+    ~CBLCollection() {
+        LOCK(_adoptMutex);
+        if (!_adopted) {
+            release(_database);
+        }
+    }
     
 #pragma mark - ACCESSORS:
     
@@ -47,9 +55,7 @@ public:
     bool isValid() const noexcept               {return _c4col.isValid();}
     uint64_t count() const                      {return _c4col.useLocked()->getDocumentCount();}
     uint64_t lastSequence() const               {return static_cast<uint64_t>(_c4col.useLocked()->getLastSequence());}
-    
-    /** Throw NotOpen if the collection or database is invalid */
-    CBLDatabase* database() const           {return _c4col.database();}
+    CBLDatabase* database() const               {return _database; }
     
 #pragma mark - DOCUMENTS:
     
@@ -161,16 +167,23 @@ protected:
     friend struct CBLDocument;
     friend struct cbl_internal::ListenerToken<CBLCollectionDocumentChangeListener>;
     
+    // Called by the database to take an ownership.
+    // Release the database to avoid the circular reference
+    void adopt(CBLDatabase* db) {
+        assert(_database == db);
+        LOCK(_adoptMutex);
+        if (!_adopted) {
+            _scope->adopt(db);
+            release(_database);
+            _adopted = true;
+        }
+    }
+    
     auto useLocked()                        { return _c4col.useLocked(); }
     template <class LAMBDA>
     void useLocked(LAMBDA callback)         { _c4col.useLocked(callback); }
     template <class RESULT, class LAMBDA>
     RESULT useLocked(LAMBDA callback)       { return _c4col.useLocked<RESULT>(callback); }
-    
-    /** Called by the database when the database is released. */
-    void close() {
-        _c4col.close(); // This will invalidate the database pointer in the access lock
-    }
     
 private:
     
@@ -204,18 +217,8 @@ private:
     }
     
     void collectionChanged() {
-        Retained<CBLDatabase> db;
-        try {
-            db = database();
-        } catch (...) {
-            C4Error error = C4Error::fromCurrentException();
-            CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
-                    "Collection changed notification failed: %s", error.description().c_str());
-        }
-        
-        if (db) {
-            db->notify(std::bind(&CBLCollection::callCollectionChangeListeners, this));
-        }
+        Retained<CBLDatabase> db = database();    
+        db->notify(std::bind(&CBLCollection::callCollectionChangeListeners, this));
     }
 
     void callCollectionChangeListeners() {
@@ -253,12 +256,10 @@ private:
         :shared_access_lock(std::move(c4col), *database->c4db())
         ,_c4db(database->c4db())
         ,_col(c4col)
-        ,_db(database)
         {
             _sentry = [this](C4Collection* c4col) {
                 if (!_isValid()) {
-                    C4Error::raise(LiteCoreDomain, kC4ErrorNotOpen,
-                                   "Invalid collection: either deleted, or db closed");
+                    C4Error::raise(LiteCoreDomain, kC4ErrorNotOpen, "Invalid collection: either deleted or db closed");
                 }
             };
         }
@@ -268,22 +269,11 @@ private:
             return _isValid();
         }
         
-        CBLDatabase* database() const {
-            auto lock = useLocked();
-            return _db;
-        }
-        
-        /** Invalidate the database pointer */
-        void close() noexcept {
-            LOCK_GUARD lock(getMutex());
-            _db = nullptr;
-        }
-        
     private:
-        bool _isValid() const noexcept                  { return _db && _col->isValid(); }
+        // Unsafe: need to call under lock:
+        bool _isValid() const noexcept                  { return !_c4db->isClosedNoLock() && _col->isValid(); }
         
         CBLDatabase::SharedC4DatabaseAccessLock _c4db;  // For retaining the shared lock
-        CBLDatabase* _cbl_nullable              _db;
         C4Collection*                           _col;
     };
     
@@ -293,6 +283,10 @@ private:
     
     alloc_slice                                             _name;
     Retained<CBLScope>                                      _scope;
+    
+    CBLDatabase*                                            _database;         // Retained unless being adopted
+    bool                                                    _adopted {false};  // Adopted by the database
+    mutable std::mutex                                      _adoptMutex;
     
     std::unique_ptr<C4CollectionObserver>                   _observer;
     Listeners<CBLCollectionChangeListener>                  _listeners;

--- a/src/CBLDatabase_CAPI.cc
+++ b/src/CBLDatabase_CAPI.cc
@@ -142,7 +142,7 @@ const CBLDatabaseConfiguration CBLDatabase_Config(const CBLDatabase* db) noexcep
 
 uint64_t CBLDatabase_Count(const CBLDatabase* db) noexcept {
     try {
-        auto col = const_cast<CBLDatabase*>(db)->getDefaultCollection(true);
+        auto col = const_cast<CBLDatabase*>(db)->getInternalDefaultCollection();
         return col->count();
     } catchAndWarn();
 }
@@ -150,7 +150,7 @@ uint64_t CBLDatabase_Count(const CBLDatabase* db) noexcept {
 /** Private API */
 uint64_t CBLDatabase_LastSequence(const CBLDatabase* db) noexcept {
     try {
-        auto col = const_cast<CBLDatabase*>(db)->getDefaultCollection(true);
+        auto col = const_cast<CBLDatabase*>(db)->getInternalDefaultCollection();
         return col->lastSequence();
     } catchAndWarn()
 }
@@ -163,7 +163,7 @@ const CBLDocument* CBLDatabase_GetDocument(const CBLDatabase* db, FLString docID
                                            CBLError* outError) noexcept
 {
     try {
-        auto col = const_cast<CBLDatabase*>(db)->getDefaultCollection(true);
+        auto col = const_cast<CBLDatabase*>(db)->getInternalDefaultCollection();
         return CBLCollection_GetDocument(col, docID, outError);
     } catchAndBridge(outError)
 }
@@ -173,7 +173,7 @@ CBLDocument* CBLDatabase_GetMutableDocument(CBLDatabase* db, FLString docID,
                                             CBLError* outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_GetMutableDocument(col, docID, outError);
     } catchAndBridge(outError)
 }
@@ -193,7 +193,7 @@ bool CBLDatabase_SaveDocumentWithConcurrencyControl(CBLDatabase* db,
                                                     CBLError* outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_SaveDocumentWithConcurrencyControl(col, doc, concurrency, outError);
     } catchAndBridge(outError)
 }
@@ -205,7 +205,7 @@ bool CBLDatabase_SaveDocumentWithConflictHandler(CBLDatabase* db,
                                                  CBLError* outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_SaveDocumentWithConflictHandler(col, doc, conflictHandler,
                                                              context, outError);
     } catchAndBridge(outError)
@@ -216,7 +216,7 @@ bool CBLDatabase_DeleteDocument(CBLDatabase *db,
                                 CBLError* outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_DeleteDocument(col, doc, outError);
     } catchAndBridge(outError)
 }
@@ -227,7 +227,7 @@ bool CBLDatabase_DeleteDocumentWithConcurrencyControl(CBLDatabase *db,
                                                       CBLError* outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_DeleteDocumentWithConcurrencyControl(col, doc, concurrency, outError);
     } catchAndBridge(outError)
 }
@@ -238,7 +238,7 @@ bool CBLDatabase_DeleteDocumentByID(CBLDatabase* db,
                                     CBLError* outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_DeleteDocumentByID(col, docID, outError);
     } catchAndBridge(outError)
 }
@@ -248,7 +248,7 @@ bool CBLDatabase_PurgeDocument(CBLDatabase* db,
                                CBLError* outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         CBLDocument::checkCollectionMatches(doc->collection(), col);
         return CBLCollection_PurgeDocumentByID(col, doc->docID(), outError);
     } catchAndBridge(outError)
@@ -260,7 +260,7 @@ bool CBLDatabase_PurgeDocumentByID(CBLDatabase* db,
                                    CBLError* outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_PurgeDocumentByID(col, docID, outError);
     } catchAndBridge(outError)
 }
@@ -270,7 +270,7 @@ CBLTimestamp CBLDatabase_GetDocumentExpiration(CBLDatabase* db,
                                                CBLError* outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_GetDocumentExpiration(col, docID, outError);
     } catchAndBridge(outError)
 }
@@ -281,7 +281,7 @@ bool CBLDatabase_SetDocumentExpiration(CBLDatabase* db,
                                        CBLError* outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_SetDocumentExpiration(col, docID, expiration, outError);
     } catchAndBridge(outError)
 }
@@ -296,7 +296,7 @@ bool CBLDatabase_CreateValueIndex(CBLDatabase *db,
                                   CBLError *outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_CreateValueIndex(col, name, config, outError);
     } catchAndBridge(outError)
 }
@@ -308,7 +308,7 @@ bool CBLDatabase_CreateFullTextIndex(CBLDatabase *db,
                                      CBLError *outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_CreateFullTextIndex(col, name, config, outError);
     } catchAndBridge(outError)
 }
@@ -319,7 +319,7 @@ bool CBLDatabase_DeleteIndex(CBLDatabase *db,
                              CBLError *outError) noexcept
 {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         return CBLCollection_DeleteIndex(col, name, outError);
     } catchAndBridge(outError)
 }
@@ -327,7 +327,7 @@ bool CBLDatabase_DeleteIndex(CBLDatabase *db,
 
 FLArray CBLDatabase_GetIndexNames(CBLDatabase *db) noexcept {
     try {
-        auto col = db->getDefaultCollection(true);
+        auto col = db->getInternalDefaultCollection();
         
         CBLError error;
         auto result = CBLCollection_GetIndexNames(col, &error);
@@ -380,7 +380,7 @@ CBLListenerToken* CBLDatabase_AddChangeListener(const CBLDatabase* db,
     };
 
     try {
-        CBLCollection* col = const_cast<CBLDatabase*>(db)->getDefaultCollection(true).detach();
+        CBLCollection* col = const_cast<CBLDatabase*>(db)->getInternalDefaultCollection().detach();
         wrappedContext->collection = col;
         
         auto token = CBLCollection_AddChangeListener(col, wrappedListener, wrappedContext);
@@ -421,7 +421,7 @@ CBLListenerToken* CBLDatabase_AddDocumentChangeListener(const CBLDatabase* db,
     };
     
     try {
-        CBLCollection* col = const_cast<CBLDatabase*>(db)->getDefaultCollection(true).detach();
+        CBLCollection* col = const_cast<CBLDatabase*>(db)->getInternalDefaultCollection().detach();
         wrappedContext->collection = col;
         
         auto token = CBLCollection_AddDocumentChangeListener(col, docID, wrappedListener, wrappedContext);

--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -68,7 +68,6 @@ CBLDocument::~CBLDocument() {
 
 
 CBLDatabase* _cbl_nullable CBLDocument::database() const {
-    // Could throw kC4ErrorNotOpen if the collection is deleted, or database is released.
     return _collection ? _collection->database() : nullptr;
 }
 

--- a/src/CBLPrivate.h
+++ b/src/CBLPrivate.h
@@ -28,8 +28,8 @@ CBL_CAPI_BEGIN
     void CBLLog_BeginExpectingExceptions() CBLAPI;
     void CBLLog_EndExpectingExceptions() CBLAPI;
 
-/** Returns the collection's database, or NULL if the collection is invalid, or the database is released. */
-    CBLDatabase* _cbl_nullable CBLCollection_Database(const CBLCollection*) CBLAPI;
+/** Returns the collection's database, */
+    CBLDatabase* CBLCollection_Database(const CBLCollection*) CBLAPI;
 
 /** Returns the last sequence number assigned in the database (default collection).
     This starts at zero and increments every time a document is saved or deleted. */

--- a/src/CBLReplicator_CAPI.cc
+++ b/src/CBLReplicator_CAPI.cc
@@ -84,14 +84,22 @@ void CBLReplicator_SetSuspended(CBLReplicator* repl, bool sus) noexcept   {repl-
 
 FLDict CBLReplicator_PendingDocumentIDs(CBLReplicator *repl, CBLError *outError) noexcept {
     try {
-        auto col = repl->database()->getDefaultCollection(true);
+        auto col = repl->defaultCollection();
+        if (!col) {
+            C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter,
+                           "The default collection is not included in the replicator config.");
+        }
         return CBLReplicator_PendingDocumentIDs2(repl, col, outError);
     } catchAndBridge(outError)
 }
 
 bool CBLReplicator_IsDocumentPending(CBLReplicator *repl, FLString docID, CBLError *outError) noexcept {
     try {
-        auto col = repl->database()->getDefaultCollection(true);
+        auto col = repl->defaultCollection();
+        if (!col) {
+            C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter,
+                           "The default collection is not included in the replicator config.");
+        }
         return CBLReplicator_IsDocumentPending2(repl, docID, col, outError);
     } catchAndBridge(outError)
 }

--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -72,7 +72,7 @@ public:
         call_once(once, std::bind(&C4RegisterBuiltInWebSocket));
         
         if (_conf.database) {
-            _defaultCollection = _conf.database->getDefaultCollection(true);
+            _defaultCollection = _conf.database->getInternalDefaultCollection();
         }
 
         _conf.validate();
@@ -237,9 +237,21 @@ public:
         _stoppable = make_unique<CBLReplicatorStoppable>(this);
     }
     
+    CBLCollection* _cbl_nullable defaultCollection() {
+        if (_defaultCollection) {
+            return _defaultCollection;
+        }
+        
+        if (auto i = _collections.find(kC4DefaultCollectionSpec); i != _collections.end()) {
+            return i->second.collection;
+        }
+        
+        return nullptr;
+    }
 
     const ReplicatorConfiguration* configuration() const    {return &_conf;}
     CBLDatabase* database() const                           {return _db;}
+    
     void setHostReachable(bool reachable)                   {_c4repl->setHostReachable(reachable);}
     void setSuspended(bool suspended)                       {_c4repl->setSuspended(suspended);}
     void stop()                                             {_c4repl->stop();}

--- a/src/CBLScope.cc
+++ b/src/CBLScope.cc
@@ -23,6 +23,5 @@ using namespace fleece;
 
 Retained<CBLCollection> CBLScope::getCollection(slice collectionName) const {
     LOCK(_mutex);
-    checkOpen();
     return _database->getCollection(collectionName, _name);
 }

--- a/test/CollectionTest.cc
+++ b/test/CollectionTest.cc
@@ -399,8 +399,6 @@ TEST_CASE_METHOD(CollectionTest, "Create Existing Collection", "[Collection]") {
     REQUIRE(col2);
     CHECK(CBLCollection_Name(col2) == "colA"_sl);
     
-    CHECK(col1 == col2);
-    
     CBLCollection_Release(col1);
     CBLCollection_Release(col2);
 }
@@ -462,10 +460,10 @@ TEST_CASE_METHOD(CollectionTest, "Get Collections from Scope", "[Collection]") {
     CHECK(CBLScope_Name(scope) == "scopeA"_sl);
     
     CBLCollection* colA2 = CBLScope_Collection(scope, "colA"_sl, &error);
-    CHECK(colA == colA2);
+    CHECK(CBLCollection_Name(colA2) == "colA"_sl);
     
     CBLCollection* colB2 = CBLScope_Collection(scope, "colB"_sl, &error);
-    CHECK(colB == colB2);
+    CHECK(CBLCollection_Name(colB2) == "colB"_sl);
     
     CHECK(!CBLScope_Collection(scope, "colC"_sl, &error));
     CHECK(error.code == 0);
@@ -539,8 +537,6 @@ TEST_CASE_METHOD(CollectionTest, "Valid Collection and Scope Names", "[Collectio
         
         CBLCollection* col2 = CBLDatabase_Collection(db, slice(name), slice(name), &error);
         REQUIRE(col2);
-        
-        CHECK(col1 == col2);
         
         CBLCollection_Release(col1);
         CBLCollection_Release(col2);

--- a/test/CollectionTest_Cpp.cc
+++ b/test/CollectionTest_Cpp.cc
@@ -232,7 +232,6 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Create Existing Collection", "[Collect
     REQUIRE(col2);
     CHECK(col2.name() == "colA");
     CHECK(col2.scopeName() == "scopeA");
-    CHECK(col1 == col2);
 }
 
 TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Delete Collection", "[Collection]") {

--- a/test/LogTest.cc
+++ b/test/LogTest.cc
@@ -260,7 +260,7 @@ TEST_CASE_METHOD(LogTest, "File Logging : Set Log Level", "[Log][FileLog]") {
     }
     
     // Verify:
-    int lineCount = 1; // Header:
+    int lineCount = 2; // 2 header lines :
     for (CBLLogLevel level : kLogLevels) {
         if (level == kCBLLogNone)
             continue;

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -505,7 +505,7 @@ TEST_CASE_METHOD(QueryTest, "Query Listener", "[Query][LiveQuery]") {
     
     cerr << "Adding listener\n";
     ListenerState state;
-    auto listenerToken = CBLQuery_AddChangeListener(query, [](void *context, CBLQuery* query, CBLListenerToken* token) {
+    CBLListenerToken* listenerToken = CBLQuery_AddChangeListener(query, [](void *context, CBLQuery* query, CBLListenerToken* token) {
         ((ListenerState*)context)->receivedCallback(context, query, token);
     }, &state);
 
@@ -543,7 +543,7 @@ TEST_CASE_METHOD(QueryTest, "Remove Query Listener", "[Query][LiveQuery]") {
     
     cerr << "Adding listener\n";
     ListenerState state;
-    auto listenerToken = CBLQuery_AddChangeListener(query, [](void *context, CBLQuery* query, CBLListenerToken* token) {
+    CBLListenerToken*  listenerToken = CBLQuery_AddChangeListener(query, [](void *context, CBLQuery* query, CBLListenerToken* token) {
         ((ListenerState*)context)->receivedCallback(context, query, token);
     }, &state);
 
@@ -585,7 +585,7 @@ TEST_CASE_METHOD(QueryTest, "Query Listener and Changing parameters", "[Query][L
 
     cerr << "Adding listener\n";
     ListenerState state;
-    auto listenerToken = CBLQuery_AddChangeListener(query, [](void *context, CBLQuery* query, CBLListenerToken* token) {
+    CBLListenerToken* listenerToken = CBLQuery_AddChangeListener(query, [](void *context, CBLQuery* query, CBLListenerToken* token) {
         ((ListenerState*)context)->receivedCallback(context, query, token);
     }, &state);
 
@@ -623,10 +623,10 @@ TEST_CASE_METHOD(QueryTest, "Multiple Query Listeners", "[Query][LiveQuery]") {
     
     cerr << "Adding listener\n";
     ListenerState state1;
-    auto token1 = CBLQuery_AddChangeListener(query, callback, &state1);
+    CBLListenerToken* token1 = CBLQuery_AddChangeListener(query, callback, &state1);
     
     ListenerState state2;
-    auto token2 = CBLQuery_AddChangeListener(query, callback, &state2);
+    CBLListenerToken* token2 = CBLQuery_AddChangeListener(query, callback, &state2);
 
     cerr << "Waiting for listener 1...\n";
     state1.waitForCount(1);
@@ -654,7 +654,7 @@ TEST_CASE_METHOD(QueryTest, "Multiple Query Listeners", "[Query][LiveQuery]") {
     
     cerr << "Adding another listener\n";
     ListenerState state3;
-    auto token3 = CBLQuery_AddChangeListener(query, callback, &state3);
+    CBLListenerToken* token3 = CBLQuery_AddChangeListener(query, callback, &state3);
     
     cerr << "Waiting for the listener 3...\n";
     state3.waitForCount(1);
@@ -684,7 +684,7 @@ TEST_CASE_METHOD(QueryTest, "Query Listener and Coalescing notification", "[Quer
     
     cerr << "Adding listener\n";
     ListenerState state;
-    auto listenerToken = CBLQuery_AddChangeListener(query, [](void *context, CBLQuery* query, CBLListenerToken* token) {
+    CBLListenerToken* listenerToken = CBLQuery_AddChangeListener(query, [](void *context, CBLQuery* query, CBLListenerToken* token) {
         ((ListenerState*)context)->receivedCallback(context, query, token);
     }, &state);
 
@@ -970,14 +970,14 @@ TEST_CASE_METHOD(QueryTest, "FTS with FTS Index in Named Collection", "[Query]")
     createDocWithJSON(people, "person2", "{\"name\": { \"first\": \"Jasper\",\"last\":\"Okorududu\"}, \"random\": \"1\"}");
     createDocWithJSON(people, "person3", "{\"name\": { \"first\": \"Monica\",\"last\":\"Polina\"}, \"random\": \"2\"}");
 
-    CBLCollection_Release(people);
-
     CBLFullTextIndexConfiguration index = {};
     index.expressionLanguage = kCBLN1QLLanguage;
     index.expressions = "name.first"_sl;
     index.ignoreAccents = false;
     CHECK(CBLCollection_CreateFullTextIndex(people, "index"_sl, index, &error));
 
+    CBLCollection_Release(people);
+    
     SECTION("name"){
         queryString = "SELECT name "
                       "FROM test.people "


### PR DESCRIPTION
* Removed scope and collection cache in the CBLDatabase implementation. This change made CBL-C inline with the other platforms’ implementation. Plus, it makes the implementation much more simpler.

* CBLDatabase still caches the (internal) default collection used for default collection based APIs (Most are the deprecated APIs). Once we remove those deprecated API, we may not need to have it.

* When caching the internal default collection in the CBLDatabase, to prevent the retain cycle, call CBLCollection’s adopt(db) function to release the database instance in the CBLCollection object.

* The database instance inside CBLCollection and CBLScope will not be invalidated. This makes several part of the code that needs the database instance much simplier as it doesn’t need to take care the case when the database is null.

* Made changes to the tests as needed. Plus, fix XCode analyzer warning in QueryTest.cc about setting nullptr to listenerToken.

* Fixed wrong information about default collection in CBLCollection. (We will need to fix this in 3.1 branch as well).

* Updated LiteCore to 3.2.0-115 otherwise it’s not buildable on XCode 15. Need to fix LogTest as now the log files have two header lines.