### PR TITLE
CBL-5851 : Change prediction callback signature to return FLMutableDict

### DIFF
--- a/include/cbl/CBLPrediction.h
+++ b/include/cbl/CBLPrediction.h
@@ -28,18 +28,18 @@ typedef struct {
     /** A pointer to any external data needed by the `prediction` callback, which will receive this as its first parameter. */
     void* _cbl_nullable context;
     
-    /** Called from within a query (or document indexing) to run the prediction.
+    /** Prediction callback, called from within a query (or document indexing) to run the prediction.
         @param context  The value of the CBLPredictiveModel's `context` field.
         @param input  The input dictionary from the query.
-        @return The output of the prediction function, encoded as a Fleece dictionary, or null if there is no output.
-        @note A null \ref FLSliceResult can be created by calling FLSliceResult_CreateWith(nullptr, 0).
+        @return The output of the prediction function as an FLMutableDict, or NULL if there is no output.
+        @note The output FLMutableDict will be automatically released after the prediction callback is called.
         @warning This function must be "pure": given the same input parameters it must always
-                produce the same output (otherwise indexes or queries may be messed up).
-                It MUST NOT alter the database or any documents, nor run a query: either of
-                those are very likely to cause a crash. */
-    FLSliceResult (* _cbl_nonnull prediction)(void* _cbl_nullable context, FLDict input);
+                 produce the same output (otherwise indexes or queries may be messed up).
+                 It MUST NOT alter the database or any documents, nor run a query: either of
+                 those are very likely to cause a crash. */
+    FLMutableDict _cbl_nullable (* _cbl_nonnull prediction)(void* _cbl_nullable context, FLDict input);
 
-    /** Called if the model is unregistered, so it can release resources. */
+    /** Unregistered callback, called if the model is unregistered, so it can release resources. */
     void (*_cbl_nullable unregistered)(void* context);
 } CBLPredictiveModel;
 

--- a/test/VectorSearchTest.hh
+++ b/test/VectorSearchTest.hh
@@ -182,9 +182,9 @@ public:
     }
     
     void registerWordEmbeddingModel() {
-        auto callback = [](void* context, FLDict input) -> FLSliceResult {
+        auto callback = [](void* context, FLDict input) -> FLMutableDict {
             auto word = fleece::Dict(input)["word"].asString();
-            if (!word) { return FLSliceResult_CreateWith(nullptr, 0); }
+            if (!word) { return nullptr; }
             
             auto vector = ((VectorSearchTest*) context)->vectorArrayForWord(word, kWordsCollectionName);
             if (!vector) {
@@ -192,17 +192,12 @@ public:
             }
             
             if (!vector) {
-                return FLSliceResult_CreateWith(nullptr, 0);
+                return nullptr;
             }
             
-            FLEncoder enc = FLEncoder_New();
-            FLEncoder_BeginDict(enc, 1);
-            FLEncoder_WriteKey(enc, "vector"_sl);
-            FLEncoder_WriteValue(enc, (FLValue)vector);
-            FLEncoder_EndDict(enc);
-            auto result = FLEncoder_Finish(enc, nullptr);
-            FLMutableArray_Release(vector);
-            return result;
+            auto output = MutableDict(FLMutableDict_New());
+            output["vector"] = Array(vector);
+            return output;
         };
         
         CBLPredictiveModel model {};


### PR DESCRIPTION
…tionary

Changed prediction callback signature to return FLMutableDict instead of FLSliceResult to be inline with the other platforms. The returned FLMutableDict will be released after the callback is called.