### PR TITLE
CBL-6922 : Allow database to stop listener when closing

### DIFF
--- a/src/CBLDatabase.cc
+++ b/src/CBLDatabase.cc
@@ -102,7 +102,7 @@ CBLDatabase::~CBLDatabase() {
 
 
 void CBLDatabase::close() {
-    stopActiveStoppables();
+    stopActiveService();
     
     try {
         auto db = _c4db->useLocked();
@@ -118,7 +118,7 @@ void CBLDatabase::close() {
 
 
 void CBLDatabase::closeAndDelete() {
-    stopActiveStoppables();
+    stopActiveService();
     
     auto db = _c4db->useLocked();
     db->closeAndDeleteFile();

--- a/src/CBLQuery.cc
+++ b/src/CBLQuery.cc
@@ -34,7 +34,7 @@ void ListenerToken<CBLQueryChangeListener>::setEnabled(bool enabled) {
     
     CBLDatabase* db = const_cast<CBLDatabase*>(_query->database());
     if (enabled) {
-        if (!db->registerStoppable(_stoppable.get())) {
+        if (!db->registerService(this, [this] { this->setEnabled(false); })) {
             CBL_Log(kCBLLogDomainQuery, kCBLLogWarning,
                     "Couldn't enable the Query Listener as the database is closing or closed.");
             return;
@@ -43,8 +43,10 @@ void ListenerToken<CBLQueryChangeListener>::setEnabled(bool enabled) {
     
     _c4obs->setEnabled(enabled);
     _isEnabled = enabled;
-    if (!enabled)
-        db->unregisterStoppable(_stoppable.get());
+    
+    if (!enabled) {
+        db->unregisterService(this);
+    }
 }
 
 

--- a/src/CBLQuery_Internal.hh
+++ b/src/CBLQuery_Internal.hh
@@ -197,8 +197,6 @@ namespace cbl_internal {
         :CBLListenerToken((const void*)callback, context)
         ,_query(query)
         {
-            _stoppable = std::make_unique<CBLQueryListenerStoppable>(this);
-            
             auto ctx = ContextManager::shared().registerObject(this);
             
             query->_c4query.useLocked([&](C4Query *c4query) {
@@ -258,22 +256,11 @@ namespace cbl_internal {
         #endif
 
     private:
-        struct CBLQueryListenerStoppable : CBLStoppable {
-        public:
-            CBLQueryListenerStoppable(ListenerToken<CBLQueryChangeListener>* token)
-            :CBLStoppable(token)
-            {}
-            
-            void stop() const override {
-                ((ListenerToken<CBLQueryChangeListener>*)_ref)->setEnabled(false);
-            }
-        };
         
         void queryChanged();    // defn is in CBLDatabase.cc, to prevent circular hdr dependency
 
         Retained<CBLQuery>  _query;
         Retained<C4QueryObserver> _c4obs;
-        std::unique_ptr<CBLQueryListenerStoppable> _stoppable;
         bool _isEnabled {false};
     };
 }

--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -215,8 +215,6 @@ public:
         
         _c4status = _c4repl->getStatus();
         _useInitialStatus = true;
-        
-        _stoppable = make_unique<CBLReplicatorStoppable>(this);
     }
     
     CBLCollection* _cbl_nullable defaultCollection() {
@@ -235,10 +233,9 @@ public:
 
     void start(bool reset) {
         LOCK(_mutex);
-        _retainSelf = this;     // keep myself from being freed until the replicator stops
         _useInitialStatus = false;
         
-        if (_db->registerStoppable(_stoppable.get())) {
+        if (_db->registerService(this, [this] { stop(); })) {
             SyncLog(Info, "%s Starting", desc().c_str());
             _c4repl->start(reset);
         } else
@@ -296,17 +293,6 @@ public:
     }
 
 private:
-    
-    struct CBLReplicatorStoppable : CBLStoppable {
-    public:
-        CBLReplicatorStoppable(CBLReplicator* r)
-        :CBLStoppable(r)
-        {}
-        
-        void stop() const override {
-            ((CBLReplicator*)_ref)->stop();
-        }
-    };
     
     alloc_slice encodeOptions(C4KeyPair* _cbl_nullable * _cbl_nullable outExternalKey) {
         Encoder enc;
@@ -368,8 +354,7 @@ private:
         }
 
         if (cblStatus.activity == kCBLReplicatorStopped) {
-            _db->unregisterStoppable(_stoppable.get());
-            _retainSelf = nullptr;  // Undoes the retain in `start`; now I can be freed
+            _db->unregisterService(this);
         }
     }
 
@@ -527,11 +512,9 @@ private:
     Retained<C4Replicator>                      _c4repl;
     string                                      _replID;
     string                                      _desc;
-    unique_ptr<CBLReplicatorStoppable>          _stoppable;
     ReplicationCollectionsMap                   _collections;       // For filters and conflict resolver
     bool                                        _useInitialStatus;  // For returning status before first start
     C4ReplicatorStatus                          _c4status {kC4Stopped};
-    Retained<CBLReplicator>                     _retainSelf;
     int                                         _activeConflictResolvers {0};
     Listeners<CBLReplicatorChangeListener>      _changeListeners;
     Listeners<CBLDocumentReplicationListener>   _docListeners;


### PR DESCRIPTION
* Registered the listener as an active service when it’s started successfully so that the database can stop the listener when it’s closed.

* Refactored so that each stoppable service doesn’t need to implement a subclass of the CBLStoppable and used Retained<CBLRefCounted> instead of manually calling retain() and release().

* Renamed CBLStoppable to CBLActiveService.