### PR TITLE
CBL-6213 : Enable Version Vector

### DIFF
--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -42,6 +42,9 @@ namespace cbl {
         /** A document's revision ID, which is a short opaque string that's guaranteed to be unique to every change made to
             the document. If the document doesn't exist yet, this function returns an empty string.  */
         std::string revisionID() const             {return asString(CBLDocument_RevisionID(ref()));}
+        
+        /** The hybrid logical timestamp in nanoseconds since epoch that the revision was created. */
+        uint64_t timestamp() const                 {return CBLDocument_Timestamp(ref());}
 
         /** A document's current sequence in the local database.
             This number increases every time the document is saved, and a more recently saved document

--- a/include/cbl/CBLDocument.h
+++ b/include/cbl/CBLDocument.h
@@ -238,6 +238,9 @@ FLString CBLDocument_ID(const CBLDocument*) CBLAPI;
     If the document doesn't exist yet, this function returns NULL. */
 FLString CBLDocument_RevisionID(const CBLDocument*) CBLAPI;
 
+/** The hybrid logical timestamp in nanoseconds since epoch that the revision was created. */
+uint64_t CBLDocument_Timestamp(const CBLDocument*) CBLAPI;
+
 /** Returns a document's current sequence in the local database.
     This number increases every time the document is saved, and a more recently saved document
     will have a greater sequence number than one saved earlier, so sequences may be used as an

--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -322,7 +322,7 @@ private:
         }
         C4DatabaseConfig2 c4Config = {};
         c4Config.parentDirectory = effectiveDir(config->directory);
-        c4Config.flags = kC4DB_Create;
+        c4Config.flags = kC4DB_Create | kC4DB_VersionVectors;
         if (config->fullSync) {
             c4Config.flags |= kC4DB_DiskSyncFull;
         }

--- a/src/CBLDocument_CAPI.cc
+++ b/src/CBLDocument_CAPI.cc
@@ -37,6 +37,7 @@ CBLDocument* CBLDocument_MutableCopy(const CBLDocument* doc) noexcept {
 
 FLSlice CBLDocument_ID(const CBLDocument* doc) noexcept                 {return doc->docID();}
 FLSlice CBLDocument_RevisionID(const CBLDocument* doc) noexcept         {return doc->revisionID();}
+uint64_t CBLDocument_Timestamp(const CBLDocument* doc) noexcept         {return doc->timestamp();}
 uint64_t CBLDocument_Sequence(const CBLDocument* doc) noexcept          {return doc->sequence();}
 CBLCollection* CBLDocument_Collection(const CBLDocument* doc) noexcept  {return doc->collection();}
 FLDict CBLDocument_Properties(const CBLDocument* doc) noexcept          {return doc->properties();}
@@ -47,8 +48,8 @@ FLSliceResult CBLDocument_CanonicalRevisionID(const CBLDocument* doc) noexcept {
 }
 
 /** Private API */
-unsigned CBLDocument_Generation(const CBLDocument* doc) noexcept {
-    return doc->generation();
+FLSliceResult CBLDocument_GetRevisionHistory(const CBLDocument* doc) noexcept {
+    return FLSliceResult(doc->getRevisionHistory());
 }
 
 FLMutableDict CBLDocument_MutableProperties(CBLDocument* doc) noexcept {

--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -24,6 +24,8 @@
 #include "fleece/Expert.hh"
 #include "fleece/Fleece.hh"
 #include "fleece/Mutable.hh"
+#include <climits>
+#include <sstream>
 #include <unordered_map>
 
 CBL_ASSUME_NONNULL_BEGIN
@@ -87,13 +89,12 @@ public:
     bool isMutable() const                      {return _mutable;}
     slice docID() const                         {return _docID;}
     slice revisionID() const                    {return _revID;}
-    unsigned generation() const                 {return C4Document::getRevIDGeneration(_revID);}
-
+    uint64_t timestamp() const                  {return C4Document::getRevIDTimestamp(_revID);}
+    
     uint64_t sequence() const {
         auto c4doc = _c4doc.useLocked();
         return c4doc ? static_cast<uint64_t>(c4doc->selectedRev().sequence) : 0;
     }
-
 
     alloc_slice canonicalRevisionID() const {
         auto c4doc = _c4doc.useLocked();
@@ -103,12 +104,18 @@ public:
         return c4doc->getSelectedRevIDGlobalForm();
     }
 
-
     C4RevisionFlags revisionFlags() const {
         auto c4doc = _c4doc.useLocked();
         return c4doc ? c4doc->selectedRev().flags : (kRevNew | kRevLeaf);
     }
-
+    
+    alloc_slice getRevisionHistory() const {
+        auto history = fleece::MutableArray::newArray();
+        auto c4doc = _c4doc.useLocked();
+        if (!c4doc)
+            return fleece::nullslice;
+        return c4doc->getRevisionHistory(UINT_MAX, nullptr, 0);
+    }
 
 #pragma mark - Properties:
 

--- a/src/CBLPrivate.h
+++ b/src/CBLPrivate.h
@@ -68,7 +68,7 @@ CBL_CAPI_BEGIN
 
     FLSliceResult CBLDocument_CanonicalRevisionID(const CBLDocument* doc) CBLAPI;
 
-    unsigned CBLDocument_Generation(const CBLDocument* doc) CBLAPI;
+    FLSliceResult CBLDocument_GetRevisionHistory(const CBLDocument* doc) CBLAPI;
     
     FLSlice CBLReplicator_UserAgent(const CBLReplicator* repl) CBLAPI;
 

--- a/src/CBLUserAgent.hh
+++ b/src/CBLUserAgent.hh
@@ -21,8 +21,6 @@
 #include "CBL_Edition.h"
 #include <sstream>
 
-using string = std::string;
-
 #ifdef _MSC_VER
 #define NOMINMAX
 #include <windows.h>
@@ -37,7 +35,7 @@ extern "C" NTSYSAPI NTSTATUS NTAPI RtlGetVersion(
 #if __APPLE__
 #include <sys/utsname.h>
 #if TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
-static string getDeviceModel(const char* fallback) {
+static std::string getDeviceModel(const char* fallback) {
     utsname uts;
     if(uname(&uts) != 0) {
         return fallback;
@@ -46,7 +44,7 @@ static string getDeviceModel(const char* fallback) {
 }
 
 #endif
-string getAppleVersion();
+std::string getAppleVersion();
 #endif
 
 #if defined(__linux__) && !defined(__ANDROID__)
@@ -56,7 +54,7 @@ string getAppleVersion();
 #include <fstream>
 #include <sys/utsname.h>
 
-static std::optional<string> tryKey(const char* filename, string&& key) {
+static std::optional<std::string> tryKey(const char* filename, std::string&& key) {
     static const std::regex r("(.*)=(.*)");
     std::ifstream fin(filename);
     if(!fin) {
@@ -64,7 +62,7 @@ static std::optional<string> tryKey(const char* filename, string&& key) {
     }
 
     fin.exceptions(std::ios_base::badbit);
-    string line;
+    std::string line;
     std::smatch match;
     while(std::getline(fin, line)) {
         if(std::regex_match(line, match, r)) {
@@ -77,7 +75,7 @@ static std::optional<string> tryKey(const char* filename, string&& key) {
     return {};
 }
 
-static string getDistroInfo() {
+static std::string getDistroInfo() {
     // os-release is apparently the standard these days
     if(auto os = tryKey("/etc/os-release", "PRETTY_NAME")) {
         return *os;
@@ -102,7 +100,7 @@ static string getDistroInfo() {
         return "Unknown Linux";
     }
 
-    return string(uts.sysname) + ' ' + uts.release;
+    return std::string(uts.sysname) + ' ' + uts.release;
 }
 #endif
 
@@ -110,15 +108,14 @@ static string getDistroInfo() {
 #include <sys/system_properties.h>
 #endif
 
-using stringstream = std::stringstream;
 using alloc_slice = fleece::alloc_slice;
 
 // TEMPLATE - “CouchbaseLite”/<version> “-” <build #> ” (Java; ” <Android API> “;” <device id> “) ” <build type> “, Commit/” (“unofficial@” <hostname> | <git commit>) ” Core/” <core version>
 // OUTPUT   - CouchbaseLite/3.1.0-SNAPSHOT (Java; Android 11; Pixel 4a) EE/debug, Commit/unofficial@HQ-Rename0337 Core/3.1.0
 
-static string createUserAgentHeader(){
-        stringstream header;
-        string os;
+static std::string createUserAgentHeader(){
+        std::stringstream header;
+        std::string os;
         alloc_slice coreVersion = c4_getVersion();
         alloc_slice coreBuild = c4_getBuildInfo();
 #if defined (__APPLE__) && defined (__MACH__)
@@ -139,7 +136,7 @@ static string createUserAgentHeader(){
         RTL_OSVERSIONINFOW version{};
         version.dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOW);
         auto result = RtlGetVersion(&version);
-        stringstream osStream;
+        std::stringstream osStream;
         if (result < 0) {
             os = "Microsoft Windows (Version Fetch Failed)";
         } else {

--- a/src/ConflictResolver.cc
+++ b/src/ConflictResolver.cc
@@ -33,18 +33,12 @@ static const CBLDocument* defaultConflictResolver(void *context,
                                                   const CBLDocument *localDoc,
                                                   const CBLDocument *remoteDoc)
 {
-    const CBLDocument* resolved;
     if (remoteDoc == nullptr || localDoc == nullptr)
-        resolved = nullptr;
-    else if (remoteDoc->generation() > localDoc->generation())
-        resolved = remoteDoc;
-    else if (localDoc->generation() > remoteDoc->generation())
-        resolved = localDoc;
-    else if (FLSlice_Compare(localDoc->revisionID(), remoteDoc->revisionID()) > 0)
-        resolved = localDoc;
+        return nullptr;
+    else if (localDoc->timestamp() > remoteDoc->timestamp())
+        return localDoc;
     else
-        resolved = remoteDoc;
-    return resolved;
+        return remoteDoc;
 }
 
 CBL_PUBLIC const CBLConflictResolver CBLDefaultConflictResolver = &defaultConflictResolver;

--- a/src/exports/CBL_Exports.txt
+++ b/src/exports/CBL_Exports.txt
@@ -137,6 +137,7 @@ CBLScope_CollectionNames
 
 CBLDocument_ID
 CBLDocument_RevisionID
+CBLDocument_Timestamp
 CBLDocument_Sequence
 CBLDocument_Collection
 CBLDocument_Create
@@ -236,7 +237,7 @@ CBLDatabase_DeleteDocumentByID
 CBLDatabase_LastSequence
 
 CBLDocument_CanonicalRevisionID
-CBLDocument_Generation
+CBLDocument_GetRevisionHistory
 
 CBLError_GetCaptureBacktraces
 CBLError_SetCaptureBacktraces

--- a/src/exports/generated/CBL.def
+++ b/src/exports/generated/CBL.def
@@ -98,6 +98,7 @@ CBLScope_Collection
 CBLScope_CollectionNames
 CBLDocument_ID
 CBLDocument_RevisionID
+CBLDocument_Timestamp
 CBLDocument_Sequence
 CBLDocument_Collection
 CBLDocument_Create
@@ -172,7 +173,7 @@ CBLCollection_LastSequence
 CBLDatabase_DeleteDocumentByID
 CBLDatabase_LastSequence
 CBLDocument_CanonicalRevisionID
-CBLDocument_Generation
+CBLDocument_GetRevisionHistory
 CBLError_GetCaptureBacktraces
 CBLError_SetCaptureBacktraces
 CBLQuery_SetListenerCallbackDelay

--- a/src/exports/generated/CBL.exp
+++ b/src/exports/generated/CBL.exp
@@ -106,6 +106,7 @@ _CBLScope_Collection
 _CBLScope_CollectionNames
 _CBLDocument_ID
 _CBLDocument_RevisionID
+_CBLDocument_Timestamp
 _CBLDocument_Sequence
 _CBLDocument_Collection
 _CBLDocument_Create
@@ -180,7 +181,7 @@ _CBLCollection_LastSequence
 _CBLDatabase_DeleteDocumentByID
 _CBLDatabase_LastSequence
 _CBLDocument_CanonicalRevisionID
-_CBLDocument_Generation
+_CBLDocument_GetRevisionHistory
 _CBLError_GetCaptureBacktraces
 _CBLError_SetCaptureBacktraces
 _CBLQuery_SetListenerCallbackDelay

--- a/src/exports/generated/CBL.gnu
+++ b/src/exports/generated/CBL.gnu
@@ -96,6 +96,7 @@ CBL_C {
 		CBLScope_CollectionNames;
 		CBLDocument_ID;
 		CBLDocument_RevisionID;
+		CBLDocument_Timestamp;
 		CBLDocument_Sequence;
 		CBLDocument_Collection;
 		CBLDocument_Create;
@@ -170,7 +171,7 @@ CBL_C {
 		CBLDatabase_DeleteDocumentByID;
 		CBLDatabase_LastSequence;
 		CBLDocument_CanonicalRevisionID;
-		CBLDocument_Generation;
+		CBLDocument_GetRevisionHistory;
 		CBLError_GetCaptureBacktraces;
 		CBLError_SetCaptureBacktraces;
 		CBLQuery_SetListenerCallbackDelay;

--- a/src/exports/generated/CBL_Android.gnu
+++ b/src/exports/generated/CBL_Android.gnu
@@ -97,6 +97,7 @@ CBL_C {
 		CBLScope_CollectionNames;
 		CBLDocument_ID;
 		CBLDocument_RevisionID;
+		CBLDocument_Timestamp;
 		CBLDocument_Sequence;
 		CBLDocument_Collection;
 		CBLDocument_Create;
@@ -171,7 +172,7 @@ CBL_C {
 		CBLDatabase_DeleteDocumentByID;
 		CBLDatabase_LastSequence;
 		CBLDocument_CanonicalRevisionID;
-		CBLDocument_Generation;
+		CBLDocument_GetRevisionHistory;
 		CBLError_GetCaptureBacktraces;
 		CBLError_SetCaptureBacktraces;
 		CBLQuery_SetListenerCallbackDelay;

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -139,6 +139,7 @@ CBLScope_Collection
 CBLScope_CollectionNames
 CBLDocument_ID
 CBLDocument_RevisionID
+CBLDocument_Timestamp
 CBLDocument_Sequence
 CBLDocument_Collection
 CBLDocument_Create
@@ -213,7 +214,7 @@ CBLCollection_LastSequence
 CBLDatabase_DeleteDocumentByID
 CBLDatabase_LastSequence
 CBLDocument_CanonicalRevisionID
-CBLDocument_Generation
+CBLDocument_GetRevisionHistory
 CBLError_GetCaptureBacktraces
 CBLError_SetCaptureBacktraces
 CBLQuery_SetListenerCallbackDelay

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -147,6 +147,7 @@ _CBLScope_Collection
 _CBLScope_CollectionNames
 _CBLDocument_ID
 _CBLDocument_RevisionID
+_CBLDocument_Timestamp
 _CBLDocument_Sequence
 _CBLDocument_Collection
 _CBLDocument_Create
@@ -221,7 +222,7 @@ _CBLCollection_LastSequence
 _CBLDatabase_DeleteDocumentByID
 _CBLDatabase_LastSequence
 _CBLDocument_CanonicalRevisionID
-_CBLDocument_Generation
+_CBLDocument_GetRevisionHistory
 _CBLError_GetCaptureBacktraces
 _CBLError_SetCaptureBacktraces
 _CBLQuery_SetListenerCallbackDelay

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -137,6 +137,7 @@ CBL_C {
 		CBLScope_CollectionNames;
 		CBLDocument_ID;
 		CBLDocument_RevisionID;
+		CBLDocument_Timestamp;
 		CBLDocument_Sequence;
 		CBLDocument_Collection;
 		CBLDocument_Create;
@@ -211,7 +212,7 @@ CBL_C {
 		CBLDatabase_DeleteDocumentByID;
 		CBLDatabase_LastSequence;
 		CBLDocument_CanonicalRevisionID;
-		CBLDocument_Generation;
+		CBLDocument_GetRevisionHistory;
 		CBLError_GetCaptureBacktraces;
 		CBLError_SetCaptureBacktraces;
 		CBLQuery_SetListenerCallbackDelay;

--- a/src/exports/generated/CBL_EE_Android.gnu
+++ b/src/exports/generated/CBL_EE_Android.gnu
@@ -138,6 +138,7 @@ CBL_C {
 		CBLScope_CollectionNames;
 		CBLDocument_ID;
 		CBLDocument_RevisionID;
+		CBLDocument_Timestamp;
 		CBLDocument_Sequence;
 		CBLDocument_Collection;
 		CBLDocument_Create;
@@ -212,7 +213,7 @@ CBL_C {
 		CBLDatabase_DeleteDocumentByID;
 		CBLDatabase_LastSequence;
 		CBLDocument_CanonicalRevisionID;
-		CBLDocument_Generation;
+		CBLDocument_GetRevisionHistory;
 		CBLError_GetCaptureBacktraces;
 		CBLError_SetCaptureBacktraces;
 		CBLQuery_SetListenerCallbackDelay;

--- a/test/ReplicatorCollectionTest.cc
+++ b/test/ReplicatorCollectionTest.cc
@@ -464,8 +464,6 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Default Conflict Resolver with Colle
     REQUIRE(foo1a);
     REQUIRE(CBLDocument_SetJSON(foo1a, slice("{\"greeting\":\"hi\"}"), &error));
     REQUIRE(CBLCollection_SaveDocument(cx[0], foo1a, &error));
-    REQUIRE(CBLDocument_SetJSON(foo1a, slice("{\"greeting\":\"hey\"}"), &error));
-    REQUIRE(CBLCollection_SaveDocument(cx[0], foo1a, &error));
     CBLDocument_Release(foo1a);
     
     auto foo1b = CBLCollection_GetMutableDocument(cy[0], "foo1"_sl, &error);
@@ -474,19 +472,17 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Default Conflict Resolver with Colle
     REQUIRE(CBLCollection_SaveDocument(cy[0], foo1b, &error));
     CBLDocument_Release(foo1b);
     
+    auto bar1b = CBLCollection_GetMutableDocument(cy[1], "bar1"_sl, &error);
+    REQUIRE(bar1b);
+    REQUIRE(CBLDocument_SetJSON(bar1b, slice("{\"greeting\":\"salve\"}"), &error));
+    REQUIRE(CBLCollection_SaveDocument(cy[1], bar1b, &error));
+    CBLDocument_Release(bar1b);
+    
     auto bar1a = CBLCollection_GetMutableDocument(cx[1], "bar1"_sl, &error);
     REQUIRE(bar1a);
     REQUIRE(CBLDocument_SetJSON(bar1a, slice("{\"greeting\":\"sawasdee\"}"), &error));
     REQUIRE(CBLCollection_SaveDocument(cx[1], bar1a, &error));
     CBLDocument_Release(bar1a);
-    
-    auto bar1b = CBLCollection_GetMutableDocument(cy[1], "bar1"_sl, &error);
-    REQUIRE(bar1b);
-    REQUIRE(CBLDocument_SetJSON(bar1b, slice("{\"greeting\":\"salve\"}"), &error));
-    REQUIRE(CBLCollection_SaveDocument(cy[1], bar1b, &error));
-    REQUIRE(CBLDocument_SetJSON(bar1b, slice("{\"greeting\":\"bonjour\"}"), &error));
-    REQUIRE(CBLCollection_SaveDocument(cy[1], bar1b, &error));
-    CBLDocument_Release(bar1b);
     
     config.replicatorType = kCBLReplicatorTypePush;
     expectedDocumentCount = 0;
@@ -512,12 +508,12 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Default Conflict Resolver with Colle
 
     auto foo1 = CBLCollection_GetDocument(cx[0], "foo1"_sl, &error);
     REQUIRE(foo1);
-    CHECK(Dict(CBLDocument_Properties(foo1)).toJSONString() == "{\"greeting\":\"hey\"}");
+    CHECK(Dict(CBLDocument_Properties(foo1)).toJSONString() == "{\"greeting\":\"hola\"}");
     CBLDocument_Release(foo1);
 
     auto bar1 = CBLCollection_GetDocument(cx[1], "bar1"_sl, &error);
     REQUIRE(bar1);
-    CHECK(Dict(CBLDocument_Properties(bar1)).toJSONString() == "{\"greeting\":\"bonjour\"}");
+    CHECK(Dict(CBLDocument_Properties(bar1)).toJSONString() == "{\"greeting\":\"sawasdee\"}");
     CBLDocument_Release(bar1);
 }
 


### PR DESCRIPTION
* Enable Version Vector (CBL-6213).
* Implement Document’s timestamp (CBL-6217).
* Implement new default conflict resolver (CBL-6221).
* (Private) Implement Document’s getRevisionHistory().
* (Private) Temporarily add Documenent’s getGlobalRevisionID() until the issue with * id is sorted out for testing.
* Fix Compile error in CBLUserAgent.hh.
* Update LiteCore to the latest master (92fc5cc)