### PR TITLE
Update LiteCore to 4.0.0-19

### DIFF
--- a/test/DatabaseTest.cc
+++ b/test/DatabaseTest.cc
@@ -771,7 +771,7 @@ TEST_CASE_METHOD(DatabaseTest, "Legacy - Database change notifications from diff
         CBLDocument_Release(doc);
     };
     
-    thread t1([=]() { createDoc(db); });
+    thread t1([&]() { createDoc(db); });
     thread t2([=]() { createDoc(anotherDB); });
     
     t1.join();

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -901,8 +901,6 @@ TEST_CASE_METHOD(QueryTest, "Test Joins with Collections", "[Query]") {
 
     string queryString;
     
-    /*
-    CBL-6243
     SECTION("Use Full Collection Name") {
         queryString = "SELECT flowers.name, colors.color "
                       "FROM test.flowers "
@@ -910,7 +908,6 @@ TEST_CASE_METHOD(QueryTest, "Test Joins with Collections", "[Query]") {
                       "ON flowers.cid = colors.cid "
                       "ORDER BY flowers.name";
     }
-    */
     
     SECTION("Use Alias Name") {
         queryString = "SELECT f.name, c.color "


### PR DESCRIPTION
* Update LiteCore to 4.0.9-19.
* Reenabled Test Joins with Collections Test's Use Full Collection Name section as CBL-6243 has been fixed in 4.0.0-10.