### PR TITLE
CBL-7004 : Add CBLURLEndpointListener_TLSIdentity API

### DIFF
--- a/include/cbl/CBLURLEndpointListener.h
+++ b/include/cbl/CBLURLEndpointListener.h
@@ -104,8 +104,13 @@ const CBLURLEndpointListenerConfiguration* CBLURLEndpointListener_Config(const C
 /** The listening port of the listener. If the listener is not started, the port will be zero. */
 uint16_t CBLURLEndpointListener_Port(const CBLURLEndpointListener*) CBLAPI;
 
+/** The TLS identity used by the listener for TLS communication. The value will be nullptr if the listener is not started, or if the TLS is disabled.
+    @note The returned identity remains valid until the listener is stopped or released.
+          If you want to keep it longer, retain it with `CBLTLSIdentity_Retain`. */
+CBLTLSIdentity* CBLURLEndpointListener_TLSIdentity(const CBLURLEndpointListener*) CBLAPI;
+
 /** The possible URLs of the listener. If the listener is not started, NULL will be returned.
- @note You are responsible for releasing the returned reference. */
+    @note You are responsible for releasing the returned reference. */
 FLMutableArray CBLURLEndpointListener_Urls(const CBLURLEndpointListener*) CBLAPI;
 
 /** The connection status of the listener */

--- a/src/CBLURLEndpointListener_CAPI.cc
+++ b/src/CBLURLEndpointListener_CAPI.cc
@@ -57,6 +57,10 @@ uint16_t CBLURLEndpointListener_Port(const CBLURLEndpointListener* listener) noe
     return listener->port();
 }
 
+CBLTLSIdentity* CBLURLEndpointListener_TLSIdentity(const CBLURLEndpointListener* listener) noexcept {
+    return listener->identity().get();
+}
+
 FLMutableArray CBLURLEndpointListener_Urls(const CBLURLEndpointListener* listener) noexcept {
     try {
         return (FLMutableArray)FLValue_Retain(listener->getUrls());
@@ -83,9 +87,5 @@ void CBLURLEndpointListener_Stop(CBLURLEndpointListener* listener) noexcept {
 // CBLPrivate.h
 FLSliceResult CBLURLEndpointListener_AnonymousLabel(const CBLURLEndpointListener* listener) noexcept {
     return (FLSliceResult)listener->anonymousLabel();
-}
-
-CBLTLSIdentity* CBLURLEndpointListener_TLSIdentity(const CBLURLEndpointListener* listener) noexcept {
-    return listener->TLSIdentity();
 }
 #endif

--- a/test/URLEndpointListenerTest.cc
+++ b/test/URLEndpointListenerTest.cc
@@ -1305,6 +1305,58 @@ TEST_CASE_METHOD(URLEndpointListenerTest, "Close Database Stops Listener", "[URL
     CBLURLEndpointListener_Release(listener);
 }
 
+// T0010-18 TestListgenerTLSIdentity
+TEST_CASE_METHOD(URLEndpointListenerTest, "Listener TLS Identity", "[URLListener]") {
+    CBLURLEndpointListenerConfiguration listenerConfig {
+        cy.data(),
+        1,
+        0         // port
+    };
+    
+    bool useAnonymosIdentity = false;
+    
+    SECTION("Disable TLS") {
+        listenerConfig.disableTLS = true;
+    }
+    
+    SECTION("With TLSIdentity") {
+        listenerConfig.tlsIdentity = createTLSIdentity(true, false);
+    }
+    
+    SECTION("With Anonymous TLSIdentity") {
+        useAnonymosIdentity = true;
+        listenerConfig.tlsIdentity = nullptr;
+    }
+    
+    CBLURLEndpointListener* listener = CBLURLEndpointListener_Create(&listenerConfig, nullptr);
+    REQUIRE(listener);
+    
+    CHECK(CBLURLEndpointListener_TLSIdentity(listener) == nullptr);
+    
+    CHECK(CBLURLEndpointListener_Start(listener, nullptr));
+    
+    if (listenerConfig.disableTLS) {
+        CHECK(CBLURLEndpointListener_TLSIdentity(listener) == nullptr);
+    } else {
+        CHECK(CBLURLEndpointListener_TLSIdentity(listener) != nullptr);
+    }
+    
+#if !defined(__linux__) && !defined(__ANDROID__)
+    if (useAnonymosIdentity) {
+        alloc_slice anonymousLabel = CBLURLEndpointListener_AnonymousLabel(listener);
+        CHECK(anonymousLabel);
+        identityLabelsToDelete.emplace_back(anonymousLabel);
+    }
+#endif
+    
+    CBLURLEndpointListener_Stop(listener);
+    
+    CHECK(CBLURLEndpointListener_TLSIdentity(listener) == nullptr);
+    
+    CBLURLEndpointListener_Release(listener);
+    CBLTLSIdentity_Release(listenerConfig.tlsIdentity);
+}
+
 TEST_CASE_METHOD(URLEndpointListenerTest, "Start and Stop Listener", "[URLListener]") {
     CBLURLEndpointListener* listener;
     {


### PR DESCRIPTION
* The CBLURLEndpointListener_TLSIdentity is public on the other platforms. Hence, make the API public in CBL-C as well.

* Added test.