### PR TITLE
Remove 'static' from inline API functions when compiling with C++

### DIFF
--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -34,7 +34,7 @@
 
 CBL_ASSUME_NONNULL_BEGIN
 
-static inline bool operator== (const CBLError &e1, const CBLError &e2) {
+inline bool operator== (const CBLError &e1, const CBLError &e2) {
     if (e1.code != 0)
         return e1.domain == e2.domain && e1.code == e2.code;
     else

--- a/include/cbl/CBLBase.h
+++ b/include/cbl/CBLBase.h
@@ -168,9 +168,9 @@ void CBL_DumpInstances(void) CBLAPI;
 
 // Declares retain/release functions for TYPE. For internal use only.
 #define CBL_REFCOUNTED(TYPE, NAME) \
-    static inline const TYPE CBL##NAME##_Retain(const TYPE _cbl_nullable t) \
+    CBLINLINE const TYPE CBL##NAME##_Retain(const TYPE _cbl_nullable t) \
                                             {return (const TYPE)CBL_Retain((CBLRefCounted*)t);} \
-    static inline void CBL##NAME##_Release(const TYPE _cbl_nullable t) {CBL_Release((CBLRefCounted*)t);}
+    CBLINLINE void CBL##NAME##_Release(const TYPE _cbl_nullable t) {CBL_Release((CBLRefCounted*)t);}
 
 /** @} */
 

--- a/include/cbl/CBLBlob.h
+++ b/include/cbl/CBLBlob.h
@@ -208,7 +208,7 @@ CBL_CAPI_BEGIN
 
     /** Returns true if a value in a document is a blob reference.
         If so, you can call \ref FLValue_GetBlob to access it. */
-    static inline bool FLValue_IsBlob(FLValue _cbl_nullable v) {
+    CBLINLINE bool FLValue_IsBlob(FLValue _cbl_nullable v) {
         return FLDict_IsBlob(FLValue_AsDict(v));
     }
 
@@ -216,7 +216,7 @@ CBL_CAPI_BEGIN
         @param value  The value (dictionary) in the document.
         @return  A \ref CBLBlob instance for this blob, or `NULL` if the value is not a blob.
         \note  The returned CBLBlob object will be released when its document is released. */
-    static inline const CBLBlob* _cbl_nullable FLValue_GetBlob(FLValue _cbl_nullable value) {
+    CBLINLINE const CBLBlob* _cbl_nullable FLValue_GetBlob(FLValue _cbl_nullable value) {
         return FLDict_GetBlob(FLValue_AsDict(value));
     }
 
@@ -226,14 +226,14 @@ CBL_CAPI_BEGIN
         @param array  The array to store into.
         @param index  The position in the array at which to store the blob reference.
         @param blob  The blob reference to be stored. */
-    static inline void FLMutableArray_SetBlob(FLMutableArray array, uint32_t index, CBLBlob *blob) {
+    CBLINLINE void FLMutableArray_SetBlob(FLMutableArray array, uint32_t index, CBLBlob *blob) {
         FLSlot_SetBlob(FLMutableArray_Set(array, index), blob);
     }
 
     /** Appends a blob reference to an array.
         @param array  The array to store into.
         @param blob  The blob reference to be stored. */
-    static inline void FLMutableArray_AppendBlob(FLMutableArray array, CBLBlob *blob) {
+    CBLINLINE void FLMutableArray_AppendBlob(FLMutableArray array, CBLBlob *blob) {
         FLSlot_SetBlob(FLMutableArray_Append(array), blob);
     }
 
@@ -241,7 +241,7 @@ CBL_CAPI_BEGIN
         @param dict  The Dict to store into.
         @param key  The key to associate the blob reference with.
         @param blob  The blob reference to be stored. */
-    static inline void FLMutableDict_SetBlob(FLMutableDict dict, FLString key, CBLBlob *blob) {
+    CBLINLINE void FLMutableDict_SetBlob(FLMutableDict dict, FLString key, CBLBlob *blob) {
         FLSlot_SetBlob(FLMutableDict_Set(dict, key), blob);
     }
 

--- a/include/cbl/CBLEncryptable.h
+++ b/include/cbl/CBLEncryptable.h
@@ -140,7 +140,7 @@ FLDict CBLEncryptable_Properties(const CBLEncryptable* encryptable) CBLAPI;
 bool FLDict_IsEncryptableValue(FLDict _cbl_nullable) CBLAPI;
 
 /** Checks whether the given FLValue is a \ref CBLEncryptable or not. */
-static inline bool FLValue_IsEncryptableValue(FLValue _cbl_nullable value) {
+CBLINLINE bool FLValue_IsEncryptableValue(FLValue _cbl_nullable value) {
     return FLDict_IsEncryptableValue(FLValue_AsDict(value));
 }
 
@@ -152,7 +152,7 @@ const CBLEncryptable* _cbl_nullable FLDict_GetEncryptableValue(FLDict _cbl_nulla
 /** Returns a \ref CBLEncryptable object corresponding to the given \ref FLValue in a document
     or NULL if the value is not a \ref CBLEncryptable.
     \note  The returned CBLEncryptable object will be released when its document is released. */
-static inline const CBLEncryptable* _cbl_nullable FLValue_GetEncryptableValue(FLValue _cbl_nullable value) {
+CBLINLINE const CBLEncryptable* _cbl_nullable FLValue_GetEncryptableValue(FLValue _cbl_nullable value) {
     return FLDict_GetEncryptableValue(FLValue_AsDict(value));
 }
 
@@ -160,7 +160,7 @@ static inline const CBLEncryptable* _cbl_nullable FLValue_GetEncryptableValue(FL
 void FLSlot_SetEncryptableValue(FLSlot slot, const CBLEncryptable* encryptable) CBLAPI;
 
 /** Set a \ref CBLEncryptable's dictionary into a mutable dictionary. */
-static inline void FLMutableDict_SetEncryptableValue(FLMutableDict dict, FLString key, CBLEncryptable* encryptable) {
+CBLINLINE void FLMutableDict_SetEncryptableValue(FLMutableDict dict, FLString key, CBLEncryptable* encryptable) {
     FLSlot_SetEncryptableValue(FLMutableDict_Set(dict, key), encryptable);
 }
 

--- a/include/cbl/CBL_Compat.h
+++ b/include/cbl/CBL_Compat.h
@@ -32,11 +32,11 @@
 
 #ifdef _MSC_VER
     #include <sal.h>
-    #define CBLINLINE               __forceinline
+    #define CBLFORCEINLINE          __forceinline
     #define _cbl_nonnull            _In_
     #define _cbl_warn_unused        _Check_return_
 #else
-    #define CBLINLINE               inline
+    #define CBLFORCEINLINE          inline
     #define _cbl_warn_unused        __attribute__((warn_unused_result))
 #endif
 
@@ -98,10 +98,12 @@
 
 #ifdef __cplusplus
     #define CBLAPI          noexcept
+    #define CBLINLINE       inline
     #define CBL_CAPI_BEGIN  extern "C" { CBL_ASSUME_NONNULL_BEGIN
     #define CBL_CAPI_END    CBL_ASSUME_NONNULL_END }
 #else
     #define CBLAPI
+    #define CBLINLINE       static inline
     #define CBL_CAPI_BEGIN  CBL_ASSUME_NONNULL_BEGIN
     #define CBL_CAPI_END    CBL_ASSUME_NONNULL_END
 #endif


### PR DESCRIPTION
The use of 'static' on these functions isn't necessary in C++ and prevents re-exporting them from a C++20 module (by #include of cbl in the global module fragment and then `export using ...;` for relevant names).

Notes:

* operator==(CBLError, CBLError) doesn't use the CBLINLINE macro because it is already in a C++ context
* There was an existing CBLINLINE macro (apparently unused), which has been renamed to CBLFORCEINLINE