### PR TITLE
CBL-6817 :  Allow docs from different instances of the same collection to save or delete

### DIFF
--- a/src/CBLCollection_Internal.hh
+++ b/src/CBLCollection_Internal.hh
@@ -66,6 +66,17 @@ public:
     uint64_t lastSequence() const               {return static_cast<uint64_t>(_c4col.useLocked()->getLastSequence());}
     CBLDatabase* database() const               {return _database; }
     
+#pragma mark - OPERATORS:
+    
+    bool operator== (const CBLCollection &coll) const {
+        // Same scope and collection name && same database reference:
+        return _fullName == coll._fullName && _database == coll._database;
+    }
+    
+    bool operator!= (const CBLCollection &coll) const {
+        return !(*this == coll);
+    }
+    
 #pragma mark - DOCUMENTS:
     
     RetainedConst<CBLDocument> getDocument(slice docID, bool allRevisions =false) const {

--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -92,6 +92,16 @@ alloc_slice CBLDocument::getRevisionHistory() const {
 }
 
 
+#pragma mark - Utils:
+
+
+void CBLDocument::checkCollectionMatches(CBLCollection* _cbl_nullable myCol, CBLCollection *colParam) {
+    if (myCol && *myCol != *colParam) {
+        C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter, "Use document on a wrong collection");
+    }
+}
+
+
 #pragma mark - SAVING:
 
 

--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -96,8 +96,9 @@ alloc_slice CBLDocument::getRevisionHistory() const {
 
 
 void CBLDocument::checkCollectionMatches(CBLCollection* _cbl_nullable myCol, CBLCollection *colParam) {
-    if (myCol && *myCol != *colParam) {
-        C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter, "Use document on a wrong collection");
+    if (myCol && (*myCol != *colParam)) {
+        C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter,
+            "The collection for save or delete does not match the document’s collection or belongs to a different database instance.");
     }
 }
 

--- a/src/CBLDocument_Internal.hh
+++ b/src/CBLDocument_Internal.hh
@@ -263,13 +263,7 @@ public:
 
 #pragma mark - Utils:
     
-    
-    static void checkCollectionMatches(CBLCollection* _cbl_nullable myCol, CBLCollection *colParam) {
-        if (myCol && myCol != colParam) {
-            C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter, "Use document on a wrong collection");
-        }
-    }
-    
+    static void checkCollectionMatches(CBLCollection* _cbl_nullable myCol, CBLCollection *colParam);
 
 #pragma mark - Internals:
 

--- a/test/DocumentTest.cc
+++ b/test/DocumentTest.cc
@@ -691,6 +691,67 @@ TEST_CASE_METHOD(DocumentTest, "Save Document into Different Collection", "[Docu
     CBLDocument_Release(doc);
 }
 
