### PR TITLE
CBL-6895: Test with Existing APIs for TLSIdentity with Callback Inter…

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		1B21A7D92D711B29000CA0D5 /* URLEndpointListenerTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B21A7D82D711B29000CA0D5 /* URLEndpointListenerTest.cc */; };
 		1B21A7DA2D711B29000CA0D5 /* URLEndpointListenerTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B21A7D82D711B29000CA0D5 /* URLEndpointListenerTest.cc */; };
 		1B21A7DB2D711B29000CA0D5 /* URLEndpointListenerTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B21A7D82D711B29000CA0D5 /* URLEndpointListenerTest.cc */; };
+		1B7694AC2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */; };
+		1B7694AD2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */; };
+		1B7694AE2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */; };
 		1BC5D9602D6E3BD10080153E /* CBLURLEndpointListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */; };
 		1BC5D9612D6E3BD10080153E /* CBLURLEndpointListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */; };
 		1BC5D9662D6E4DA60080153E /* CBLURLEndpointListener_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BC5D9652D6E4DA60080153E /* CBLURLEndpointListener_CAPI.cc */; };
@@ -428,6 +431,8 @@
 
 /* Begin PBXFileReference section */
 		1B21A7D82D711B29000CA0D5 /* URLEndpointListenerTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = URLEndpointListenerTest.cc; sourceTree = "<group>"; };
+		1B7694AA2DA07261006EEEAB /* TLSIdentityTest.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TLSIdentityTest.hh; sourceTree = "<group>"; };
+		1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "TLSIdentityTest+Apple.mm"; sourceTree = "<group>"; };
 		1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLURLEndpointListener.h; sourceTree = "<group>"; };
 		1BC5D9652D6E4DA60080153E /* CBLURLEndpointListener_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLURLEndpointListener_CAPI.cc; sourceTree = "<group>"; };
 		1BC5D9672D6E50960080153E /* CBLURLEndpointListener_Internal.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CBLURLEndpointListener_Internal.hh; sourceTree = "<group>"; };
@@ -902,7 +907,9 @@
 				FC82CE0428C6E2BD001FA083 /* ReplicatorCollectionTest_Cpp.cc */,
 				2736A633242E5A74002B9D65 /* ReplicatorEETest.cc */,
 				93C70D1626CB334D0093E927 /* ReplicatorPropEncTest.cc */,
+				1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */,
 				1BF21A3C2D84E419009534EC /* TLSIdentityTest.cc */,
+				1B7694AA2DA07261006EEEAB /* TLSIdentityTest.hh */,
 				1B21A7D82D711B29000CA0D5 /* URLEndpointListenerTest.cc */,
 				40FE2E0F2C12AF52005E99E9 /* VectorSearchTest.hh */,
 				406E46D22BACAEFF0088198C /* VectorSearchTest.cc */,
@@ -1698,6 +1705,7 @@
 				275B3599234C158900FE9CF0 /* CouchbaseLiteTests.mm in Sources */,
 				275B358E23481D0C00FE9CF0 /* CBLTest.c in Sources */,
 				FC645E2E29088211007D5536 /* Platform_Apple.mm in Sources */,
+				1B7694AC2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */,
 				2736A635242E5A74002B9D65 /* ReplicatorEETest.cc in Sources */,
 				93C70D3526D01B5A0093E927 /* BlobTest.cc in Sources */,
 				FC0907E828AD763600201B07 /* DocumentTest_Cpp.cc in Sources */,
@@ -1748,6 +1756,7 @@
 				FC645E2D29088211007D5536 /* Platform_Apple.mm in Sources */,
 				1B21A7DA2D711B29000CA0D5 /* URLEndpointListenerTest.cc in Sources */,
 				93C70D3426D01B5A0093E927 /* BlobTest.cc in Sources */,
+				1B7694AD2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */,
 				27B61DB921D6ECA70027CCDB /* DatabaseTest.cc in Sources */,
 				1BF21A3F2D84E419009534EC /* TLSIdentityTest.cc in Sources */,
 				277FEE5321E6BCA500B60E3C /* DatabaseTest_Cpp.cc in Sources */,
@@ -1802,6 +1811,7 @@
 				FC645E1A29085C84007D5536 /* ReplicatorCollectionTest_Cpp.cc in Sources */,
 				FC645E1029085C26007D5536 /* BlobTest.cc in Sources */,
 				FC645E1129085C2A007D5536 /* BlobTest_Cpp.cc in Sources */,
