### PR TITLE
CBL-6651 : Fix and enable android GHA PR Validation

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -16,8 +16,7 @@ env:
 
 jobs:
   build:
-    if: false
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -27,19 +26,15 @@ jobs:
     - name: Setup Android SDK
       run: |
         java -version
-        $ANDROID_SDK_ROOT/tools/bin/sdkmanager --list
-        $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;27.0.12077973"
-        $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "cmake;3.28.1"
-
-    - name: Setup Java SDK
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'adopt'
-        java-version: 11
+        $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --list
+        $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "ndk;27.2.12479018"
+        $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "cmake;3.31.0"
         
     - name: Build
       working-directory: ${{github.workspace}}
       run: | 
+        export ANDROID_NDK_VERSION=27.2.12479018
+        export ANDROID_CMAKE_VERSION=3.31.0
         scripts/build_android.sh -a x86_64
 
     - name: Prepare for Tests

--- a/test/platforms/Android/app/CMakeLists.txt
+++ b/test/platforms/Android/app/CMakeLists.txt
@@ -6,7 +6,6 @@
 cmake_minimum_required(VERSION 3.18.1)
 
 # Declares and names the project.
-
 project("cbl_tests")
 
 set(CBL_DIR ${PROJECT_SOURCE_DIR}/../../../..)
@@ -19,6 +18,13 @@ list(APPEND CMAKE_PREFIX_PATH ${LIB_CBLITE_DIR})
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE NEVER)
 find_package(CouchbaseLite REQUIRED)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# BUILD SETTINGS:
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 11)
 
 add_definitions(
     -DCBL_TESTS

--- a/test/platforms/Android/app/build.gradle
+++ b/test/platforms/Android/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
 android {
     namespace 'com.couchbase.tests'
     compileSdk 32
+    ndkVersion '27.2.12479018'
 
     ext {
         PROJECT_DIR = "${projectDir}"
@@ -60,7 +61,7 @@ android {
     externalNativeBuild {
         cmake {
             path file('CMakeLists.txt')
-            version '3.18.1'
+            version '3.31.0'
         }
     }
 

--- a/test/platforms/Android/app/src/main/cpp/native-lib.cpp
+++ b/test/platforms/Android/app/src/main/cpp/native-lib.cpp
@@ -56,18 +56,12 @@ public:
     }
 };
 
-namespace Catch {
-    ostream& cout() {
-        static ostream ret(new AndroidLogStream());
-        return ret;
-    }
-    ostream& clog() {
-        static ostream ret(new AndroidLogStream());
-        return ret;
-    }
-    ostream& cerr() {
-        return clog();
-    }
+// Initialize the custom stream buffer
+static AndroidLogStream androidLogStream;
+void redirectCatchToLogcat() {
+    std::cout.rdbuf(&androidLogStream);
+    std::clog.rdbuf(&androidLogStream);
+    std::cerr.rdbuf(&androidLogStream);
 }
 
 extern "C" JNIEXPORT int JNICALL
@@ -94,6 +88,8 @@ Java_com_couchbase_tests_CouchbaseLiteTest_runTests(
         AndroidLog::log(level, m);
     });
     CBLLog_SetCallbackLevel(kCBLLogInfo);
+
+    redirectCatchToLogcat();
 
     // Preparing Catch test arguments:
     vector<string> tmpArgs;


### PR DESCRIPTION
* Updated to use macos-13
* Used the new Android cmd_tools to install the SDK and tool required.
* Updated NDK and CMake version to be able to compile modern C++ codes in LiteCore and Fleece.
* Fix Android Test’s code that runs catch tests.