### PR TITLE
Revert "CBL-6951 : Relax database validation rules in URLEndpoint"

### DIFF
--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -65,17 +65,11 @@ namespace cbl_internal {
         CBLURLEndpoint(fleece::slice url)
         :_url(url)
         {
-            if (!C4Address::fromURL(_url, &_address, nullptr)) {
+            if (!C4Address::fromURL(_url, &_address, (fleece::slice*)&_dbName)) {
                 C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter,
                                "Invalid URLEndpoint url '%.*s'", FMTSLICE(_url));
-            }
-            
-            if (!extractRemoteDatabaseName(&_address, &_dbName)) {
-                C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter,
-                               "Invalid Database Name in URLEndpoint url '%.*s'", FMTSLICE(_url));
-            }
-            
-            if (_address.scheme != kC4Replicator2Scheme && _address.scheme != kC4Replicator2TLSScheme) {
+            } else if (_address.scheme != kC4Replicator2Scheme &&
+                       _address.scheme != kC4Replicator2TLSScheme) {
                 C4Error::raise(LiteCoreDomain, kC4ErrorInvalidParameter,
                                "Invalid scheme for URLEndpoint url '%.*s'. It must be either 'ws:' or 'wss:'.",
                                FMTSLICE(_url));
@@ -89,23 +83,6 @@ namespace cbl_internal {
     private:
         fleece::alloc_slice _url;
         C4String _dbName = { };
-        
-        bool extractRemoteDatabaseName(C4Address* address, C4String* outDbName) {
-            auto str = fleece::slice(address->path);
-            
-            if ( str.hasSuffix(fleece::slice("/")) ) str.setSize(str.size - 1);
-            const uint8_t* slash;
-            while ( (slash = str.findByte('/')) != nullptr ) str.setStart(slash + 1);
-            
-            address->path = fleece::slice(address->path.buf, str.buf);
-            outDbName->buf = str.buf;
-            outDbName->size = str.size;
-            return validateDatabaseName(str);
-        }
-        
-        bool validateDatabaseName(fleece::slice dbName) {
-            return (dbName.size > 0);
-        }
     };
 
 #ifdef COUCHBASE_ENTERPRISE

--- a/test/ReplicatorTest.cc
+++ b/test/ReplicatorTest.cc
@@ -52,7 +52,7 @@ TEST_CASE_METHOD(ReplicatorTest, "Bad config", "[Replicator]") {
 }
 
 
-TEST_CASE_METHOD(ReplicatorTest, "Validate url", "[Replicator]") {
+TEST_CASE_METHOD(ReplicatorTest, "Bad url", "[Replicator]") {
     ExpectingExceptions x;
     
     // No db:
@@ -62,39 +62,11 @@ TEST_CASE_METHOD(ReplicatorTest, "Validate url", "[Replicator]") {
     CHECK(error.domain == kCBLDomain);
     CHECK(error.code == kCBLErrorInvalidParameter);
     
-    // No db:
-    endpoint = CBLEndpoint_CreateWithURL("ws://localhost:4984/"_sl, &error);
-    CHECK(!endpoint);
-    CHECK(error.domain == kCBLDomain);
-    CHECK(error.code == kCBLErrorInvalidParameter);
-    
     // Invalid scheme:
     endpoint = CBLEndpoint_CreateWithURL("https://localhost:4984/db"_sl, &error);
     CHECK(!endpoint);
     CHECK(error.domain == kCBLDomain);
     CHECK(error.code == kCBLErrorInvalidParameter);
-    
-    // Good db:
-    endpoint = CBLEndpoint_CreateWithURL("ws://localhost:4984/db"_sl, &error);
-    CHECK(endpoint);
-    CBLEndpoint_Free(endpoint);
-    
-    endpoint = CBLEndpoint_CreateWithURL("ws://localhost:4984/db.1"_sl, &error);
-    CHECK(endpoint);
-    CBLEndpoint_Free(endpoint);
-    
-    endpoint = CBLEndpoint_CreateWithURL("ws://localhost:4984/Db"_sl, &error);
-    CHECK(endpoint);
-    CBLEndpoint_Free(endpoint);
-    
-    endpoint = CBLEndpoint_CreateWithURL("ws://localhost:4984/db/"_sl, &error);
-    CHECK(endpoint);
-    CBLEndpoint_Free(endpoint);
-    
-    // wss:
-    endpoint = CBLEndpoint_CreateWithURL("wss://localhost:4984/db"_sl, &error);
-    CHECK(endpoint);
-    CBLEndpoint_Free(endpoint);
 }
 
 #ifndef __ANDROID__


### PR DESCRIPTION
* Relaxing the rules in URLEndpoint alone is not enough. C4Replicator also performs the same validation when the internal socket factor is used. Will leave this as an open issue for 3.2.3.

* This reverts commit 0aa1b195312a11b21d03d59e8351301f30543c01.