+				1B7694AE2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */,
 				FC645E1429085C5D007D5536 /* DatabaseTest_Cpp.cc in Sources */,
 				40E32F442D2F45A3000CED57 /* LogTest_Cpp.cc in Sources */,
 				FC645E1629085C6B007D5536 /* DocumentTest_Cpp.cc in Sources */,

--- a/Xcode/xcconfigs/CBL_Tests.xcconfig
+++ b/Xcode/xcconfigs/CBL_Tests.xcconfig
@@ -25,3 +25,5 @@ LLVM_LTO                = NO    // LTO makes tests very slow to link and confuse
 CLANG_WARN__EXIT_TIME_DESTRUCTORS           = NO
 GCC_WARN_UNKNOWN_PRAGMAS                    = NO
 CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND    = NO
+
+OTHER_LDFLAGS = $(inherited) -framework Security

--- a/src/CBLPrivate.h
+++ b/src/CBLPrivate.h
@@ -45,8 +45,12 @@ CBL_CAPI_BEGIN
     bool CBLCollection_IsIndexTrained(const CBLCollection* collection,
                                       FLString name,
                                       CBLError* _cbl_nullable outError) CBLAPI;
+
     CBLKeyPair* CBLKeyPair_GenerateRSAKeyPair(FLSlice passwordOrNull,
                                               CBLError* _cbl_nullable outError) CBLAPI;
