### PR TITLE
CBL-6885: Anonymous TLS Identity for URLEndpointListener

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		1BF21A3E2D84E419009534EC /* TLSIdentityTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BF21A3C2D84E419009534EC /* TLSIdentityTest.cc */; };
 		1BF21A3F2D84E419009534EC /* TLSIdentityTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BF21A3C2D84E419009534EC /* TLSIdentityTest.cc */; };
 		1BF21B212D8E3ED0009534EC /* CBLTLSIdentity+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1BF21B202D8E3ED0009534EC /* CBLTLSIdentity+Apple.mm */; };
+		1BF21BBE2D9C5835009534EC /* CBLURLEndpointListener.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BF21BBD2D9C5835009534EC /* CBLURLEndpointListener.cc */; };
 		271A98B0243FDF56008C032D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 271A98AF243FDF55008C032D /* SystemConfiguration.framework */; };
 		271C2A3121CAC98F0045856E /* CBLReplicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A2C21CAC98F0045856E /* CBLReplicator.h */; };
 		271C2A3221CAC98F0045856E /* CBLBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A2D21CAC98F0045856E /* CBLBase.h */; };
@@ -435,6 +436,7 @@
 		1BF219BF2D7F930F009534EC /* CBLTLSIdentity_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLTLSIdentity_CAPI.cc; sourceTree = "<group>"; };
 		1BF21A3C2D84E419009534EC /* TLSIdentityTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TLSIdentityTest.cc; sourceTree = "<group>"; };
 		1BF21B202D8E3ED0009534EC /* CBLTLSIdentity+Apple.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "CBLTLSIdentity+Apple.mm"; sourceTree = "<group>"; };
+		1BF21BBD2D9C5835009534EC /* CBLURLEndpointListener.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLURLEndpointListener.cc; sourceTree = "<group>"; };
 		2716F8F5247D9D6700BE21D9 /* exports */ = {isa = PBXFileReference; lastKnownFileType = folder; path = exports; sourceTree = "<group>"; };
 		271A98AF243FDF55008C032D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		271C2A2321CAC8920045856E /* libcblite-static.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libcblite-static.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -767,6 +769,7 @@
 				27D11BFF235140E300C58A70 /* CBLReplicator_Internal.hh */,
 				FCC063C828588DA6000C5BD7 /* CBLScope.cc */,
 				FCD8299C2835AC20004AA814 /* CBLScope_Internal.hh */,
+				1BF21BBD2D9C5835009534EC /* CBLURLEndpointListener.cc */,
 				1BC5D9672D6E50960080153E /* CBLURLEndpointListener_Internal.hh */,
 				AE591AB729473A4400E4BDE8 /* CBLUserAgent.hh */,
 				42D1B68F2978AD31003B9871 /* CBLUserAgent.mm */,
@@ -1671,6 +1674,7 @@
 				27B61D5621D5ABA60027CCDB /* CBLQuery_CAPI.cc in Sources */,
 				277FEE7521ED3C4900B60E3C /* CBLReplicator_CAPI.cc in Sources */,
 				FCD829B32835EE39004AA814 /* CBLScope_CAPI.cc in Sources */,
+				1BF21BBE2D9C5835009534EC /* CBLURLEndpointListener.cc in Sources */,
 				40E7CA732BFE7336004BE7E1 /* ContextManager.cc in Sources */,
 				27D11BF02351043B00C58A70 /* ConflictResolver.cc in Sources */,
 				27886C8E21F64C1400069BEA /* Listener.cc in Sources */,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.1)
-cmake_policy(VERSION 3.1)
+cmake_minimum_required (VERSION 3.5)
+cmake_policy(VERSION 3.5)
 
 if(NOT DEFINED CMAKE_OSX_SYSROOT)
     # Tells Mac builds to use the current SDK's headers & libs, not what's in the OS.
