### PR TITLE
CBL-6678 : Auto create log directory

### DIFF
--- a/src/CBLBase_CAPI.cc
+++ b/src/CBLBase_CAPI.cc
@@ -18,6 +18,7 @@
 
 #include "CBLBase.h"
 #include "CBLPrivate.h"
+#include "FilePath.hh"
 #include "Internal.hh"
 #include "Listener.hh"
 #include <iostream>
@@ -68,4 +69,12 @@ void CBLListener_Remove(CBLListenerToken *token) noexcept {
         token->remove();
         release(token);
     }
+}
+
+/** Private API */
+bool CBL_DeleteDirectoryRecursive(FLString dir, CBLError* _cbl_nullable outError) noexcept {
+    try {
+        auto path = litecore::FilePath(fleece::slice(dir), "");
+        return path.delRecursive();
+    } catchAndBridge(outError)
 }

--- a/src/CBLPrivate.h
+++ b/src/CBLPrivate.h
@@ -89,4 +89,8 @@ FLMutableArray CBLCollection_GetIndexesInfo(const CBLCollection* collection,
     /** Use c4log to log the message so that the message will be sent to LiteCore's callback and file logging */
     void CBLLog_LogWithC4Log(CBLLogDomain domain, CBLLogLevel level, const char *message) CBLAPI;
 
+    /** A utility for deleting directory recursively used in tests. This function is using LiteCore's FilePath which is cross-platform.
+        TODO: When std::filesystem available from C++ 17 can be used, we can get rid of this function. */
+    bool CBL_DeleteDirectoryRecursive(FLString dir, CBLError* _cbl_nullable outError) CBLAPI;
+
 CBL_CAPI_END

--- a/src/exports/CBL_Exports.txt
+++ b/src/exports/CBL_Exports.txt
@@ -258,3 +258,5 @@ CBLLog_EndExpectingExceptions
 
 CBLLog_Reset
 CBLLog_LogWithC4Log
+
+CBL_DeleteDirectoryRecursive

--- a/src/exports/generated/CBL.def
+++ b/src/exports/generated/CBL.def
@@ -189,6 +189,7 @@ CBLLog_BeginExpectingExceptions
 CBLLog_EndExpectingExceptions
 CBLLog_Reset
 CBLLog_LogWithC4Log
+CBL_DeleteDirectoryRecursive
 kCBLDefaultDatabaseFullSync
 kCBLDefaultDatabaseMmapDisabled
 kCBLDefaultLogFileUsePlaintext

--- a/src/exports/generated/CBL.exp
+++ b/src/exports/generated/CBL.exp
@@ -197,6 +197,7 @@ _CBLLog_BeginExpectingExceptions
 _CBLLog_EndExpectingExceptions
 _CBLLog_Reset
 _CBLLog_LogWithC4Log
+_CBL_DeleteDirectoryRecursive
 _kCBLDefaultDatabaseFullSync
 _kCBLDefaultDatabaseMmapDisabled
 _kCBLDefaultLogFileUsePlaintext

--- a/src/exports/generated/CBL.gnu
+++ b/src/exports/generated/CBL.gnu
@@ -187,6 +187,7 @@ CBL_C {
 		CBLLog_EndExpectingExceptions;
 		CBLLog_Reset;
 		CBLLog_LogWithC4Log;
+		CBL_DeleteDirectoryRecursive;
 		kCBLDefaultDatabaseFullSync;
 		kCBLDefaultDatabaseMmapDisabled;
 		kCBLDefaultLogFileUsePlaintext;

--- a/src/exports/generated/CBL_Android.gnu
+++ b/src/exports/generated/CBL_Android.gnu
@@ -188,6 +188,7 @@ CBL_C {
 		CBLLog_EndExpectingExceptions;
 		CBLLog_Reset;
 		CBLLog_LogWithC4Log;
+		CBL_DeleteDirectoryRecursive;
 		kCBLDefaultDatabaseFullSync;
 		kCBLDefaultDatabaseMmapDisabled;
 		kCBLDefaultLogFileUsePlaintext;

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -230,6 +230,7 @@ CBLLog_BeginExpectingExceptions
 CBLLog_EndExpectingExceptions
 CBLLog_Reset
 CBLLog_LogWithC4Log
+CBL_DeleteDirectoryRecursive
 kCBLDefaultDatabaseFullSync
 kCBLDefaultDatabaseMmapDisabled
 kCBLDefaultLogFileUsePlaintext

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -238,6 +238,7 @@ _CBLLog_BeginExpectingExceptions
 _CBLLog_EndExpectingExceptions
 _CBLLog_Reset
 _CBLLog_LogWithC4Log
+_CBL_DeleteDirectoryRecursive
 _kCBLDefaultDatabaseFullSync
 _kCBLDefaultDatabaseMmapDisabled
 _kCBLDefaultLogFileUsePlaintext

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -228,6 +228,7 @@ CBL_C {
 		CBLLog_EndExpectingExceptions;
 		CBLLog_Reset;
 		CBLLog_LogWithC4Log;
+		CBL_DeleteDirectoryRecursive;
 		kCBLDefaultDatabaseFullSync;
 		kCBLDefaultDatabaseMmapDisabled;
 		kCBLDefaultLogFileUsePlaintext;

--- a/src/exports/generated/CBL_EE_Android.gnu
+++ b/src/exports/generated/CBL_EE_Android.gnu
@@ -229,6 +229,7 @@ CBL_C {
 		CBLLog_EndExpectingExceptions;
 		CBLLog_Reset;
 		CBLLog_LogWithC4Log;
+		CBL_DeleteDirectoryRecursive;
 		kCBLDefaultDatabaseFullSync;
 		kCBLDefaultDatabaseMmapDisabled;
 		kCBLDefaultLogFileUsePlaintext;


### PR DESCRIPTION
CBL-C doesn’t automatically create the specified log directory if it doesn’t exist while the other platforms do. This commit enhances the log  (both old and log sink api) to create the log directory if it doesn’t exist.