### PR TITLE
CBL-5711 : Add note that replicators cannot be started in a transaction

### DIFF
--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -403,6 +403,7 @@ namespace cbl {
         }
 
         /** Starts a replicator, asynchronously. Does nothing if it's already started.
+            @note Replicators cannot be started from within a database's transaction.
             @param resetCheckpoint  If true, the persistent saved state ("checkpoint") for this replication
                                    will be discarded, causing it to re-scan all documents. This significantly
                                    increases time and bandwidth (redundant docs are not transferred, but their

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -462,6 +462,7 @@ CBLReplicator* _cbl_nullable CBLReplicator_Create(const CBLReplicatorConfigurati
 const CBLReplicatorConfiguration* CBLReplicator_Config(CBLReplicator*) CBLAPI;
 
 /** Starts a replicator, asynchronously. Does nothing if it's already started.
+    @note Replicators cannot be started from within a database's transaction.
     @param replicator  The replicator instance.
     @param resetCheckpoint  If true, the persistent saved state ("checkpoint") for this replication
                         will be discarded, causing it to re-scan all documents. This significantly


### PR DESCRIPTION
Added note that replicators cannot be started in a transaction.