@@ -137,6 +137,7 @@ set(
     src/CBLScope.cc
     src/CBLScope_CAPI.cc
     src/CBLTLSIdentity_CAPI.cc
+    src/CBLURLEndpointListener.cc
     src/CBLURLEndpointListener_CAPI.cc
     src/CBLVectorIndexConfig_CAPI.cc
     src/ConflictResolver.cc

--- a/include/cbl/CBLTLSIdentity.h
+++ b/include/cbl/CBLTLSIdentity.h
@@ -221,7 +221,7 @@ CBLTLSIdentity* _cbl_nullable CBLTLSIdentity_IdentityWithLabel(FLString persiste
 
 /** Create a TLS identity with the given RSA keypair and certificates. */
 _cbl_warn_unused
-CBLTLSIdentity* _cbl_nullable CBLTLSIdentity_IdentityWithKeyPairAndCerts(CBLKeyPair* _cbl_nullable keypair,
+CBLTLSIdentity* _cbl_nullable CBLTLSIdentity_IdentityWithKeyPairAndCerts(CBLKeyPair* keypair,
                                                                          CBLCert* cert,
                                                                          CBLError* _cbl_nullable outError) CBLAPI;
 

--- a/src/CBLDatabase_CAPI.cc
+++ b/src/CBLDatabase_CAPI.cc
@@ -155,6 +155,12 @@ uint64_t CBLDatabase_LastSequence(const CBLDatabase* db) noexcept {
     } catchAndWarn()
 }
 
+/** Private API */
+FLSliceResult CBLDatabase_PublicUUID(const CBLDatabase* db) noexcept {
+    try {
+        return FLSliceResult(db->publicUUID());
+    } catchAndWarn()
+}
 
 #pragma mark - DOCUMENTS:
 

--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -137,7 +137,9 @@ public:
 
     uint64_t count() const                           {return _c4db->useLocked()->getDocumentCount();}
     uint64_t lastSequence() const                    {return static_cast<uint64_t>(_c4db->useLocked()->getLastSequence());}
-    
+    alloc_slice publicUUID() const                   {C4UUID uuid = _c4db->useLocked()->getPublicUUID();
+                                                      return {uuid.bytes, 16}; }
+
     std::string desc() const                         {return "CBLDatabase[" + _name.asString() + "]";}
 
     

--- a/src/CBLPrivate.h
+++ b/src/CBLPrivate.h
@@ -32,6 +32,9 @@ CBL_CAPI_BEGIN
     This starts at zero and increments every time a document is saved or deleted. */
     uint64_t CBLDatabase_LastSequence(const CBLDatabase*) CBLAPI;
 
+/** Returns the public UUID of the database.*/
+    FLSliceResult CBLDatabase_PublicUUID(const CBLDatabase*) CBLAPI;
+
 /** Returns the last sequence number assigned in the collection.
     This starts at zero and increments every time a document is saved or deleted. */
     uint64_t CBLCollection_LastSequence(const CBLCollection*) CBLAPI;

--- a/src/CBLTLSIdentity_CAPI.cc
+++ b/src/CBLTLSIdentity_CAPI.cc
@@ -62,10 +62,9 @@ CBLKeyPair* CBLKeyPair_RSAKeyPairWithPrivateKeyData(FLSlice privateKeyData,
 
 // CBLPrivate.h
 CBLKeyPair* CBLKeyPair_GenerateRSAKeyPair(FLSlice passwordOrNull, CBLError* outError) noexcept {
-    C4KeyPair* c4Key = C4KeyPair::generate(kC4RSA, 2048, false).detach();
-    if ( !c4Key ) C4Error::raise(LiteCoreDomain, kC4ErrorCrypto, "fails to generate a KeyPair.");
-
-    return retain(new CBLKeyPair{c4Key});
+    try {
+        return retain(CBLKeyPair::GenerateRSAKeyPair(passwordOrNull));
+    } catchAndBridge(outError);
 }
 
 FLSliceResult CBLKeyPair_PublicKeyDigest(CBLKeyPair* keyPair) noexcept {

--- a/src/CBLTLSIdentity_Internal.hh
+++ b/src/CBLTLSIdentity_Internal.hh
@@ -301,14 +301,12 @@ public:
         return true;
     }
 
-    static CBLTLSIdentity* IdentityWithLabel(slice persistentLabel) {
+    static CBLTLSIdentity* _cbl_nullable IdentityWithLabel(slice persistentLabel) {
         std::scoped_lock<std::mutex> lock(_mutex);
 
         Retained<C4Cert> cert = C4Cert::load(persistentLabel);
-        if (!cert) {
-            C4Error::raise(LiteCoreDomain, kC4ErrorCrypto, "Fails to create the cert from the lable");
-        }
-        return new CBLTLSIdentity(nullptr, new CBLCert(cert.get()));
+        if (!cert) return nullptr;
+        else       return new CBLTLSIdentity(nullptr, new CBLCert(cert.get()));
     }
 #endif // #if !defined(__linux__) && !defined(__ANDROID__)
 
@@ -320,7 +318,7 @@ public:
         return expires;
     }
 
-    CBLKeyPair* privateKey() const { return _cblKeyPair; }
+    CBLKeyPair* _cbl_nullable privateKey() const { return _cblKeyPair; }
 
 private:
     Retained<CBLKeyPair> _cblKeyPair; // may be null

--- a/src/CBLTLSIdentity_Internal.hh
+++ b/src/CBLTLSIdentity_Internal.hh
@@ -70,7 +70,14 @@ public:
     }
     
     C4KeyPair* c4KeyPair() const { return _c4KeyPair; }
-    
+
+    // Private:
+    static CBLKeyPair* GenerateRSAKeyPair(slice passwordOrNull) {
+        C4KeyPair* c4Key = C4KeyPair::generate(kC4RSA, 2048, false).detach();
+        if ( !c4Key ) C4Error::raise(LiteCoreDomain, kC4ErrorCrypto, "fails to generate a KeyPair.");
+        return new CBLKeyPair{c4Key};
+    }
+
 private:
     Retained<C4KeyPair> _c4KeyPair;
 };

--- a/src/CBLURLEndpointListener.cc
+++ b/src/CBLURLEndpointListener.cc
@@ -1,0 +1,216 @@
+//
+//  CBLURLEndpointListener.cc
+//
+// Copyright © 2025 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "CBLURLEndpointListener_Internal.hh"
+
+#ifdef COUCHBASE_ENTERPRISE
+
+using namespace fleece;
+
+std::mutex CBLURLEndpointListener::_mutex;
+constexpr CBLTimestamp kCBLAnonymousIdentityMinValidTimeAllowed = 86400; /* 24 Hours */
+
+bool CBLURLEndpointListener::start() {
+    std::scoped_lock lock(_mutex);
+
+    if (_c4listener) return true;
+
+    Assert(_conf.collectionCount > 0);
+
+    C4ListenerConfig c4config {
+        _conf.port,
+        _conf.networkInterface,
+        kC4SyncAPI
+    };
+    c4config.allowPush = true;
+    c4config.allowPull = !_conf.readOnly;
+    c4config.enableDeltaSync = _conf.enableDeltaSync;
+
+    C4TLSConfig tls = {};
+
+    if (!_conf.disableTLS) {
+        constexpr bool persistent =
+#if !defined(__linux__) && !defined(__ANDROID__)
+        true;
+#else
+        false;
+#endif
+        CBLTLSIdentity* identity = effectiveTLSIdentity(persistent);
+        if (!identity) {
+            CBL_Log(kCBLLogDomainListener, kCBLLogWarning, "Cannot determine TLSIdentity when TLS is enabled. %s", dumpConfig().c_str());
+            return false;
+        }
+        tls.certificate = identity->certificates()->c4Cert();
+        if (identity->privateKey()) {
+            tls.privateKeyRepresentation = kC4PrivateKeyFromKey;
+            tls.key = identity->privateKey()->c4KeyPair();
+        } else {
+            tls.privateKeyRepresentation = kC4PrivateKeyFromCert;
+        }
+        tls.requireClientCerts = false;
+        c4config.tlsConfig = &tls;
+    }
+
+    if (_conf.authenticator) {
+        if (_conf.authenticator->withCert) {
+            // certificate
+            // Pre-condition: !_conf.disableTLS
+            tls.requireClientCerts = true;
+            tls.tlsCallbackContext = this;
+            tls.certAuthCallback = [](C4Listener *listener, C4Slice clientCertData, void *context) -> bool {
+                auto me = reinterpret_cast<CBLURLEndpointListener*>(context);
+                return me->_conf.authenticator->certCallback(me->_conf.context, clientCertData);
+            };
+        } else {
+            // user/password
+            c4config.httpAuthCallback = [](C4Listener* listener, C4Slice authHeader, void* context) -> bool {
+                slice header{authHeader};
+                auto space = header.findByte(' ');
+                if (!space) return false;
+
+                else header = header.from(space + 1);
+                while ( !header.empty() && header[0] == ' ' )
+                    header = header.from(1);
+                alloc_slice decoded = fleece::base64::decode(header);
+                auto colon = decoded.findByte(':');
+                if (!colon) return false;
+
+                slice usr = decoded.upTo(colon);
+                slice pwd = decoded.from(colon + 1);
+
+                auto me = reinterpret_cast<CBLURLEndpointListener*>(context);
+                Assert(me->_c4listener == listener);
+                return me->_conf.authenticator->pswCallback(me->_conf.context, usr, pwd);
+            };
+            c4config.callbackContext = this;
+        }
+    }
+
+    std::unique_ptr<C4Listener> c4listener{new C4Listener(c4config)};
+    auto ret = [&](bool succ) -> bool {
+        if (succ) {
+            _c4listener = c4listener.release();
+        }
+        return succ;
+    };
+
+    CBLDatabase* cblDb = _conf.collections[0]->database();
+    bool succ = true;
+    cblDb->c4db()->useLocked([&](C4Database* db) {
+        slice dbname = db->getName();
+        if ( (succ = c4listener->shareDB(dbname, db)) ) {
+            for (unsigned i = 0; i < _conf.collectionCount; ++i) {
+                _conf.collections[i]->useLocked([&](C4Collection* coll) {
+                    succ = c4listener->shareCollection(dbname, coll);
+                });
+                if (!succ) break;
+            }
+        }
+    });
+
+    return ret(succ);
+}
+
+void CBLURLEndpointListener::stop() {
+    std::scoped_lock lock(_mutex);
+    if (_c4listener) {
+        delete _c4listener;
+        _c4listener = nullptr;
+    }
+}
+
+std::string CBLURLEndpointListener::dumpConfig() {
+    return {};
+}
+
+CBLTLSIdentity* CBLURLEndpointListener::effectiveTLSIdentity(bool persistent) {
+    if (_conf.disableTLS)
+        return nullptr;
+
+    if (!_effectiveTLSIdentity)
+        _effectiveTLSIdentity = _conf.tlsIdentity ? _conf.tlsIdentity : anonymousTLSIdentity(persistent);
+
+    return _effectiveTLSIdentity;
+}
+
+Retained<CBLTLSIdentity> CBLURLEndpointListener::anonymousTLSIdentity(bool persistent) {
+    Retained<CBLTLSIdentity> identity;
+    alloc_slice label;
+    std::unique_ptr<CBLKeyPair, void(*)(CBLKeyPair*)> keypair{
+        nullptr,
+        [](CBLKeyPair* k) {
+            CBLKeyPair_Release(k);
+        }
+    };
+    if (persistent) {
+#if !defined(__linux__) && !defined(__ANDROID__)
+        label = labelForAnonymousTLSIdentity();
+        if (!label) return nullptr;
+
+        identity = CBLTLSIdentity::IdentityWithLabel(label);
+        C4Error error{};
+        if (identity) {
+            CBL_Log(kCBLLogDomainListener, kCBLLogVerbose, "Found anonymous identity by label = '%.*s'", (int)label.size, (char*)label.buf);
+
+            CBLTimestamp expire = identity->expiration();
+            if (expire/1000 > kCBLAnonymousIdentityMinValidTimeAllowed) {
+                return identity;
+            }
+
+            CBL_Log(kCBLLogDomainListener, kCBLLogVerbose, "Delete anonymous identity of label = '%.*s' (expiration = %ld)", (int)label.size, (char*)label.buf, (long)(expire/1000));
+
+            CBLTLSIdentity_DeleteIdentityWithLabel(label, cbl_internal::external(&error));
+            if (error.code) {
+                CBL_Log(kCBLLogDomainListener, kCBLLogWarning, "Error when delete anonymous identity of label = '%.*s', error = %d/%d", (int)label.size, (char*)label.buf, error.domain, error.code);
+            }
+        }
+
+        if (error.code && error.code != kC4ErrorNotFound) {
+            C4Error::raise(error);
+        }
+#else //#if !defined(__linux__) && !defined(__ANDROID__)
+        C4Error::raise(LiteCoreDomain, kC4ErrorUnimplemented, "No persistent key support");
+#endif
+    } else {
+        keypair.reset(CBLKeyPair_GenerateRSAKeyPair(fleece::nullslice, nullptr));
+        if (!keypair) {
+            CBL_Log(kCBLLogDomainListener, kCBLLogWarning, "Failed to create an anonymous self-signed key-pair");
+            return nullptr;
+        }
+    }
+
+    fleece::MutableDict mdict = fleece::MutableDict::newDict();
+    mdict[kCBLCertAttrKeyCommonName] = "CBLAnonymousCertificate";
+
+    if (persistent) {
+#if !defined(__linux__) && !defined(__ANDROID__)
+        identity = CBLTLSIdentity::SelfSignedCertIdentityWithLabel(true, label, mdict, 0);
+#endif
+    } else {
+        identity = CBLTLSIdentity::SelfSignedCertIdentity(true, keypair.get(), mdict, 0);
+    }
+
+    return identity;
+}
+
+alloc_slice CBLURLEndpointListener::labelForAnonymousTLSIdentity() {
+    alloc_slice uuid = CBLDatabase_PublicUUID(_conf.collections[0]->database());
+    return alloc_slice{uuid.hexString()};
+}
+
+#endif //#ifdef COUCHBASE_ENTERPRISE

--- a/src/CBLURLEndpointListener.cc
+++ b/src/CBLURLEndpointListener.cc
@@ -143,7 +143,7 @@ CBLTLSIdentity* CBLURLEndpointListener::effectiveTLSIdentity(bool persistent) {
         return nullptr;
 
     if (!_effectiveTLSIdentity)
-        _effectiveTLSIdentity = _conf.tlsIdentity ? _conf.tlsIdentity : anonymousTLSIdentity(persistent);
+        _effectiveTLSIdentity = _conf.tlsIdentity ? _conf.tlsIdentity : anonymousTLSIdentity(persistent).get();
 
     return _effectiveTLSIdentity;
 }

--- a/src/CBLURLEndpointListener_CAPI.cc
+++ b/src/CBLURLEndpointListener_CAPI.cc
@@ -62,7 +62,8 @@ CBLConnectionStatus CBLURLEndpointListener_Status(const CBLURLEndpointListener* 
 
 bool CBLURLEndpointListener_Start(CBLURLEndpointListener* listener, CBLError* outError) noexcept {
     try {
-        return listener->start();
+        listener->start();
+        return true;
     } catchAndBridge(outError)
 }
 

--- a/src/CBLURLEndpointListener_Internal.hh
+++ b/src/CBLURLEndpointListener_Internal.hh
@@ -27,6 +27,7 @@
 #include "CBLTLSIdentity_Internal.hh"
 #include "c4Listener.hh"
 #include <mutex>
+using namespace fleece;
 
 #ifdef COUCHBASE_ENTERPRISE
 
@@ -107,7 +108,7 @@ public:
         }
     }
 
