### PR TITLE
CBL-5638 : Port ReplicatorConfiguration change

### DIFF
--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -605,6 +605,43 @@ TEST_CASE_METHOD(ReplicatorLocalTest, "Document Replication Listener", "[Replica
     CHECK(replicatedDocIDs.empty());
 }
 
+TEST_CASE_METHOD(ReplicatorLocalTest, "DocIDs Push Filters", "[Replicator]") {
+    MutableDocument doc1("foo1");
+    doc1["greeting"] = "Howdy!";
+    db.saveDocument(doc1);
+    
+    MutableDocument doc2("foo2");
+    doc2["greeting"] = "Howdy!";
+    db.saveDocument(doc2);
+    
+    auto docIDs = FLMutableArray_NewFromJSON("[\"foo1\"]"_sl, NULL);;
+    config.replicatorType = kCBLReplicatorTypePush;
+    config.documentIDs = FLMutableArray_NewFromJSON("[\"foo1\"]"_sl, NULL);;
+    expectedDocumentCount = 1;
+    replicate();
+    CHECK(asVector(replicatedDocIDs) == vector<string>{"foo1"});
+    
+    FLMutableArray_Release(docIDs);
+}
+
+TEST_CASE_METHOD(ReplicatorLocalTest, "DocIDs Pull Filters", "[Replicator]") {
+    MutableDocument doc1("foo1");
+    doc1["greeting"] = "Howdy!";
+    otherDB.saveDocument(doc1);
+    
+    MutableDocument doc2("foo2");
+    doc2["greeting"] = "Howdy!";
+    otherDB.saveDocument(doc2);
+    
+    auto docIDs = FLMutableArray_NewFromJSON("[\"foo1\"]"_sl, NULL);;
+    config.replicatorType = kCBLReplicatorTypePull;
+    config.documentIDs = FLMutableArray_NewFromJSON("[\"foo1\"]"_sl, NULL);;
+    expectedDocumentCount = 1;
+    replicate();
+    CHECK(asVector(replicatedDocIDs) == vector<string>{"foo1"});
+    
+    FLMutableArray_Release(docIDs);
+}
 
 class ReplicatorFilterTest : public ReplicatorLocalTest {
 public:


### PR DESCRIPTION
* Ported the change from release/3.1 branch (a5ff22ea8a1513d28fe222770083907d3b8cd0cd).

* Moved the config validation call into ReplicatorConfiguration itself.

* Moved the code that generates the effective replication collections from CBLReplicator into the ReplicatorConfiguration.

* Retained collection objects inside ReplicatorConfiguration. This is important to ensure the collection life time inside the replicator object.

* Added DocIDs Push /Pull Filters tests.