### PR TITLE
CBL-6911 : Add API for creating listener cert auth with root certs

### DIFF
--- a/include/cbl/CBLURLEndpointListener.h
+++ b/include/cbl/CBLURLEndpointListener.h
@@ -43,8 +43,13 @@ typedef bool (*CBLListenerCertAuthCallback) (
     FLSlice cert                ///< Certificate data
 );
 
-/** Creates a certificate authenticator for verifying client certificate when the TLS client certificate authentication is used. */
+/** Creates a certificate authenticator for verifying client certificate with the specified authentication callback
+    when the TLS client certificate authentication is used. */
 _cbl_warn_unused CBLListenerAuthenticator* CBLListenerAuth_CreateCertificate(CBLListenerCertAuthCallback auth) CBLAPI;
+
+/** Creates a certificate authenticator for verifying client certificate with the specified root certificates to trust
+    when the TLS client certificate authentication is used. */
+_cbl_warn_unused CBLListenerAuthenticator* CBLListenerAuth_CreateCertificateWithRootCerts(CBLCert* rootCerts) CBLAPI;
 
 /** Frees a CBLListenerAuthenticator object. */
 void CBLListenerAuth_Free(CBLListenerAuthenticator* _cbl_nullable) CBLAPI;

--- a/src/CBLURLEndpointListener_CAPI.cc
+++ b/src/CBLURLEndpointListener_CAPI.cc
@@ -23,13 +23,19 @@
 CBLListenerAuthenticator* CBLListenerAuth_CreatePassword(CBLListenerPasswordAuthCallback auth) noexcept {
     try {
         return new CBLListenerAuthenticator(auth);
-    } catchAndBridge(nullptr);
+    } catchAndWarn();
 }
 
 CBLListenerAuthenticator* CBLListenerAuth_CreateCertificate(CBLListenerCertAuthCallback auth) noexcept {
     try {
         return new CBLListenerAuthenticator(auth);
-    } catchAndBridge(nullptr);
+    } catchAndWarn();
+}
+
+CBLListenerAuthenticator* CBLListenerAuth_CreateCertificateWithRootCerts(CBLCert* rootCerts) noexcept {
+    try {
+        return new CBLListenerAuthenticator(rootCerts);
+    } catchAndWarn();
 }
 
 void CBLListenerAuth_Free(CBLListenerAuthenticator* _cbl_nullable auth) noexcept {
@@ -53,7 +59,7 @@ uint16_t CBLURLEndpointListener_Port(const CBLURLEndpointListener* listener) noe
 FLMutableArray CBLURLEndpointListener_Urls(const CBLURLEndpointListener* listener) noexcept {
     try {
         return (FLMutableArray)FLValue_Retain(listener->getUrls());
-    } catchAndBridge(nullptr)
+    } catchAndWarn()
 }
 
 CBLConnectionStatus CBLURLEndpointListener_Status(const CBLURLEndpointListener* listener) noexcept {

--- a/src/CBLURLEndpointListener_Internal.hh
+++ b/src/CBLURLEndpointListener_Internal.hh
@@ -39,21 +39,29 @@ struct CBLListenerAuthenticator {
         CBLListenerCertAuthCallback     certCallback;
         void*                           callback;
     };
-    bool withCert{false};
+    
+    bool isCert{false};             // Whether the authenticator is a CertAuth
+    Retained<CBLCert> rootCerts;    // For CertAuth created with root certs
 
-    CBLListenerAuthenticator(CBLListenerPasswordAuthCallback auth)
-    : pswCallback(auth)
-    , withCert(false)
+    CBLListenerAuthenticator(CBLListenerPasswordAuthCallback callback)
+    : pswCallback(callback)
+    , isCert(false)
     {}
 
-    CBLListenerAuthenticator(CBLListenerCertAuthCallback auth)
-    : certCallback(auth)
-    , withCert(true)
+    CBLListenerAuthenticator(CBLListenerCertAuthCallback callback)
+    : certCallback(callback)
+    , isCert(true)
+    {}
+    
+    CBLListenerAuthenticator(CBLCert* cert)
+    : rootCerts(cert)
+    , isCert(true)
     {}
 
     CBLListenerAuthenticator(const CBLListenerAuthenticator& src)
     : callback(src.callback)
-    , withCert(src.withCert)
+    , rootCerts(src.rootCerts)
+    , isCert(src.isCert)
     {}
 };
 
@@ -65,7 +73,7 @@ public:
         if (conf.collectionCount == 0) {
             C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter, "No collections in CBLURLEndpointListenerConfiguration");
         }
-        if (_conf.authenticator && _conf.authenticator->withCert) {
+        if (_conf.authenticator && _conf.authenticator->isCert) {
             if (_conf.disableTLS)
                 C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter, "TLS must be enabled to use the cert authenticator");
         }


### PR DESCRIPTION
* Added API for creating listener cert auth with root certs.

* Used catchAndWarn() instead of catchAndBridge(nullprt) for the functions that return non-null.