-    bool start();
+    void start();
     void stop();
 
 protected:

--- a/src/exports/CBL_Exports.txt
+++ b/src/exports/CBL_Exports.txt
@@ -243,6 +243,7 @@ CBLCollection_LastSequence
 
 CBLDatabase_DeleteDocumentByID
 CBLDatabase_LastSequence
+CBLDatabase_PublicUUID
 
 CBLDocument_CanonicalRevisionID
 CBLDocument_Generation

--- a/src/exports/generated/CBL.def
+++ b/src/exports/generated/CBL.def
@@ -179,6 +179,7 @@ CBLCollection_GetIndexesInfo
 CBLCollection_LastSequence
 CBLDatabase_DeleteDocumentByID
 CBLDatabase_LastSequence
+CBLDatabase_PublicUUID
 CBLDocument_CanonicalRevisionID
 CBLDocument_Generation
 CBLDocument_GetRevisionHistory

--- a/src/exports/generated/CBL.exp
+++ b/src/exports/generated/CBL.exp
@@ -187,6 +187,7 @@ _CBLCollection_GetIndexesInfo
 _CBLCollection_LastSequence
 _CBLDatabase_DeleteDocumentByID
 _CBLDatabase_LastSequence
+_CBLDatabase_PublicUUID
 _CBLDocument_CanonicalRevisionID
 _CBLDocument_Generation
 _CBLDocument_GetRevisionHistory

