### PR TITLE
CBL-5606 : Fix lock caused by saving doc and notifying change

### DIFF
--- a/src/CBLCollection.cc
+++ b/src/CBLCollection.cc
@@ -108,7 +108,7 @@ namespace cbl_internal {
 Retained<CBLListenerToken> CBLCollection::addChangeListener(CBLCollectionChangeListener listener,
                                                             void* _cbl_nullable ctx)
 {
-    auto lock =_c4col.useLocked(); // Ensure the database lifetime while creating the Listener oken
+    auto lock =_c4col.useLocked(); // Ensure the database lifetime while creating the Listener token
     auto token = addListener([&] { return new ListenerToken<CBLCollectionChangeListener>(this, listener, ctx); });
     _listeners.add((ListenerToken<CBLCollectionChangeListener>*)token.get());
     return token;
@@ -118,7 +118,7 @@ Retained<CBLListenerToken> CBLCollection::addDocumentListener(slice docID,
                                                               CBLCollectionDocumentChangeListener listener,
                                                               void* _cbl_nullable ctx)
 {
-    auto lock =_c4col.useLocked(); // // Ensure the database lifetime while creating the Listener oken
+    auto lock =_c4col.useLocked(); // // Ensure the database lifetime while creating the Listener token
     auto token = new ListenerToken<CBLCollectionDocumentChangeListener>(this, docID, listener, ctx);
     _docListeners.add(token);
     return token;

--- a/src/CBLCollection.cc
+++ b/src/CBLCollection.cc
@@ -23,6 +23,31 @@ using namespace fleece;
 using namespace cbl_internal;
 
 namespace cbl_internal {
+    template<>
+    struct ListenerToken<CBLCollectionChangeListener> : public CBLListenerToken {
+    public:
+        ListenerToken(CBLCollection *collection, CBLCollectionChangeListener callback, void *context)
+        :CBLListenerToken((const void*)callback, context)
+        ,_collection(collection)
+        ,_database(collection->database()) { }
+        
+        ~ListenerToken() { }
+        
+        CBLCollectionChangeListener _cbl_nullable callback() const {
+            return (CBLCollectionChangeListener)_callback;
+        }
+        
+        void call(const CBLCollectionChange* change) {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            auto cb = callback();
+            if (cb) {
+                cb(_context, change);
+            }
+        }
+    private:
+        Retained<CBLCollection> _collection;
+        Retained<CBLDatabase> _database;
+    };
 
     template<>
     struct ListenerToken<CBLCollectionDocumentChangeListener> : public CBLListenerToken {
@@ -31,6 +56,7 @@ namespace cbl_internal {
                       CBLCollectionDocumentChangeListener callback, void *context)
         :CBLListenerToken((const void*)callback, context)
         ,_collection(collection)
+        ,_database(collection->database())
         ,_docID(docID)
         {
             _c4obs = _collection->useLocked()->observeDocument(docID, [this](C4DocumentObserver*,
@@ -69,32 +95,30 @@ namespace cbl_internal {
             CBLDocumentChange change = {};
             change.collection = _collection;
             change.docID = _docID;
-
-            Retained<CBLDatabase> db;
-            try {
-                db = _collection->database();
-            } catch (...) {
-                C4Error error = C4Error::fromCurrentException();
-                CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
-                        "Document changed notification failed: %s", error.description().c_str());
-            }
-
-            if (db) {
-                db->notify(this, change);
-            }
+            _database->notify(this, change);
         }
 
         Retained<CBLCollection> _collection;
+        Retained<CBLDatabase> _database;
         alloc_slice _docID;
         std::unique_ptr<C4DocumentObserver> _c4obs;
     };
-
 }
 
-Retained<CBLListenerToken>
-CBLCollection::addDocumentListener(slice docID, CBLCollectionDocumentChangeListener listener,
-                                   void* _cbl_nullable ctx)
+Retained<CBLListenerToken> CBLCollection::addChangeListener(CBLCollectionChangeListener listener,
+                                                            void* _cbl_nullable ctx)
 {
+    auto lock =_c4col.useLocked(); // Ensure the database lifetime while creating the Listener oken
+    auto token = addListener([&] { return new ListenerToken<CBLCollectionChangeListener>(this, listener, ctx); });
+    _listeners.add((ListenerToken<CBLCollectionChangeListener>*)token.get());
+    return token;
+}
+
+Retained<CBLListenerToken> CBLCollection::addDocumentListener(slice docID, 
+                                                              CBLCollectionDocumentChangeListener listener,
+                                                              void* _cbl_nullable ctx)
+{
+    auto lock =_c4col.useLocked(); // // Ensure the database lifetime while creating the Listener oken
     auto token = new ListenerToken<CBLCollectionDocumentChangeListener>(this, docID, listener, ctx);
     _docListeners.add(token);
     return token;

--- a/src/CBLCollection_CAPI.cc
+++ b/src/CBLCollection_CAPI.cc
@@ -113,7 +113,7 @@ uint64_t CBLCollection_Count(const CBLCollection* collection) noexcept {
     } catchAndWarn()
 }
 
-/** Private API */
+/** Private API used in tests. */
 CBLDatabase* CBLCollection_Database(const CBLCollection* collection) noexcept {
     try {
         return collection->database();

--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -319,6 +319,7 @@ private:
 #endif
 
     Retained<CBLCollection>       _collection;      // Collection (null for new doc)
+    Retained<CBLDatabase>         _database;        // Database (null for new doc)
     litecore::access_lock<Retained<C4Document>>  _c4doc; // LiteCore doc (null for new doc)
     alloc_slice const             _docID;           // Document ID (never empty)
     mutable alloc_slice           _revID;           // Revision ID

--- a/src/CBLPrivate.h
+++ b/src/CBLPrivate.h
@@ -28,8 +28,8 @@ CBL_CAPI_BEGIN
     void CBLLog_BeginExpectingExceptions() CBLAPI;
     void CBLLog_EndExpectingExceptions() CBLAPI;
 
-/** Returns the collection's database, or NULL if the collection is invalid, or the database is released. */
-    CBLDatabase* _cbl_nullable CBLCollection_Database(const CBLCollection*) CBLAPI;
+/** Returns the collection's database pointer which is unretained. This is used by tests. */
+    CBLDatabase* CBLCollection_Database(const CBLCollection*) CBLAPI;
 
 /** Returns the last sequence number assigned in the database (default collection).
     This starts at zero and increments every time a document is saved or deleted. */

--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -184,11 +184,11 @@ namespace cbl_internal
             // Throw an exception if the validation failed:
             validate();
             
-            CBLCollection* defaultCollection = nullptr;
+            Retained<CBLCollection> defaultCollection = nullptr;
             if (database) {
                 // This can technically throw if the default collection doesn't exist (We don't allow now).
                 // So call first before copying anything:
-                defaultCollection = database->getDefaultCollection(true).get();
+                defaultCollection = database->getDefaultCollection(true);
             }
             
             if (endpoint) {
@@ -229,7 +229,7 @@ namespace cbl_internal
                 collections = _effectiveCollections.data();
             } else {
                 // Create a replication collection using the default collection:
-                assert(defaultCollection != nullptr);
+                assert(defaultCollection);
                 CBLReplicationCollection col {};
                 col.collection = defaultCollection;
                 col.conflictResolver = conflictResolver;

--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -175,23 +175,26 @@ namespace cbl_internal
         using Dict = fleece::Dict;
         using slice = fleece::slice;
         using Array = fleece::Array;
+        template <class T> using Retained = fleece::Retained<T>;
 
     public:
         ReplicatorConfiguration(const CBLReplicatorConfiguration &conf) {
             *(CBLReplicatorConfiguration*)this = conf;
-            retain(database);
-            if (endpoint)
-                endpoint = endpoint->clone();
             
-            if (collections) {
-                // Copy collections and retain the collection object inside:
-                for (int i = 0; i < collectionCount; i++) {
-                    retain(collections[i].collection);
-                    _collections.push_back(collections[i]);
-                }
-                collections = _collections.data();
+            // Throw an exception if the validation failed:
+            validate();
+            
+            CBLCollection* defaultCollection = nullptr;
+            if (database) {
+                // This can technically throw if the default collection doesn't exist (We don't allow now).
+                // So call first before copying anything:
+                defaultCollection = database->getDefaultCollection(true).get();
             }
-
+            
+            if (endpoint) {
+                endpoint = endpoint->clone();
+            }
+            
             authenticator = authenticator ? authenticator->clone() : nullptr;
             headers = FLDict_MutableCopy(headers, kFLDeepCopyImmutables);
             channels = FLArray_MutableCopy(channels, kFLDeepCopyImmutables);
@@ -214,57 +217,51 @@ namespace cbl_internal
             Dict headersDict = Dict(headers);
             fleece::Value userAgent = headersDict[kCBLReplicatorUserAgent];
             _userAgent = userAgent ? userAgent.asstring() : createUserAgentHeader();
+            
+            if (collections) {
+                // Copy replication collections, channels, and document ids:
+                for (int i = 0; i < collectionCount; i++) {
+                    CBLReplicationCollection col = collections[i];
+                    col.channels = FLArray_MutableCopy(col.channels, kFLDeepCopyImmutables);
+                    col.documentIDs = FLArray_MutableCopy(col.documentIDs, kFLDeepCopyImmutables);
+                    _effectiveCollections.push_back(col);
+                }
+                collections = _effectiveCollections.data();
+            } else {
+                // Create a replication collection using the default collection:
+                assert(defaultCollection != nullptr);
+                CBLReplicationCollection col {};
+                col.collection = defaultCollection;
+                col.conflictResolver = conflictResolver;
+                col.pushFilter = pushFilter;
+                col.pullFilter = pullFilter;
+                col.channels = FLArray_Retain(channels);        // Already copied
+                col.documentIDs = FLArray_Retain(documentIDs);  // Already copied
+                _effectiveCollections.push_back(col);
+            }
+            
+            // Retain the collections and database:
+            for (auto& col : _effectiveCollections) {
+                _retainedCollections.push_back(col.collection);
+                if (!_retainedDatabase) {
+                    _retainedDatabase = col.collection->database();
+                }
+            }
         }
 
         ~ReplicatorConfiguration() {
-            release(database);
-            
-            for (int i = 0; i < collectionCount; i++) {
-                release(_collections[i].collection);
-            }
-            
             CBLEndpoint_Free(endpoint);
             CBLAuth_Free(authenticator);
             FLDict_Release(headers);
             FLArray_Release(channels);
             FLArray_Release(documentIDs);
+            
+            for (auto& col : _effectiveCollections) {
+                FLArray_Release(col.channels);
+                FLArray_Release(col.documentIDs);
+            }
         }
         
-
-        void validate() const {
-            const char *problem = nullptr;
-            if (!database && !collections)
-                problem = "Invalid config: Missing both database and collections";
-            else if (database && collections)
-                problem = "Invalid config: Both database and collections are set at same time";
-            else if (collections && collectionCount == 0)
-                problem = "Invalid config: collectionCount is zero";
-            else if ((documentIDs || channels || pushFilter || pullFilter) && !database)
-                problem = "Invalid config: Cannot use documentIDs, channels, pushFilter or "
-                          "pullFilter when collections is set. Set the properties in "
-                          "CBLReplicationCollection instead.";
-            else if (conflictResolver && !database)
-                problem = "Invalid config: Cannot use conflictResolver when collections is set. "
-                          "Set the property in CBLReplicationCollection instead.";
-        #ifdef COUCHBASE_ENTERPRISE
-            else if ((propertyEncryptor || propertyDecryptor ) && !database)
-                problem = "Invalid config: Cannot use propertyEncryptor or propertyDecryptor "
-                          "when collections is set. Use documentPropertyEncryptor or "
-                          "documentPropertyDecryptor instead.";
-        #endif
-            else if (!endpoint || replicatorType > kCBLReplicatorTypePull)
-                problem = "Invalid config: Missing endpoints or bad type";
-            else if (!endpoint->valid())
-                problem = "Invalid endpoint";
-            else if (proxy && (proxy->type > kCBLProxyHTTPS ||
-                                                    !proxy->hostname.buf || !proxy->port))
-                problem = "Invalid replicator proxy settings";
-
-            if (problem)
-                C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter, "%s", problem);
-        }
-
-
         // Writes a LiteCore replicator optionsDict
         void writeOptions(Encoder &enc) const {
             fleece::MutableDict mHeaders = headers ? FLDict_AsMutable(headers) : FLMutableDict_New();
@@ -345,17 +342,68 @@ namespace cbl_internal
             writeOptionalKey(enc, kC4ReplicatorOptionChannels,      Array(collection.channels));
         }
 
-        slice getUserAgent() const {
-            return slice(_userAgent);
-        }
-
+        slice getUserAgent() const                                                  { return slice(_userAgent); }
+        CBLDatabase* effectiveDatabase() const                                      { return _retainedDatabase; }
+        const std::vector<CBLReplicationCollection>& effectiveCollections() const   { return _effectiveCollections; }
+        
         ReplicatorConfiguration(const ReplicatorConfiguration&) =delete;
         ReplicatorConfiguration& operator=(const ReplicatorConfiguration&) =delete;
-
+        
     private:
         using string = std::string;
         using alloc_slice = fleece::alloc_slice;
-
+        
+        void validate() const {
+            const char *problem = nullptr;
+            if (!database && !collections)
+                problem = "Invalid config: Missing both database and collections";
+            else if (database && collections)
+                problem = "Invalid config: Both database and collections are set at same time";
+            else if (collections && collectionCount == 0)
+                problem = "Invalid config: collectionCount is zero";
+            else if ((documentIDs || channels || pushFilter || pullFilter) && !database)
+                problem = "Invalid config: Cannot use documentIDs, channels, pushFilter or "
+                          "pullFilter when collections is set. Set the properties in "
+                          "CBLReplicationCollection instead.";
+            else if (conflictResolver && !database)
+                problem = "Invalid config: Cannot use conflictResolver when collections is set. "
+                          "Set the property in CBLReplicationCollection instead.";
+        #ifdef COUCHBASE_ENTERPRISE
+            else if ((propertyEncryptor || propertyDecryptor ) && !database)
+                problem = "Invalid config: Cannot use propertyEncryptor or propertyDecryptor "
+                          "when collections is set. Use documentPropertyEncryptor or "
+                          "documentPropertyDecryptor instead.";
+        #endif
+            else if (!endpoint || replicatorType > kCBLReplicatorTypePull)
+                problem = "Invalid config: Missing endpoints or bad type";
+            else if (!endpoint->valid())
+                problem = "Invalid endpoint";
+            else if (proxy && (proxy->type > kCBLProxyHTTPS ||
+                                                    !proxy->hostname.buf || !proxy->port))
+                problem = "Invalid replicator proxy settings";
+            
+            if (collections) {
+                CBLDatabase* db = nullptr;
+                for (int i = 0; i < collectionCount; i++) {
+                    auto collection = collections[i].collection;
+                    if (!collection->isValid()) {
+                        problem = "An invalid collection was found in the configuration.";
+                        break;
+                    }
+                    
+                    if (!db) {
+                        db = collection->database();
+                    } else if (db != collection->database()) {
+                        problem = "Invalid config: collections are not from the same database instance.";
+                        break;
+                    }
+                }
+            }
+            
+            if (problem)
+                C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter, "%s", problem);
+        }
+        
         static slice copyString(slice str, alloc_slice &allocated)
         {
             allocated = alloc_slice(str);
@@ -363,7 +411,11 @@ namespace cbl_internal
         }
 
         string                                  _userAgent;
-        std::vector<CBLReplicationCollection>   _collections;
+        std::vector<CBLReplicationCollection>   _effectiveCollections;
+        
+        std::vector<Retained<CBLCollection>>    _retainedCollections;
+        Retained<CBLDatabase>                   _retainedDatabase;
+        
         alloc_slice                             _pinnedServerCert, _trustedRootCerts;
         CBLProxySettings                        _proxy;
         alloc_slice                             _proxyHostname, _proxyUsername, _proxyPassword;

--- a/src/Listener.hh
+++ b/src/Listener.hh
@@ -177,7 +177,7 @@ namespace cbl_internal {
             return t;
         }
 
-        void add(ListenerToken<LISTENER>* _cbl_nonnull token)                {ListenersBase::add(token);}
+        void add(ListenerToken<LISTENER>* _cbl_nonnull token)   {ListenersBase::add(token);}
         void clear()                                            {ListenersBase::clear();}
         bool empty() const                                      {return ListenersBase::empty();}
 

--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -639,7 +639,6 @@ TEST_CASE_METHOD(ReplicatorLocalTest, "DocIDs Pull Filters", "[Replicator]") {
     FLMutableArray_Release(docIDs);
 }
 
-
 class ReplicatorFilterTest : public ReplicatorLocalTest {
 public:
     int count = 0;

--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -601,6 +601,44 @@ TEST_CASE_METHOD(ReplicatorLocalTest, "Document Replication Listener", "[Replica
     CHECK(replicatedDocIDs.empty());
 }
 
+TEST_CASE_METHOD(ReplicatorLocalTest, "DocIDs Push Filters", "[Replicator]") {
+    MutableDocument doc1("foo1");
+    doc1["greeting"] = "Howdy!";
+    db.saveDocument(doc1);
+    
+    MutableDocument doc2("foo2");
+    doc2["greeting"] = "Howdy!";
+    db.saveDocument(doc2);
+    
+    auto docIDs = FLMutableArray_NewFromJSON("[\"foo1\"]"_sl, NULL);;
+    config.replicatorType = kCBLReplicatorTypePush;
+    config.documentIDs = FLMutableArray_NewFromJSON("[\"foo1\"]"_sl, NULL);;
+    expectedDocumentCount = 1;
+    replicate();
+    CHECK(asVector(replicatedDocIDs) == vector<string>{"foo1"});
+    
+    FLMutableArray_Release(docIDs);
+}
+
+TEST_CASE_METHOD(ReplicatorLocalTest, "DocIDs Pull Filters", "[Replicator]") {
+    MutableDocument doc1("foo1");
+    doc1["greeting"] = "Howdy!";
+    otherDB.saveDocument(doc1);
+    
+    MutableDocument doc2("foo2");
+    doc2["greeting"] = "Howdy!";
+    otherDB.saveDocument(doc2);
+    
+    auto docIDs = FLMutableArray_NewFromJSON("[\"foo1\"]"_sl, NULL);;
+    config.replicatorType = kCBLReplicatorTypePull;
+    config.documentIDs = FLMutableArray_NewFromJSON("[\"foo1\"]"_sl, NULL);;
+    expectedDocumentCount = 1;
+    replicate();
+    CHECK(asVector(replicatedDocIDs) == vector<string>{"foo1"});
+    
+    FLMutableArray_Release(docIDs);
+}
+
 
 class ReplicatorFilterTest : public ReplicatorLocalTest {
 public:


### PR DESCRIPTION
* Issue : When notify collection change, the code needs to obtain the database lock in order to get the database instance from the collection object. The deadlock could occurred if a document save happens at the same time on the other thread as the document save will need to wait to open its transaction while the other transaction is still opened by the notification thead.

* Solution : Keep the database pointer inside the Collection class without resetting its to null to invalidate the pointer so that there is no lock required when accessing it. As the collection objects cannot retain the database object to avoid retain cycle (collections are cached inside the database object), the database object need to be retained else where where it is being used (along side with its collection object). The database object now is explicity retained by Document, Listener Token (Collection and Document Change Listener), and ReplicatorConfiguration objects.

* Moved the logic to generate the effective replication collections, retain Collection objects and retain Database object from CBLReplicator class into the ReplicatorConfiguration class so those logics are done together in a single place. Added missing document ids filter tests to ensure that the moved logic work correctly for the document ids filter.

* Added a test that cana reproduce the issue.

* Note: The code change is noticably larger than what we normally want in the release branch. However, the change is appropriate and is not as complex as it looks and is actually simpler than before.