### PR TITLE
Fix C++23 build errors due to std::make_unique on forward declared class

### DIFF
--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -290,19 +290,9 @@ namespace cbl {
     
     private:
         
-        static void _callListener(void* _cbl_nullable context, const CBLCollectionChange* change) {
-            Collection col = Collection((CBLCollection*)change->collection);
-            std::vector<slice> docIDs((slice*)&change->docIDs[0], (slice*)&change->docIDs[change->numDocs]);
-            auto ch = std::make_unique<CollectionChange>(col, docIDs);
-            CollectionChangeListener::call(context, ch.get());
-        }
+        static void _callListener(void* _cbl_nullable context, const CBLCollectionChange* change);
 
-        static void _callDocListener(void* _cbl_nullable context, const CBLDocumentChange* change) {
-            Collection col = Collection((CBLCollection*)change->collection);
-            slice docID = change->docID;
-            auto ch = std::make_unique<DocumentChange>(col, docID);
-            CollectionDocumentChangeListener::call(context, ch.get());
-        }
+        static void _callDocListener(void* _cbl_nullable context, const CBLDocumentChange* change);
     };
 
     /** Collection change info notified to the collection change listener's callback. */
@@ -362,6 +352,22 @@ namespace cbl {
     inline Collection Database::getDefaultCollection() const {
         CBLError error {};
         return Collection::adopt(CBLDatabase_DefaultCollection(ref(), &error), &error) ;
+    }
+
+    // Collection method bodies:
+
+    inline void Collection::_callListener(void* _cbl_nullable context, const CBLCollectionChange* change) {
+        Collection col = Collection((CBLCollection*)change->collection);
+        std::vector<slice> docIDs((slice*)&change->docIDs[0], (slice*)&change->docIDs[change->numDocs]);
+        auto ch = std::make_unique<CollectionChange>(col, docIDs);
+        CollectionChangeListener::call(context, ch.get());
+    }
+
+    inline void Collection::_callDocListener(void* _cbl_nullable context, const CBLDocumentChange* change) {
+        Collection col = Collection((CBLCollection*)change->collection);
+        slice docID = change->docID;
+        auto ch = std::make_unique<DocumentChange>(col, docID);
+        CollectionDocumentChangeListener::call(context, ch.get());
     }
 }
 


### PR DESCRIPTION
When C++23 is enabled (CMAKE_CXX_STANDARD=23) there are errors such as:

```
error: allocation of incomplete type 'cbl::CollectionChange'
```

The problem appears to be related to `std::make_unique` becoming constexpr in C++23; this change fixes the build for C++23 by ensuring `std::make_unique` is called after the types are fully defined.