### PR TITLE
CBL-6071 : Implement FullSync DatabaseConfiguration property

### DIFF
--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -82,6 +82,16 @@ typedef struct {
 #ifdef COUCHBASE_ENTERPRISE
     CBLEncryptionKey encryptionKey;     ///< The database's encryption key (if any)
 #endif
+    /** As Couchbase Lite normally configures its databases, There is a very
+        small (though non-zero) chance that a power failure at just the wrong
+        time could cause the most recently committed transaction's changes to
+        be lost. This would cause the database to appear as it did immediately
+        before that transaction.
+     
+        Setting this mode true ensures that an operating system crash or
+        power failure will not cause the loss of any data.  FULL synchronous
+        is very safe but it is also dramatically slower. */
+    bool fullSync;
 } CBLDatabaseConfiguration;
 
 /** Returns the default database configuration. */


### PR DESCRIPTION
* Cherry-Picked the change from cce49636faccc9358249d574b9cea1d658059a7f in release/3.1 branch. There was a conflict in DatabaseTest.cc which is easy to resolve.
* Implemented FullSync DatabaseConfiguration property.
* No change to C++ Public API as it uses C's CBLDatabaseConfiguration directory.
* Updated LiteCore to 3.2.0-223