### PR TITLE
Lazily construct full list of log domains

### DIFF
--- a/src/CBLLogSinks.cc
+++ b/src/CBLLogSinks.cc
@@ -55,7 +55,7 @@ const std::vector<C4LogDomain>& CBLLogSinks::c4LogDomains() {
             kC4SyncLog,
             kC4WebSocketLog
         };
-        static C4LogDomain listenerDomain = c4log_getDomain("Listener", true);
+        C4LogDomain listenerDomain = c4log_getDomain("Listener", true);
         vec.push_back(listenerDomain);
         return vec;
     }();
@@ -206,7 +206,8 @@ void CBLLogSinks::updateLogLevels() {
     C4LogLevel c4LogLevel = C4LogLevel(domainsLogLevel);
     
     if (_sDomainsLogLevel.load() != domainsLogLevel) {
-        for (C4LogDomain domain : c4LogDomains()) {
+        auto domains = c4LogDomains();
+        for (C4LogDomain domain : domains) {
             c4log_setLevel(domain, c4LogLevel);
         }
 

--- a/src/CBLLogSinks.cc
+++ b/src/CBLLogSinks.cc
@@ -44,18 +44,27 @@ CBLFileLogSink CBLLogSinks::_sFileSink { kCBLLogNone, kFLSliceNull };
 
 std::shared_mutex CBLLogSinks::_sMutex;
 
-// Listener domain is not published explicitly with C4. It has
-// to be initialized in CBLogSinks::init().
-C4LogDomain C4LogDomainListener;
-
-static const C4LogDomain kC4Domains[] = { kC4DatabaseLog, kC4QueryLog, kC4SyncLog, kC4WebSocketLog, C4LogDomainListener };
 static const char* kC4ExtraDomains[] = { "SyncBusy", "Changes", "BLIPMessages", "TLS", "Zip" };
+
+const std::vector<C4LogDomain>& CBLLogSinks::c4LogDomains() {
+    static const std::vector<C4LogDomain> c4Domains = [] {
+        // MUST match CBLLogDomain order
+        std::vector<C4LogDomain> vec = {
+            kC4DatabaseLog,
+            kC4QueryLog,
+            kC4SyncLog,
+            kC4WebSocketLog
+        };
+        static C4LogDomain listenerDomain = c4log_getDomain("Listener", true);
+        vec.push_back(listenerDomain);
+        return vec;
+    }();
+    return c4Domains;
+}
 
 static once_flag initFlag;
 void CBLLogSinks::init() {
     call_once(initFlag, [](){
-        C4LogDomain* domains = (C4LogDomain*)kC4Domains;
-        domains[kCBLLogDomainListener] = C4LogDomainListener = c4log_getDomain("Listener", true);
         updateLogLevels();
     });
 }
@@ -104,7 +113,8 @@ void CBLLogSinks::log(CBLLogDomain domain, CBLLogLevel level, const char *msg) {
     logToCustomLogSink(customSink, domain, level, msg);
     
     // To file log:
-    c4slog(kC4Domains[domain], C4LogLevel(level), slice(msg));
+    C4LogDomain c4LogDomain = toC4LogDomain(domain);
+    c4slog(c4LogDomain, C4LogLevel(level), slice(msg));
 }
 
 void CBLLogSinks::validateAPIUsage(LogAPIStyle style) {
@@ -130,7 +140,8 @@ void CBLLogSinks::reset(void) {
 }
 
 void CBLLogSinks::logWithC4Log(CBLLogDomain domain, CBLLogLevel level, const char *msg) {
-    c4log(kC4Domains[domain], C4LogLevel(level), "%s", msg);
+    C4LogDomain c4Domain = toC4LogDomain(domain);
+    c4log(c4Domain, C4LogLevel(level), "%s", msg);
 }
 
 // Private Functions
@@ -195,12 +206,12 @@ void CBLLogSinks::updateLogLevels() {
     C4LogLevel c4LogLevel = C4LogLevel(domainsLogLevel);
     
     if (_sDomainsLogLevel.load() != domainsLogLevel) {
-        for (const auto c4LogDomain : kC4Domains) {
-            c4log_setLevel(c4LogDomain, c4LogLevel);
+        for (C4LogDomain domain : c4LogDomains()) {
+            c4log_setLevel(domain, c4LogLevel);
         }
 
         for(const auto* extraName : kC4ExtraDomains) {
-            auto* domain = c4log_getDomain(extraName, false);
+            C4LogDomain domain = c4log_getDomain(extraName, false);
             if (domain) {
                 c4log_setLevel(domain, c4LogLevel);
             }
@@ -267,6 +278,13 @@ void CBLLogSinks::logToCustomLogSink(CBLCustomLogSink& customSink,
     customSink.callback(domain, level, FLStr(msg));
 }
 
+C4LogDomain CBLLogSinks::toC4LogDomain(CBLLogDomain domain) {
+    const auto& domains = c4LogDomains();
+    size_t index = static_cast<size_t>(domain);
+    assert(index < domains.size());
+    return domains[index];
+}
+
 CBLLogDomain CBLLogSinks::toCBLLogDomain(C4LogDomain c4Domain) {
     static const unordered_map<string_view, CBLLogDomain> domainMap = {
         {"DB", kCBLLogDomainDatabase},
@@ -300,6 +318,8 @@ std::string CBLLogSinks::toLogDomainName(CBLLogDomain domain) {
             return "Replicator";
         case kCBLLogDomainNetwork:
             return "Network";
+        case kCBLLogDomainListener:
+            return "Listener";
         default:
             return "Database";
     }

--- a/src/CBLLogSinks_Internal.hh
+++ b/src/CBLLogSinks_Internal.hh
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <shared_mutex>
 #include <unordered_map>
+#include <vector>
 
 class CBLLogSinks {
 public:
@@ -66,6 +67,9 @@ private:
     static CBLFileLogSink _sFileSink;
     
     static std::shared_mutex _sMutex;
+    
+    static const std::vector<C4LogDomain>& c4LogDomains();
+    static C4LogDomain toC4LogDomain(CBLLogDomain);
     
     static void _setConsoleLogSink(const CBLConsoleLogSink&);
     static void _setCustomLogSink(const CBLCustomLogSink&);


### PR DESCRIPTION
* Lazily construct and cache full list of log domains lazily instead of doing it in the init() function and ensure that the full list of the log domains is ready before being accessed.

* Remove a workaround to populate the listener domain to a const array.