### PR TITLE
CBL-5894 : Update IndexUpdater API and sync illegal behavior

### DIFF
--- a/include/cbl/CBLQueryIndex.h
+++ b/include/cbl/CBLQueryIndex.h
@@ -124,8 +124,7 @@ size_t CBLIndexUpdater_Count(const CBLIndexUpdater* updater) CBLAPI;
     @param updater  The index updater.
     @param index  The zero-based index.
     @return A Fleece value of the index's evaluated expression at the given index. */
-FLValue _cbl_nullable CBLIndexUpdater_Value(CBLIndexUpdater* updater,
-                                            size_t index) CBLAPI;
+FLValue CBLIndexUpdater_Value(CBLIndexUpdater* updater, size_t index) CBLAPI;
 
 /** ENTERPRISE EDITION ONLY
  
@@ -149,16 +148,15 @@ bool CBLIndexUpdater_SetVector(CBLIndexUpdater* updater,
     Skip setting the vector for the value corresponding to the index.
     The vector will be required to compute and set again when the `CBLQueryIndex_BeginUpdate` is later called.
     @param updater  The index updater.
-    @param index The zero-based index.
-    @param outError  On failure, an error is written here.
-    @return True if success, or False if an error occurred. */
-bool CBLIndexUpdater_SkipVector(CBLIndexUpdater* updater, size_t index, CBLError* _cbl_nullable outError) CBLAPI;
+    @param index The zero-based index. */
+void CBLIndexUpdater_SkipVector(CBLIndexUpdater* updater, size_t index) CBLAPI;
 
 /** ENTERPRISE EDITION ONLY
  
     Updates the index with the computed vectors and removes any index rows for which null vector was given.
     If there are any indexes that do not have their vector value set or are skipped, a error will be returned.
     @note Before calling `CBLIndexUpdater_Finish`, the set vectors are kept in the memory.
+    @warning The index updater cannot be used after calling `CBLIndexUpdater_Finish`.
     @param updater  The index updater.
     @param outError  On failure, an error is written here.
     @return True if success, or False if an error occurred. */

--- a/src/CBLQueryIndex_CAPI.cc
+++ b/src/CBLQueryIndex_CAPI.cc
@@ -45,13 +45,13 @@ CBLIndexUpdater* _cbl_nullable CBLQueryIndex_BeginUpdate(CBLQueryIndex* index, s
 size_t CBLIndexUpdater_Count(const CBLIndexUpdater* updater) noexcept {
     try {
         return updater->count();
-    } catchAndWarn()
+    } catchAndAbort()
 }
 
-FLValue _cbl_nullable CBLIndexUpdater_Value(CBLIndexUpdater* updater, size_t index) noexcept {
+FLValue CBLIndexUpdater_Value(CBLIndexUpdater* updater, size_t index) noexcept {
     try {
         return updater->value(index);
-    } catchAndWarn()
+    } catchAndAbort()
 }
 
 bool CBLIndexUpdater_SetVector(CBLIndexUpdater* updater, size_t index, const float vector[_cbl_nullable],
@@ -63,11 +63,10 @@ bool CBLIndexUpdater_SetVector(CBLIndexUpdater* updater, size_t index, const flo
     } catchAndBridge(outError)
 }
 