+TEST_CASE_METHOD(DocumentTest, "Save Document into Same Collection Different Instance", "[Document]") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+    
+    CBLError error;
+    CHECK(CBLCollection_SaveDocument(col, doc, &error));
+    
+    CBLScope* scope = CBLCollection_Scope(col);
+    CBLCollection* col2 = CBLDatabase_Collection(db, CBLCollection_Name(col), CBLScope_Name(scope), &error);
+    CHECK(col != col2);
+    CHECK(CBLCollection_SaveDocument(col2, doc, &error));
+    
+    CBLDocument_Release(doc);
+    CBLScope_Release(scope);
+    CBLCollection_Release(col2);
+}
+
+TEST_CASE_METHOD(DocumentTest, "Save Document into Same Collection Different DB Instance", "[Document]") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+    
+    CBLError error;
+    CHECK(CBLCollection_SaveDocument(col, doc, &error));
+    
+    auto config = databaseConfig();
+    auto anotherDB = CBLDatabase_Open(kDatabaseName, &config, &error);
+    REQUIRE(anotherDB);
+    
+    CBLScope* scope = CBLCollection_Scope(col);
+    CBLCollection* col2 = CBLDatabase_Collection(anotherDB, CBLCollection_Name(col), CBLScope_Name(scope), &error);
+    CHECK(col != col2);
+    
+    ExpectingExceptions x;
+    CHECK(!CBLCollection_SaveDocument(col2, doc, &error));
+    CHECK(error.domain == kCBLDomain);
+    CHECK(error.code == kCBLErrorInvalidParameter);
+    
+    CBLDocument_Release(doc);
+    CBLScope_Release(scope);
+    CBLCollection_Release(col2);
+    CBLDatabase_Release(anotherDB);
+}
+
+TEST_CASE_METHOD(DocumentTest, "Save Document into Different Default Collection Instance", "[Document]") {
+    CBLDocument* doc = CBLDocument_CreateWithID("foo"_sl);
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, "greeting"_sl, "Howdy!"_sl);
+    
+    CBLError error;
+    CHECK(CBLCollection_SaveDocument(defaultCollection, doc, &error));
+    
+    CBLCollection* defaultCollection2 = CBLDatabase_DefaultCollection(db, &error);
+    CHECK(defaultCollection != defaultCollection2);
+    CHECK(CBLCollection_SaveDocument(defaultCollection2, doc, &error));
+    
+    CBLDocument_Release(doc);
+    CBLCollection_Release(defaultCollection2);
+}
+
 #pragma mark - Revision History
 
 /*
@@ -873,6 +934,66 @@ TEST_CASE_METHOD(DocumentTest, "Delete Document from Different Collection", "[Do
     CHECK(!CBLCollection_DeleteDocument(otherCol, doc, &error));
     CHECK(error.domain == kCBLDomain);
     CHECK(error.code == kCBLErrorInvalidParameter);
+    CBLDocument_Release(doc);
+}
+
+TEST_CASE_METHOD(DocumentTest, "Delete Document from Same Collection Different Instance", "[Document]") {
+    createDocument(col, "doc1", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLCollection_GetDocument(col, "doc1"_sl, &error);
+    REQUIRE(doc);
+    
+    CBLScope* scope = CBLCollection_Scope(col);
+    CBLCollection* col2 = CBLDatabase_Collection(db, CBLCollection_Name(col), CBLScope_Name(scope), &error);
+    CHECK(col != col2);
+    
+    CHECK(CBLCollection_DeleteDocument(col2, doc, &error));
+    
+    CBLScope_Release(scope);
+    CBLCollection_Release(col2);
+    CBLDocument_Release(doc);
+}
+
+TEST_CASE_METHOD(DocumentTest, "Delete Document from Same Collection Different DB Instance", "[Document]") {
+    createDocument(col, "doc1", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLCollection_GetDocument(col, "doc1"_sl, &error);
+    REQUIRE(doc);
+
+    auto config = databaseConfig();
+    auto anotherDB = CBLDatabase_Open(kDatabaseName, &config, &error);
+    REQUIRE(anotherDB);
+    
+    CBLScope* scope = CBLCollection_Scope(col);
+    CBLCollection* col2 = CBLDatabase_Collection(anotherDB, CBLCollection_Name(col), CBLScope_Name(scope), &error);
+    CHECK(col != col2);
+    
+    ExpectingExceptions x;
+    CHECK(!CBLCollection_DeleteDocument(col2, doc, &error));
+    CHECK(error.domain == kCBLDomain);
+    CHECK(error.code == kCBLErrorInvalidParameter);
+    
+    CBLDocument_Release(doc);
+    CBLScope_Release(scope);
+    CBLCollection_Release(col2);
+    CBLDatabase_Release(anotherDB);
+}
+
+TEST_CASE_METHOD(DocumentTest, "Delete Document from Different Default Collection Instance", "[Document]") {
+    createDocument(defaultCollection, "doc1", "foo", "bar");
+    
+    CBLError error;
+    const CBLDocument* doc = CBLCollection_GetDocument(defaultCollection, "doc1"_sl, &error);
+    REQUIRE(doc);
+    
+    CBLCollection* defaultCollection2 = CBLDatabase_DefaultCollection(db, &error);
+    CHECK(defaultCollection != defaultCollection2);
+    
+    CHECK(CBLCollection_DeleteDocument(defaultCollection2, doc, &error));
+    
+    CBLCollection_Release(defaultCollection2);
     CBLDocument_Release(doc);
 }
 


### PR DESCRIPTION
* For CBSE-19553

* Relaxed the validation rule to allow docs from different instances of the same collection (but from the same db instance) to save or delete.

* This validation is inline with .NET and JAX implementation.