### PR TITLE
The raspbian 9 compiler vanished from sourceforge so host it

### DIFF
--- a/jenkins/cross_manifest.json
+++ b/jenkins/cross_manifest.json
@@ -1,6 +1,6 @@
 {
     "raspbian9": {
-        "toolchain": "https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.3.0/Raspberry%20Pi%202%2C%203/cross-gcc-9.3.0-pi_2-3.tar.gz/download",
+        "toolchain": "http://downloads.build.couchbase.com/mobile/toolchains/cross-gcc-9.3.0-pi_2-3.tar.gz",
         "sysroot": "debian-stretch-armhf.tar.gz"
     },
     "debian9-x86_64": {

--- a/jenkins/linux-package-config.json
+++ b/jenkins/linux-package-config.json
@@ -15,11 +15,11 @@
       "target_debs": [ "debian10", "debian11", "debian12", "ubuntu20.04", "ubuntu22.04" ]
     },
     "armhf": {
-        "build_os": "raspios10-armhf", 
+        "build_os": "raspbian9", 
         "strip_prefix": "arm-linux-gnueabihf-",
         "toolchain": "Toolchain-pi",
         "target_osname": "linux-armhf",
-        "target_debs": [ "debian10", "debian11", "debian12", "ubuntu20.04", "ubuntu22.04" ]
+        "target_debs": [ "debian9", "debian10", "debian11", "debian12", "ubuntu20.04", "ubuntu22.04" ]
     }
   },
   "package_distro_config": {


### PR DESCRIPTION
This required an intensive rebuild from the scripts downstream, and moving the result to a place that we control.  Re-enable raspbian9.