-bool CBLIndexUpdater_SkipVector(CBLIndexUpdater* updater, size_t index, CBLError* _cbl_nullable outError) noexcept {
+void CBLIndexUpdater_SkipVector(CBLIndexUpdater* updater, size_t index) noexcept {
     try {
         updater->skipVector(index);
-        return true;
-    } catchAndBridge(outError)
+    } catchAndAbort()
 }
 
 bool CBLIndexUpdater_Finish(CBLIndexUpdater* updater, CBLError* _cbl_nullable outError) noexcept {

--- a/src/CBLQueryIndex_Internal.hh
+++ b/src/CBLQueryIndex_Internal.hh
@@ -18,6 +18,7 @@
 
 #pragma once
 #include "access_lock.hh"
+#include "CBLDatabase_Internal.hh"
 #include "Internal.hh"
 #include <mutex>
 #include <unordered_map>
@@ -45,7 +46,7 @@ private:
 
 struct CBLIndexUpdater final : public CBLRefCounted {
 public:
-    CBLIndexUpdater(Retained<C4IndexUpdater>&& indexUpdater, CBLQueryIndex* index);
+    CBLIndexUpdater(Retained<C4IndexUpdater>&& indexUpdater, CBLDatabase* db);
     
     ~CBLIndexUpdater();
     
@@ -68,10 +69,13 @@ protected:
     CBLBlob* getBlob(Dict blobDict, const C4BlobKey&);
    
 private:
+    
+    inline void checkFinishedUnLock() const;
+    
     mutable std::mutex                                      _mutex;
+    
     Retained<C4IndexUpdater>                                _c4IndexUpdater;
-    litecore::shared_access_lock<Retained<C4IndexUpdater>>  _c4IndexUpdaterWithLock;
-    Retained<CBLQueryIndex>                                 _index;
+    Retained<CBLDatabase>                                   _db;
     
     Doc                                                     _fleeceDoc;    // Fleece Doc that owns the values
     std::unordered_map<FLDict, Retained<CBLBlob>>           _blobs;        // Cached CBLBLobs, keyed by FLDict

--- a/src/Internal.hh
+++ b/src/Internal.hh
@@ -107,6 +107,9 @@ using namespace cbl_internal;
 #define catchAndWarn() \
     catchAndBridge(nullptr)
 
+#define catchAndAbort() \
+    catch (...) { cbl_internal::BridgeException(__FUNCTION__, nullptr); std::terminate(); }
+
 
 #define LOCK(MUTEX)     std::lock_guard<decltype(MUTEX)> _lock(MUTEX)
 

--- a/test/LazyVectorIndexTest.cc
+++ b/test/LazyVectorIndexTest.cc
@@ -1098,26 +1098,14 @@ TEST_CASE_METHOD(VectorSearchTest, "TestIndexUpdaterIndexOutOfBounds", "[VectorS
     
     array<int, 2> indices { -1, 1 };
     for (auto i : indices) {
-        {
-            // This is in line with FLArray, returns null when index is out-of-bound.
-            ExpectingExceptions x {};
-            auto value = CBLIndexUpdater_Value(updater, i);
-            CHECK(!value);
-        }
+        // Note: These two functions cannot be tested as they will abort when index is out-of-bound.
+        // CBLIndexUpdater_Value(updater, i)
+        // CBLIndexUpdater_SkipVector(updater, i)
         
-        {
-            ExpectingExceptions x {};
-            float vector[] = { 1.0, 2.0, 3.0 };
-            CHECK(!CBLIndexUpdater_SetVector(updater, i, vector, 3, &error));
-            CheckError(error, kCBLErrorInvalidParameter);
-        }
-        
-        {
-            error = {};
-            ExpectingExceptions x {};
-            CHECK(!CBLIndexUpdater_SkipVector(updater, i, &error));
-            CheckError(error, kCBLErrorInvalidParameter);
-        }
+        ExpectingExceptions x;
+        float vector[] = { 1.0, 2.0, 3.0 };
+        CHECK(!CBLIndexUpdater_SetVector(updater, i, vector, 3, &error));
+        CheckError(error, kCBLErrorInvalidParameter);
     }
     
     CBLIndexUpdater_Release(updater);
@@ -1152,6 +1140,10 @@ TEST_CASE_METHOD(VectorSearchTest, "TestIndexUpdaterIndexOutOfBounds", "[VectorS
  * 5. Call finish() again and check that a CouchbaseLiteException with the code NotOpen is thrown.
  */
 TEST_CASE_METHOD(VectorSearchTest, "TestIndexUpdaterUseAfterFinished", "[VectorSearch][LazyVectorIndex]") {
+    // These 3 functions will abort after the updater is finished.
+    // CBLIndexUpdater_Count(updater, i)
+    // CBLIndexUpdater_Value(updater, i)
+    // CBLIndexUpdater_SkipVector(updater, i)
     CBLError error {};
     
     CBLVectorIndexConfiguration config { kCBLN1QLLanguage, "word"_sl, 300, 8, true };
@@ -1165,19 +1157,6 @@ TEST_CASE_METHOD(VectorSearchTest, "TestIndexUpdaterUseAfterFinished", "[VectorS
     
     // This will call finish:
     updateWordsIndexWithUpdater(updater);
-    
-    CHECK(CBLIndexUpdater_Count(updater) == 0);
-    
-    CHECK(CBLIndexUpdater_Value(updater, 0) == nullptr);
-    
-    // No-Ops
-    float vector[] = { 1.0, 2.0, 3.0 };
-    CHECK(CBLIndexUpdater_SetVector(updater, 0, vector, 3, &error));
-    CheckNoError(error);
-    
-    // No-Ops
-    CHECK(CBLIndexUpdater_SkipVector(updater, 0, &error));
-    CheckNoError(error);
     
     // Call finish again:
     ExpectingExceptions x;

--- a/test/LazyVectorIndexTest.cc
+++ b/test/LazyVectorIndexTest.cc
@@ -31,6 +31,7 @@
  * - Test 6 (TestGetIndexOnClosedDatabase) is done in "Close Database then Use Collection".
  * - Test 7 (testInvalidCollection) is done in "Delete Collection then Use Collection".
  * - Test 16 (TestIndexUpdaterArrayIterator) Not applicable for C (Not Implement Iterator in C, not the main purpose of the updater and hard to use)
+ * - Test 25 (TestIndexUpdaterCallFinishTwice) Merged with Test 27.
  */
 
 /**
@@ -1124,28 +1125,33 @@ TEST_CASE_METHOD(VectorSearchTest, "TestIndexUpdaterIndexOutOfBounds", "[VectorS
 }
 
 /**
- * 26. TestIndexUpdaterCallFinishTwice
+ * 27. TestIndexUpdaterUseAfterFinished
  *
  * Description
- * Test that when calling IndexUpdater's finish() after it was finished,
- * a CuchbaseLiteException is thrown.
+ * Test that using the index updater after calling finish() behaves as expected.
+ *     - Getting count property returns zero.
+ *     - Getting value returns null.
+ *     - Calling setVector() will be no-ops (success as no exception thrown)
+ *     - Calling skiVector() will be no-ops (success as no exception thrown)
+ * Note: Test 26 and 27 can be merged into a single test as desire.
  *
  * Steps
  * 1. Copy database words_db.
  * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
+ *       - expression: "word"
+ *       - dimensions: 300
+ *       - centroids : 8
+ *       - isLazy : true
  * 3. Call beginUpdate() with limit 1 to get an IndexUpdater object.
- *     - Get the word string from the IndexUpdater.
- *     - Query the vector by word from the _default.words collection.
- *     - Convert the vector result which is an array object to a platform's float array.
- *     - Call setVector() with the platform's float array at the index..
- * 8. Call finish() and check that the finish() is successfully called.
- * 9. Call finish() again and check that a CouchbaseLiteException with the code Unsupported is thrown.
+ *       - Get the word string from the IndexUpdater.
+ *       - Query the vector by word from the _default.words collection.
+ *       - Convert the vector result which is an array object to a platform's float array.
+ *       - Call setVector() with the platform's float array at the index.
+ *       
+ * 4. Call finish() and check that the finish() is successfully called.
+ * 5. Call finish() again and check that a CouchbaseLiteException with the code NotOpen is thrown.
  */
-TEST_CASE_METHOD(VectorSearchTest, "TestIndexUpdaterCallFinishTwice", "[.CBL-5843]") {
+TEST_CASE_METHOD(VectorSearchTest, "TestIndexUpdaterUseAfterFinished", "[VectorSearch][LazyVectorIndex]") {
     CBLError error {};
     
     CBLVectorIndexConfiguration config { kCBLN1QLLanguage, "word"_sl, 300, 8, true };
@@ -1160,9 +1166,23 @@ TEST_CASE_METHOD(VectorSearchTest, "TestIndexUpdaterCallFinishTwice", "[.CBL-584
     // This will call finish:
     updateWordsIndexWithUpdater(updater);
     
+    CHECK(CBLIndexUpdater_Count(updater) == 0);
+    
+    CHECK(CBLIndexUpdater_Value(updater, 0) == nullptr);
+    
+    // No-Ops
+    float vector[] = { 1.0, 2.0, 3.0 };
+    CHECK(CBLIndexUpdater_SetVector(updater, 0, vector, 3, &error));
+    CheckNoError(error);
+    
+    // No-Ops
+    CHECK(CBLIndexUpdater_SkipVector(updater, 0, &error));
+    CheckNoError(error);
+    
     // Call finish again:
+    ExpectingExceptions x;
     CHECK(!CBLIndexUpdater_Finish(updater, &error));
-    CheckError(error, kCBLErrorUnsupported);
+    CheckError(error, kCBLErrorNotOpen);
     
     CBLIndexUpdater_Release(updater);
     CBLQueryIndex_Release(index);

--- a/test/VectorSearchTest.cc
+++ b/test/VectorSearchTest.cc
@@ -1154,20 +1154,10 @@ TEST_CASE_METHOD(VectorSearchTest, "testVectorMatchWithMultipleAndExpression", "
     CBLVectorIndexConfiguration config { kCBLN1QLLanguage, "vector"_sl, 300, 8 };
     createWordsIndex(config);
     
-    string sql = "SELECT word, catid FROM _default.words WHERE (VECTOR_MATCH(words_index, $vector, 300) AND word is valued) AND catid = 'cat1'";
-    auto query = CreateQuery(wordDB, sql);
-    setDinnerParameter(query);
-    
-    alloc_slice explanation(CBLQuery_Explain(query));
-    CHECK(vectorIndexUsedInExplain(explanation, "words_index"));
-    
-    CBLError error {};
-    auto results = CBLQuery_Execute(query, &error);
-    CHECK(results);
+    auto results = executeWordsQuery(300, false, "AND word is valued AND catid = 'cat1'");
     CHECK(CountResults(results) == 50);
     
     CBLResultSet_Release(results);
-    CBLQuery_Release(query);
 }
 
 /**

--- a/test/VectorSearchTest.hh
+++ b/test/VectorSearchTest.hh
@@ -265,8 +265,7 @@ public:
                     outUpdatedWords->push_back(slice(word).asString());
                 }
             } else {
-                CHECK(CBLIndexUpdater_SkipVector(updater, i, &error));
-                CheckNoError(error);
+                CBLIndexUpdater_SkipVector(updater, i);
                 
                 if (outSkippedWords) {
                     outSkippedWords->push_back(slice(word).asString());


### PR DESCRIPTION
* Updated IndexUpdater API to sync illegal behavior with the other platforms : If functions have out error, return out error; otherwise abort.

* Added TestIndexUpdaterUseAfterFinished.

* Used LiteCore 3.2.0-210