--- a/src/exports/generated/CBL.gnu
+++ b/src/exports/generated/CBL.gnu
@@ -177,6 +177,7 @@ CBL_C {
 		CBLCollection_LastSequence;
 		CBLDatabase_DeleteDocumentByID;
 		CBLDatabase_LastSequence;
+		CBLDatabase_PublicUUID;
 		CBLDocument_CanonicalRevisionID;
 		CBLDocument_Generation;
 		CBLDocument_GetRevisionHistory;

--- a/src/exports/generated/CBL_Android.gnu
+++ b/src/exports/generated/CBL_Android.gnu
@@ -178,6 +178,7 @@ CBL_C {
 		CBLCollection_LastSequence;
 		CBLDatabase_DeleteDocumentByID;
 		CBLDatabase_LastSequence;
+		CBLDatabase_PublicUUID;
 		CBLDocument_CanonicalRevisionID;
 		CBLDocument_Generation;
 		CBLDocument_GetRevisionHistory;

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -267,6 +267,7 @@ CBLCollection_GetIndexesInfo
 CBLCollection_LastSequence
 CBLDatabase_DeleteDocumentByID
 CBLDatabase_LastSequence
+CBLDatabase_PublicUUID
 CBLDocument_CanonicalRevisionID
 CBLDocument_Generation
 CBLDocument_GetRevisionHistory

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -276,6 +276,7 @@ _CBLCollection_GetIndexesInfo
 _CBLCollection_LastSequence
 _CBLDatabase_DeleteDocumentByID
 _CBLDatabase_LastSequence
+_CBLDatabase_PublicUUID
 _CBLDocument_CanonicalRevisionID
 _CBLDocument_Generation
 _CBLDocument_GetRevisionHistory

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -265,6 +265,7 @@ CBL_C {
 		CBLCollection_LastSequence;
 		CBLDatabase_DeleteDocumentByID;
 		CBLDatabase_LastSequence;
+		CBLDatabase_PublicUUID;
 		CBLDocument_CanonicalRevisionID;
 		CBLDocument_Generation;
 		CBLDocument_GetRevisionHistory;

--- a/src/exports/generated/CBL_EE_Android.gnu
+++ b/src/exports/generated/CBL_EE_Android.gnu
@@ -266,6 +266,7 @@ CBL_C {
 		CBLCollection_LastSequence;
 		CBLDatabase_DeleteDocumentByID;
 		CBLDatabase_LastSequence;
+		CBLDatabase_PublicUUID;
 		CBLDocument_CanonicalRevisionID;
 		CBLDocument_Generation;
 		CBLDocument_GetRevisionHistory;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.1)
-cmake_policy(VERSION 3.1)
+cmake_minimum_required (VERSION 3.5)
+cmake_policy(VERSION 3.5)
 project (CBL_C_Tests)
 
 set(TOP ${PROJECT_SOURCE_DIR}/../)

--- a/test/URLEndpointListenerTest.cc
+++ b/test/URLEndpointListenerTest.cc
@@ -378,6 +378,7 @@ TEST_CASE_METHOD(URLEndpointListenerTest, "Listener with Cert Authentication", "
         CBLTLSIdentity* id = CBLTLSIdentity_IdentityWithLabel(persistentLabel, nullptr);
         CHECK(id);
         CBLTLSIdentity_Release(id);
+        CHECK(CBLTLSIdentity_DeleteIdentityWithLabel(persistentLabel, nullptr));
     }
 #endif
 


### PR DESCRIPTION
For Linux or Android, we create an self-signed TLS Identity whose life attached to the Listener. For other platforms, we will save the Identity by label being the UUID of the database.