+
+    CBLKeyPair* CBLKeyPair_PublicKeyFromData(FLSlice data,
+                                             CBLError* _cbl_nullable outError) CBLAPI;
 #endif
 
 FLMutableArray CBLCollection_GetIndexesInfo(const CBLCollection* collection,

--- a/src/CBLTLSIdentity_CAPI.cc
+++ b/src/CBLTLSIdentity_CAPI.cc
@@ -61,10 +61,17 @@ CBLKeyPair* CBLKeyPair_CreateWithPrivateKeyData(FLSlice privateKeyData,
 }
 
 // CBLPrivate.h
-
 CBLKeyPair* CBLKeyPair_GenerateRSAKeyPair(FLSlice passwordOrNull, CBLError* outError) noexcept {
     try {
         return retain(CBLKeyPair::GenerateRSAKeyPair(passwordOrNull));
+    } catchAndBridge(outError);
+}
+
+// CBLPrivate.h
+CBLKeyPair* CBLKeyPair_PublicKeyFromData(FLSlice data,
+                                         CBLError* _cbl_nullable outError) noexcept {
+    try {
+        return retain(CBLKeyPair::PublicKeyFromData(data));
     } catchAndBridge(outError);
 }
 

--- a/src/CBLTLSIdentity_Internal.hh
+++ b/src/CBLTLSIdentity_Internal.hh
@@ -54,7 +54,7 @@ public:
         c4Callbacks.decrypt       = callbacks.decrypt;
         c4Callbacks.sign          = (SignFuncPtr)callbacks.sign;
         c4Callbacks.free          = callbacks.free;
-        return new CBLKeyPair{C4KeyPair::fromExternal(kC4RSA, keySizeInBits, externalKey, c4Callbacks).detach()};
+        return new CBLKeyPair{C4KeyPair::fromExternal(kC4RSA, keySizeInBits, externalKey, c4Callbacks).get()};
     }
     
     alloc_slice publicKeyDigest() const {
@@ -75,6 +75,12 @@ public:
     static CBLKeyPair* GenerateRSAKeyPair(slice passwordOrNull) {
         C4KeyPair* c4Key = C4KeyPair::generate(kC4RSA, 2048, false).detach();
         if ( !c4Key ) C4Error::raise(LiteCoreDomain, kC4ErrorCrypto, "fails to generate a KeyPair.");
+        return new CBLKeyPair{c4Key};
+    }
+
+    static CBLKeyPair* PublicKeyFromData(slice data) {
+        C4KeyPair* c4Key = C4KeyPair::fromPublicKeyData(data).detach();
+        if (!c4Key) C4Error::raise(LiteCoreDomain, kC4ErrorCrypto, "fails to get PublicKey from data.");
         return new CBLKeyPair{c4Key};
     }
 

--- a/src/exports/CBL_EE_Exports.txt
+++ b/src/exports/CBL_EE_Exports.txt
@@ -69,6 +69,7 @@ CBLIndexUpdater_Value
 
 CBLCollection_IsIndexTrained
 CBLKeyPair_GenerateRSAKeyPair
+CBLKeyPair_PublicKeyFromData
 
 ### URLEndpointListener
 

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -40,6 +40,7 @@ CBLIndexUpdater_Finish
 CBLIndexUpdater_Value
 CBLCollection_IsIndexTrained
 CBLKeyPair_GenerateRSAKeyPair
+CBLKeyPair_PublicKeyFromData
 CBLListenerAuth_CreatePassword
 CBLListenerAuth_CreateCertificate
 CBLListenerAuth_Free

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -49,6 +49,7 @@ _CBLIndexUpdater_Finish
 _CBLIndexUpdater_Value
 _CBLCollection_IsIndexTrained
 _CBLKeyPair_GenerateRSAKeyPair
+_CBLKeyPair_PublicKeyFromData
 _CBLListenerAuth_CreatePassword
 _CBLListenerAuth_CreateCertificate
 _CBLListenerAuth_Free

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -38,6 +38,7 @@ CBL_C {
 		CBLIndexUpdater_Value;
 		CBLCollection_IsIndexTrained;
 		CBLKeyPair_GenerateRSAKeyPair;
+		CBLKeyPair_PublicKeyFromData;
 		CBLListenerAuth_CreatePassword;
 		CBLListenerAuth_CreateCertificate;
 		CBLListenerAuth_Free;

--- a/src/exports/generated/CBL_EE_Android.gnu
+++ b/src/exports/generated/CBL_EE_Android.gnu
@@ -39,6 +39,7 @@ CBL_C {
 		CBLIndexUpdater_Value;
 		CBLCollection_IsIndexTrained;
 		CBLKeyPair_GenerateRSAKeyPair;
+		CBLKeyPair_PublicKeyFromData;
 		CBLListenerAuth_CreatePassword;
 		CBLListenerAuth_CreateCertificate;
 		CBLListenerAuth_Free;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,11 +59,13 @@ elseif(APPLE)
     target_sources(
         CBL_C_Tests PRIVATE
         Platform_Apple.mm
+        TLSIdentityTest+Apple.mm
     )
     if(BUILD_ENTERPRISE)
         target_link_libraries(CBL_C_Tests PUBLIC  "-framework CoreFoundation"
                                                   "-framework CoreML"
-                                                  "-framework Vision")
+                                                  "-framework Vision"
+                                                  "-framework Security")
     endif()
 elseif(UNIX)
     target_link_libraries(CBL_C_Tests PUBLIC dl)

--- a/test/TLSIdentityTest+Apple.mm
+++ b/test/TLSIdentityTest+Apple.mm
@@ -1,0 +1,193 @@
+//
+// TLSIdentityTest+Apple.mm
+//
+// Copyright © 2025 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
+#include "TLSIdentityTest.hh"
+#include <sstream>
+
+#ifdef COUCHBASE_ENTERPRISE
+
+__unused static inline void warnCFError(CFErrorRef cfError, const char *fnName) {
+    auto error = (__bridge NSError*)cfError;
+    auto message = error.description;
+    CBL_Log(kCBLLogDomainListener, kCBLLogError, "%s failed: %s", fnName, message.UTF8String);
+}
+
+static NSData* uncopiedNSData(fleece::slice slice) {
+    if (!slice.buf)
+        return nil;
+    return [[NSData alloc] initWithBytesNoCopy: (void*)slice.buf length: slice.size freeWhenDone: NO];
+}
+
+struct TLSIdentityTest::ExternalKey::Impl {
+    Impl(SecKeyRef publicKey, SecKeyRef privateKey, unsigned keySizeInBits)
+    : _publicKeyRef(publicKey)
+    , _privateKeyRef(privateKey)
+    , _keyLength((keySizeInBits + 7) / 8)
+    {}
+
+    ~Impl() {
+        CFRelease(_publicKeyRef);
+        CFRelease(_privateKeyRef);
+    }
+
+    bool publicKeyData(void* output, size_t outputMaxLen, size_t* outputLen) {
+        CFErrorRef error;
+        CFDataRef data = SecKeyCopyExternalRepresentation(_publicKeyRef, &error);
+        if (!data) {
+            warnCFError(error, "SecKeyCopyExternalRepresentation");
+            return false;
+        }
+        fleece::slice dataSlice{CFDataGetBytePtr(data), (size_t)CFDataGetLength(data)};
+        // Converting it into the DER format LiteCore expects.
+        CBLKeyPair* publicKey = CBLKeyPair_PublicKeyFromData(dataSlice, nullptr);
+        if (!publicKey) {
+            CBL_Log(kCBLLogDomainListener, kCBLLogError, "Error from PublickKeyFromData");
+            CFRelease(data);
+            return false;
+        }
+
+        fleece::alloc_slice result = CBLKeyPair_PublicKeyData(publicKey);
+        *outputLen = result.size;
+
+        if (*outputLen <= outputMaxLen) {
+            result.copyTo(output);
+        } else {
+            CBL_Log(kCBLLogDomainListener, kCBLLogError, "Key size is too big to put in the output");
+        }
+
+        CFRelease(data);
+        CBLKeyPair_Release(publicKey);
+
+        return *outputLen <= outputMaxLen;
+    }
+
+    bool decrypt(fleece::slice input, void* output, size_t outputMaxLen, size_t* outputLen) {
+        // No exceptions may be thrown from this function!
+        @autoreleasepool {
+            CBL_Log(kCBLLogDomainListener, kCBLLogInfo, "Decrypting using Keychain private key");
+            NSData* data = uncopiedNSData(input);
+            CFErrorRef error;
+            NSData* cleartext = CFBridgingRelease( SecKeyCreateDecryptedData(_privateKeyRef,
+                                                         kSecKeyAlgorithmRSAEncryptionPKCS1,
+                                                         (CFDataRef)data, &error) );
+            if (!cleartext) {
+                warnCFError(error, "SecKeyCreateDecryptedData");
+                return false;
+            }
+            *outputLen = cleartext.length;
+            if (*outputLen > outputMaxLen) {
+                // should never happen
+                CBL_Log(kCBLLogDomainListener, kCBLLogError, "outputLen is too small in callback decrypt");
+                return false;
+            }
+            memcpy(output, cleartext.bytes, *outputLen);
+            return true;
+        }
+    }
+
+    bool sign(int/*mbedtls_md_type_t*/ mbedDigestAlgorithm, fleece::slice inputData, void* outSignature) {
+        // No exceptions may be thrown from this function!
+        CBL_Log(kCBLLogDomainListener, kCBLLogInfo, "Signing using Keychain private key");
+        @autoreleasepool {
+            // Map mbedTLS digest algorithm ID to SecKey algorithm ID:
+            static const SecKeyAlgorithm kDigestAlgorithmMap[9] = {
+                kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw,
+                NULL,
+                NULL,
+                NULL,
+                kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA1,
+                kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA224,
+                kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256,
+                kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384,
+                kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512,
+            };
+            SecKeyAlgorithm digestAlgorithm = nullptr;
+            if (mbedDigestAlgorithm >= 0 && mbedDigestAlgorithm < 9)
+                digestAlgorithm = kDigestAlgorithmMap[mbedDigestAlgorithm];
+            if (!digestAlgorithm) {
+                CBL_Log(kCBLLogDomainListener, kCBLLogWarning, "Keychain private key: unsupported mbedTLS digest algorithm %d", mbedDigestAlgorithm);
+                return false;
+            }
+
+            // Create the signature:
+            NSData* data = uncopiedNSData(inputData);
+            CFErrorRef error;
+            NSData* sigData = CFBridgingRelease( SecKeyCreateSignature(_privateKeyRef,
+                                                             digestAlgorithm,
+                                                             (CFDataRef)data, &error) );
+            if (!sigData) {
+                warnCFError(error, "SecKeyCreateSignature");
+                return false;
+            }
+            assert(sigData.length == _keyLength);
+            memcpy(outSignature, sigData.bytes, _keyLength);
+            return true;
+        }
+    }
+
+    SecKeyRef _publicKeyRef;
+    SecKeyRef _privateKeyRef;
+    /** Key length, in _bytes_ not bits. */
+    unsigned const _keyLength;
+};
+
+TLSIdentityTest::ExternalKey* TLSIdentityTest::ExternalKey::generateRSA(unsigned keySizeInBits) {
+    @autoreleasepool {
+        CBL_Log(kCBLLogDomainListener, kCBLLogInfo, "Generating %d-bit RSA key-pair in Keychain", keySizeInBits);
+
+        NSDictionary* params = @ {
+            (id)kSecAttrKeyType:        (id)kSecAttrKeyTypeRSA,
+            (id)kSecAttrKeySizeInBits:  @(keySizeInBits),
+            (id)kSecAttrIsPermanent:    @NO,
+        };
+
+        SecKeyRef publicKey = NULL, privateKey = NULL;
+        CFErrorRef error;
+        privateKey = SecKeyCreateRandomKey((CFDictionaryRef)params, &error);
+        if (!privateKey) {
+            CBL_Log(kCBLLogDomainListener, kCBLLogWarning, "SecKeyCreateRandomKey");
+            return nullptr;
+        }
+        publicKey = SecKeyCopyPublicKey(privateKey);
+        if (!publicKey) {
+            CBL_Log(kCBLLogDomainListener, kCBLLogWarning, "SecKeyCopyPublicKey");
+            CFRelease(privateKey);
+            return nullptr;
+        }
+        return new TLSIdentityTest::ExternalKey(new Impl(publicKey, privateKey, keySizeInBits));
+    }
+}
+
+TLSIdentityTest::ExternalKey::ExternalKey(Impl* impl) : _impl(impl) {}
+TLSIdentityTest::ExternalKey::~ExternalKey() = default;
+
+bool TLSIdentityTest::ExternalKey::publicKeyData(void* output, size_t outputMaxLen, size_t* outputLen) {
+    return _impl->publicKeyData(output, outputMaxLen, outputLen);
+}
+
+bool TLSIdentityTest::ExternalKey::decrypt(fleece::slice input, void *output, size_t output_max_len, size_t *output_len) {
+    return _impl->decrypt(input, output, output_max_len, output_len);
+}
+
+bool TLSIdentityTest::ExternalKey::sign(CBLSignatureDigestAlgorithm mbedDigestAlgorithm, fleece::slice inputData, void *outSignature) {
+    return _impl->sign(mbedDigestAlgorithm, inputData, outSignature);
+}
+
+#endif // #ifdef COUCHBASE_ENTERPRISE

--- a/test/TLSIdentityTest.cc
+++ b/test/TLSIdentityTest.cc
@@ -16,7 +16,7 @@
 // limitations under the License.
 //
 
-#include "CBLTest.hh"
+#include "TLSIdentityTest.hh"
 #include "CBLPrivate.h"
 #include "fleece/Mutable.hh"
 
@@ -27,18 +27,6 @@ using namespace std::chrono;
 using namespace fleece;
 
 #ifdef COUCHBASE_ENTERPRISE
-
-class TLSIdentityTest : public CBLTest {
-public:
-
-    TLSIdentityTest() {
-        
-    }
-
-    ~TLSIdentityTest() {
-      
-    }
-};
 
 TEST_CASE_METHOD(TLSIdentityTest, "Self-Signed Cert Identity", "[TSLIdentity]") {
     CBLError outError;

--- a/test/TLSIdentityTest.hh
+++ b/test/TLSIdentityTest.hh
@@ -1,0 +1,48 @@
+//
+// DatabaseTest.hh
+//
+// Copyright © 2025 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include "CBLTest.hh"
+
+#ifdef COUCHBASE_ENTERPRISE
+
+class TLSIdentityTest : public CBLTest {
+public:
+    TLSIdentityTest() {}
+    ~TLSIdentityTest() {}
+
+#ifdef __APPLE__
+    class ExternalKey {
+    public:
+        static ExternalKey* generateRSA(unsigned keySizeInBits);
+
+        ~ExternalKey();
+
+        bool publicKeyData(void* output, size_t outputMaxLen, size_t* outputLen);
+        bool decrypt(fleece::slice input, void *output, size_t output_max_len, size_t *output_len);
+        bool sign(CBLSignatureDigestAlgorithm mbedDigestAlgorithm, fleece::slice inputData, void *outSignature);
+
+    private:
+        struct Impl;
+        ExternalKey(Impl*);
+        std::unique_ptr<Impl> _impl;
+    };
+#endif //#ifdef __APPLE__
+};
+
+#endif // #ifdef COUCHBASE_ENTERPRISE


### PR DESCRIPTION
…face

We test the interface by taking the SecKeys of the Apple platform as the external keys. For it, we introduced Security Framework to Test project.