### PR TITLE
CBL-5380 : Update iOS Deployment Target Version to 12.0

### DIFF
--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -24,7 +24,7 @@ FLEECE      = $(LITECORE)/vendor/fleece
 CBL_VERSION_STRING                                 = 0.0.0 // The actual version number will be set by Jenkins Build.
 CBL_BUILD_NUMBER                                   = 0     // The actual build number will be set by Jenkins Build.
 
-IPHONEOS_DEPLOYMENT_TARGET                         = 11.0
+IPHONEOS_DEPLOYMENT_TARGET                         = 12.0
 MACOSX_DEPLOYMENT_TARGET                           = 10.14
 TVOS_DEPLOYMENT_TARGET                             = 11.0
 SUPPORTED_PLATFORMS                                = macosx iphoneos iphonesimulator appletvos appletvsimulator


### PR DESCRIPTION
We are bumping the iOS target version in Beryllium to 12.0.