### PR TITLE
Change CBLKeyPair_CreateWithCallbacks Signature

### DIFF
--- a/src/CBLTLSIdentity_CAPI.cc
+++ b/src/CBLTLSIdentity_CAPI.cc
@@ -43,12 +43,12 @@ const FLString kCBLCertAttrKeyRegisteredID = FLSTR("registeredID");
 
 // KeyPair
 
-CBLKeyPair* CBLKeyPair_CreateWithCallbacks(void* context,
-                                           size_t keySizeInBits,
-                                           CBLKeyPairCallbacks callbacks,
-                                           CBLError* outError) noexcept {
+CBLKeyPair* CBLKeyPair_CreateWithExternalKey(size_t keySizeInBits,
+                                             void* externalKey,
+                                             CBLExternalKeyCallbacks callbacks,
+                                             CBLError* outError) noexcept {
     try {
-        return retain(CBLKeyPair::CreateKeyPairWithCallbacks(context, keySizeInBits, callbacks));
+        return retain(CBLKeyPair::CreateKeyPairWithExternalKey(keySizeInBits, externalKey, callbacks));
     } catchAndBridge(outError);
 }
 

--- a/src/exports/CBL_EE_Exports.txt
+++ b/src/exports/CBL_EE_Exports.txt
@@ -106,7 +106,7 @@ kCBLCertAttrKeyURL
 kCBLCertAttrKeyIPAddress
 kCBLCertAttrKeyRegisteredID
 
-CBLKeyPair_CreateWithCallbacks
+CBLKeyPair_CreateWithExternalKey
 CBLKeyPair_CreateWithPrivateKeyData
 CBLKeyPair_PublicKeyDigest
 CBLKeyPair_PublicKeyData

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -68,7 +68,7 @@ kCBLCertAttrKeyHostname
 kCBLCertAttrKeyURL
 kCBLCertAttrKeyIPAddress
 kCBLCertAttrKeyRegisteredID
-CBLKeyPair_CreateWithCallbacks
+CBLKeyPair_CreateWithExternalKey
 CBLKeyPair_CreateWithPrivateKeyData
 CBLKeyPair_PublicKeyDigest
 CBLKeyPair_PublicKeyData

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -77,7 +77,7 @@ _kCBLCertAttrKeyHostname
 _kCBLCertAttrKeyURL
 _kCBLCertAttrKeyIPAddress
 _kCBLCertAttrKeyRegisteredID
-_CBLKeyPair_CreateWithCallbacks
+_CBLKeyPair_CreateWithExternalKey
 _CBLKeyPair_CreateWithPrivateKeyData
 _CBLKeyPair_PublicKeyDigest
 _CBLKeyPair_PublicKeyData

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -66,7 +66,7 @@ CBL_C {
 		kCBLCertAttrKeyURL;
 		kCBLCertAttrKeyIPAddress;
 		kCBLCertAttrKeyRegisteredID;
-		CBLKeyPair_CreateWithCallbacks;
+		CBLKeyPair_CreateWithExternalKey;
 		CBLKeyPair_CreateWithPrivateKeyData;
 		CBLKeyPair_PublicKeyDigest;
 		CBLKeyPair_PublicKeyData;

--- a/src/exports/generated/CBL_EE_Android.gnu
+++ b/src/exports/generated/CBL_EE_Android.gnu
@@ -67,7 +67,7 @@ CBL_C {
 		kCBLCertAttrKeyURL;
 		kCBLCertAttrKeyIPAddress;
 		kCBLCertAttrKeyRegisteredID;
-		CBLKeyPair_CreateWithCallbacks;
+		CBLKeyPair_CreateWithExternalKey;
 		CBLKeyPair_CreateWithPrivateKeyData;
 		CBLKeyPair_PublicKeyDigest;
 		CBLKeyPair_PublicKeyData;

--- a/test/TLSIdentityTest.cc
+++ b/test/TLSIdentityTest.cc
@@ -369,12 +369,12 @@ TEST_CASE_METHOD(URLEndpointListenerTest, "Self-Signed Identity with PrivateKey 
     ExternalKeyContext ekContext{externalKey};
 
     // Creates a RSA KeyPair from the KeyPair callback.
-
-    CBLKeyPair* cblKeyPair = CBLKeyPair_CreateWithCallbacks(&ekContext, 2048,
-                                                            CBLKeyPairCallbacks{
-            // These callbacks are defined in TLSIdentityTest+Apple.mm
-            kc_publicKeyData, kc_decrypt, kc_sign, kc_free},
-                                                            &outError);
+    // These callbacks are defined in TLSIdentityTest+Apple.mm
+    CBLKeyPair* cblKeyPair = CBLKeyPair_CreateWithExternalKey(2048,
+                                                              &ekContext,
+                                                              CBLExternalKeyCallbacks{kc_publicKeyData, kc_decrypt, kc_sign, kc_free},
+                                                              &outError);
+    
     CHECK(outError.code == 0);
     CHECK(cblKeyPair);
 

--- a/test/URLEndpointListenerTest.cc
+++ b/test/URLEndpointListenerTest.cc
@@ -88,11 +88,10 @@ CBLTLSIdentity* URLEndpointListenerTest::createTLSIdentity(bool isServer, bool w
         keypair.reset(CBLKeyPair_GenerateRSAKeyPair(fleece::nullslice, nullptr));
     } else {
 #ifdef __APPLE__
-        keypair.reset(CBLKeyPair_CreateWithCallbacks(TLSIdentityTest::ExternalKey::generateRSA(2048),
-                                                     2048,
-                                                     CBLKeyPairCallbacks{
-            kc_publicKeyData, kc_decrypt, kc_sign, kc_free},
-                                                     nullptr));
+        keypair.reset(CBLKeyPair_CreateWithExternalKey(2048,
+                                                       TLSIdentityTest::ExternalKey::generateRSA(2048),
+                                                       CBLExternalKeyCallbacks{kc_publicKeyData, kc_decrypt, kc_sign, kc_free},
+                                                       nullptr));
 #else
         return nullptr;
 #endif
@@ -579,11 +578,7 @@ TEST_CASE_METHOD(URLEndpointListenerTest, "Busy Port", "[URLListener]") {
     CHECK(!succ);
 
     // Checks that an error is returned as POSIX/EADDRINUSE or equivalent when starting the second listener.
-
-    CHECK(outError.code); // EADDRINUSE
-    // Error messages may differ by platforms.
-    // alloc_slice errmsg = CBLError_Message(&outError);
-    // CHECK(errmsg == "Address already in use");
+    CHECK(outError.code); // EADDRINUSE (Error messages may differ by platforms)
 
     // Stops both listeners.
     CBLURLEndpointListener_Stop(listener);


### PR DESCRIPTION
To make it easier to understand and make the context object make sense, change the signature as follows:

* Rename the callback to CBLExternalKeyCallbacks.
* For each callback function, rename context param to externalKey.
* Rename CBLKeyPair_CreateWithCallbacks to CBLKeyPair_CreateWithExternalKey.
* Rename context param to externalKey and move the param before callbacks.
* In CBLTLSIdentity_IdentityWithKeyPairAndCerts, keypair is not nullable.