### PR TITLE
CBL-7039 : Correct and Improve TLSIdentity API Doc

### DIFF
--- a/src/CBLTLSIdentity_CAPI.cc
+++ b/src/CBLTLSIdentity_CAPI.cc
@@ -138,13 +138,13 @@ CBLKeyPair* CBLCert_PublicKey(CBLCert* cert) noexcept {
 CBLTLSIdentity* CBLTLSIdentity_CreateIdentityWithKeyPair(CBLKeyUsages usages,
                                                          CBLKeyPair* keypair,
                                                          FLDict attributes,
-                                                         CBLTimestamp expiration,
+                                                         CBLTimestamp validityInMilliseconds,
                                                          CBLError* outError) noexcept {
     try {
         return retain(CBLTLSIdentity::CreateIdentity(usages,
                                                      keypair,
                                                      attributes,
-                                                     expiration));
+                                                     validityInMilliseconds));
     } catchAndBridge(outError);
 }
 
@@ -166,11 +166,11 @@ CBLTimestamp CBLTLSIdentity_Expiration(CBLTLSIdentity* tlsID) noexcept {
 
 CBLTLSIdentity* CBLTLSIdentity_CreateIdentity(CBLKeyUsages usages,
                                               FLDict attrs,
-                                              CBLTimestamp exp,
+                                              int64_t validityInMilliseconds,
                                               FLString label,
                                               CBLError* outError) noexcept {
     try {
-        return retain(CBLTLSIdentity::CreateIdentity(usages, attrs, exp, label));
+        return retain(CBLTLSIdentity::CreateIdentity(usages, attrs, validityInMilliseconds, label));
     } catchAndBridge(outError);
 }
 


### PR DESCRIPTION
* Improved TLSIdentity API Doc based on feedback.

* Changed the expiration parameter in `CBLTLSIdentity_CreateIdentity` and `CBLTLSIdentity_CreateIdentityWithKeyPair` to `validityInMilliseconds` and updated its API doc accordingly to reflect the actual behavior.