### PR TITLE
CBL-6160 : Fix CouchbaseLite.modulemap

### DIFF
--- a/Xcode/CouchbaseLite.modulemap
+++ b/Xcode/CouchbaseLite.modulemap
@@ -11,7 +11,11 @@ framework module CouchbaseLite {
     header "CBLEncryptable.h"
     header "CBLLog.h"
     header "CBLPlatform.h"
+    header "CBLPrediction.h"
     header "CBLQuery.h"
+    header "CBLQueryIndex.h"
+    header "CBLQueryIndexTypes.h"
+    header "CBLQueryTypes.h"
     header "CBLReplicator.h"
     header "CBLScope.h"
     


### PR DESCRIPTION
Included the missing header files.