### PR TITLE
CBL-7314 : Remove deprecated Logging API

### DIFF
--- a/include/cbl/CBLLog.h
+++ b/include/cbl/CBLLog.h
@@ -28,7 +28,8 @@ CBL_CAPI_BEGIN
  */
 
 /** Formats and writes a message to the log, in the given domain at the given level.
-    \warning This function takes a `printf`-style format string, with extra parameters to match the format placeholders, and has the same security vulnerabilities as other `printf`-style functions.
+    \warning This function takes a `printf`-style format string, with extra parameters to match the format placeholders,
+             and has the same security vulnerabilities as other `printf`-style functions.
 
     If you are logging a fixed string, call \ref CBL_LogMessage instead, otherwise any `%`
     characters in the `format` string will be misinterpreted as placeholders and the dreaded
@@ -52,77 +53,6 @@ void CBL_Log(CBLLogDomain domain,
 void CBL_LogMessage(CBLLogDomain domain,
                     CBLLogLevel level,
                     FLSlice message) CBLAPI;
-
-/** \name Console Logging and Custom Logging
-    @{ */
-
-/** A logging callback that the application can register. */
-typedef CBLLogSinkCallback CBLLogCallback;
-
-/** Gets the current log level for debug console logging.
-    Only messages at this level or higher will be logged to the console.
-    @warning  <b>Deprecated :</b> Use CBLLogSinks_Console instead. */
-CBLLogLevel CBLLog_ConsoleLevel(void) CBLAPI;
-
-/** Sets the detail level of logging.
-    Only messages whose level is ≥ the given level will be logged to the console.
-    @warning  <b>Deprecated :</b> Use CBLLogSinks_SetConsole instead. */
-void CBLLog_SetConsoleLevel(CBLLogLevel) CBLAPI;
-
-/** Gets the current log level for debug console logging.
-    Only messages at this level or higher will be logged to the callback.
-    @warning  <b>Deprecated :</b> Use CBLLogSinks_CustomSink instead. */
-CBLLogLevel CBLLog_CallbackLevel(void) CBLAPI;
-
-/** Sets the detail level of logging.
-    Only messages whose level is ≥ the given level will be logged to the callback.
-    @warning  <b>Deprecated :</b> Use CBLLogSinks_SetCustom instead. */
-void CBLLog_SetCallbackLevel(CBLLogLevel) CBLAPI;
-
-/** Gets the current log callback.
-    @warning  <b>Deprecated :</b> Use CBLLogSinks_CustomSink instead. */
-CBLLogCallback CBLLog_Callback(void) CBLAPI;
-
-/** Sets the callback for receiving log messages. If set to NULL, no messages are logged to the console.
-    @warning  <b>Deprecated :</b> Use CBLLogSinks_SetCustom instead. */
-void CBLLog_SetCallback(CBLLogCallback _cbl_nullable callback) CBLAPI;
-
-/** @} */
-
-/** \name Log File Configuration
-    @{ */
-
-/** The properties for configuring logging to files.
-    @warning `usePlaintext` results in significantly larger log files and higher CPU usage that may slow
-            down your app; we recommend turning it off in production.
-    @warning  <b>Deprecated :</b> Use CBLLogSinks_SetFile instead. */
-typedef struct {
-    CBLLogLevel level;       ///< The minimum level of message to write (Required).
-    
-    FLString directory;      ///< The directory where log files will be created (Required).
-    
-    /** Max number of older log files to keep (in addition to current one.)
-        The default is \ref kCBLDefaultLogFileMaxRotateCount. */
-    uint32_t maxRotateCount;
-    
-    /** The size in bytes at which a file will be rotated out (best effort).
-        The default is \ref kCBLDefaultLogFileMaxSize. */
-    size_t maxSize;
-    
-    /** Whether or not to log in plaintext (as opposed to binary.) Plaintext logging is slower and bigger.
-        The default is \ref kCBLDefaultLogFileUsePlaintext. */
-    bool usePlaintext;
-} CBLLogFileConfiguration;
-
-/** Gets the current file logging configuration, or NULL if none is configured.
-    @warning  <b>Deprecated :</b> Use CBLLogSinks_File instead. */
-const CBLLogFileConfiguration* _cbl_nullable CBLLog_FileConfig(void) CBLAPI;
-
-/** Sets the file logging configuration, and begins logging to files.
-    @warning  <b>Deprecated :</b> Use CBLLogSinks_SetFile instead. */
-bool CBLLog_SetFileConfig(CBLLogFileConfiguration, CBLError* _cbl_nullable outError) CBLAPI;
-
-/** @} */
 
 /** @} */
 

--- a/src/CBLLog.cc
+++ b/src/CBLLog.cc
@@ -1,7 +1,7 @@
 //
 // CBLLog.cc
 //
-// Copyright © 2019 Couchbase. All rights reserved.
+// Copyright © 2025 Couchbase. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,77 +26,8 @@ using namespace std;
 using namespace fleece;
 using namespace litecore;
 
-static CBLLogFileConfiguration sLogFileConfig;
-static alloc_slice sLogFileDir;
-
 void CBLLog_Init() {
     CBLLogSinks::init();
-}
-
-CBLLogLevel CBLLog_ConsoleLevel() CBLAPI {
-    CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::oldStyle);
-    return CBLLogSinks::consoleLogSink().level;
-}
-
-void CBLLog_SetConsoleLevel(CBLLogLevel level) CBLAPI {
-    CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::oldStyle);
-    CBLLogSinks::setConsoleLogSink({ level, kCBLLogDomainMaskAll });
-}
-
-CBLLogLevel CBLLog_CallbackLevel() CBLAPI {
-    CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::oldStyle);
-    return CBLLogSinks::customLogSink().level;
-}
-
-void CBLLog_SetCallbackLevel(CBLLogLevel level) CBLAPI {
-    CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::oldStyle);
-    
-    auto config = CBLLogSinks::customLogSink();
-    config.level = level;
-    CBLLogSinks::setCustomLogSink(config);
-}
-
-CBLLogCallback CBLLog_Callback() CBLAPI {
-    CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::oldStyle);
-    return CBLLogSinks::customLogSink().callback;
-}
-
-void CBLLog_SetCallback(CBLLogCallback callback) CBLAPI {
-    CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::oldStyle);
-    
-    auto config = CBLLogSinks::customLogSink();
-    config.callback = callback;
-    CBLLogSinks::setCustomLogSink(config);
-}
-
-const CBLLogFileConfiguration* CBLLog_FileConfig() CBLAPI {
-    CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::oldStyle);
-    
-    if (sLogFileConfig.directory.buf)
-        return &sLogFileConfig;
-    else
-        return nullptr;
-}
-
-bool CBLLog_SetFileConfig(CBLLogFileConfiguration config, CBLError *outError) CBLAPI {
-    CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::oldStyle);
-    
-    sLogFileDir = config.directory;     // copy string to the heap
-    config.directory = sLogFileDir;     // and put the heap copy in the struct
-    sLogFileConfig = config;
-    
-    CBLFileLogSink fileLogSink { };
-    fileLogSink.level = config.level;
-    fileLogSink.directory = sLogFileConfig.directory;
-    auto maxRotateCount = config.maxRotateCount > 0 ? config.maxRotateCount : kCBLDefaultLogFileMaxRotateCount;
-    fileLogSink.maxKeptFiles = maxRotateCount + 1;
-    fileLogSink.maxSize = config.maxSize;
-    fileLogSink.usePlaintext = config.usePlaintext;
-    
-    try {
-        CBLLogSinks::setFileLogSink(fileLogSink);
-        return true;
-    } catchAndBridge(outError)
 }
 
 void CBL_Log(CBLLogDomain domain, CBLLogLevel level, const char *format, ...) CBLAPI {
@@ -132,8 +63,6 @@ void CBLLog_EndExpectingExceptions() CBLAPI {
 /** Private API */
 void CBLLog_Reset(void) CBLAPI {
     CBLLogSinks::reset();
-    sLogFileDir = nullptr;
-    sLogFileConfig = { kCBLLogNone, kFLSliceNull };
 }
 
 /** Private API */

--- a/src/CBLLogSinks_CAPI.cc
+++ b/src/CBLLogSinks_CAPI.cc
@@ -1,7 +1,7 @@
 //
 // CBLLogSinks_CAPI.cc
 //
-// Copyright © 2024 Couchbase. All rights reserved.
+// Copyright © 2025 Couchbase. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,31 +19,25 @@
 #include "CBLLogSinks_Internal.hh"
 
 void CBLLogSinks_SetConsole(CBLConsoleLogSink logSink) noexcept {
-    try { CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::newStyle); } catchAndAbort()
-    CBLLogSinks::setConsoleLogSink(logSink);
+    try { CBLLogSinks::setConsoleLogSink(logSink); } catchAndWarnNoReturn();
 }
 
 CBLConsoleLogSink CBLLogSinks_Console(void) noexcept {
-    try { CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::newStyle); } catchAndAbort()
-    return CBLLogSinks::consoleLogSink();
+    try { return CBLLogSinks::consoleLogSink(); } catchAndWarn();
 }
 
 void CBLLogSinks_SetCustom(CBLCustomLogSink logSink) noexcept {
-    try { CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::newStyle); } catchAndAbort()
-    CBLLogSinks::setCustomLogSink(logSink);
+    try { CBLLogSinks::setCustomLogSink(logSink); } catchAndWarnNoReturn();
 }
 
 CBLCustomLogSink CBLLogSinks_CustomSink(void) noexcept {
-    try { CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::newStyle); } catchAndAbort()
-    return CBLLogSinks::customLogSink();
+    try { return CBLLogSinks::customLogSink(); } catchAndWarn();
 }
 
 void CBLLogSinks_SetFile(CBLFileLogSink logSink) noexcept {
-    try { CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::newStyle); } catchAndAbort()
     try { CBLLogSinks::setFileLogSink(logSink); } catchAndWarnNoReturn();
 }
 
 CBLFileLogSink CBLLogSinks_File(void) noexcept {
-    try { CBLLogSinks::validateAPIUsage(CBLLogSinks::LogAPIStyle::newStyle); } catchAndAbort()
-    return CBLLogSinks::fileLogSink();
+    try { return CBLLogSinks::fileLogSink(); } catchAndWarn();
 }

--- a/src/CBLLogSinks_Internal.hh
+++ b/src/CBLLogSinks_Internal.hh
@@ -1,7 +1,7 @@
 //
 // CBLLogSink_Internal.hh
 //
-// Copyright © 2024 Couchbase. All rights reserved.
+// Copyright © 2025 Couchbase. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,23 +45,13 @@ public:
     
     static void log(CBLLogDomain domain, CBLLogLevel level, const char *msg);
     
-    // Temporarily until removing the old logging API
-    enum class LogAPIStyle {
-        none,
-        oldStyle,
-        newStyle,
-    };
-    static void validateAPIUsage(LogAPIStyle usage);
-    
     // For testing purpose
     static void reset(void);
     static void logWithC4Log(CBLLogDomain domain, CBLLogLevel level, const char *msg);
     
 private:
-    static std::atomic<LogAPIStyle> _sAPIStyle;
-    
-    static std::atomic<CBLLogLevel> _sDomainsLogLevel;
-    static std::atomic<CBLLogLevel> _sCallbackLogLevel;
+    static CBLLogLevel _sDomainsLogLevel;
+    static CBLLogLevel _sCallbackLogLevel;
     
     static CBLConsoleLogSink _sConsoleSink;
     static CBLCustomLogSink _sCustomSink;
@@ -72,10 +62,8 @@ private:
     static const std::vector<C4LogDomain>& c4LogDomains();
     static C4LogDomain toC4LogDomain(CBLLogDomain);
     
-    static void _setConsoleLogSink(const CBLConsoleLogSink&);
-    static void _setCustomLogSink(const CBLCustomLogSink&);
-    static void _setFileLogSink(const CBLFileLogSink&);
-    static void updateLogLevels();
+    static void setFileLogSinkNoLock(const CBLFileLogSink&);
+    static void updateLogLevelsNoLock();
     
     static void c4LogCallback(C4LogDomain c4Domain, C4LogLevel c4Level, const char *msg, va_list args);
     static void logToConsoleLogSink(CBLConsoleLogSink&, CBLLogDomain, CBLLogLevel, const char *);

--- a/src/exports/CBL_Exports.txt
+++ b/src/exports/CBL_Exports.txt
@@ -146,15 +146,6 @@ CBLDocument_SetJSON
 CBL_Log
 CBL_LogMessage
 
-CBLLog_Callback
-CBLLog_SetCallback
-CBLLog_CallbackLevel
-CBLLog_SetCallbackLevel
-CBLLog_ConsoleLevel
-CBLLog_SetConsoleLevel
-CBLLog_FileConfig
-CBLLog_SetFileConfig
-
 CBLLogSinks_SetConsole
 CBLLogSinks_Console
 CBLLogSinks_SetCustom

--- a/src/exports/generated/CBL.def
+++ b/src/exports/generated/CBL.def
@@ -105,14 +105,6 @@ CBLDocument_CreateJSON
 CBLDocument_SetJSON
 CBL_Log
 CBL_LogMessage
-CBLLog_Callback
-CBLLog_SetCallback
-CBLLog_CallbackLevel
-CBLLog_SetCallbackLevel
-CBLLog_ConsoleLevel
-CBLLog_SetConsoleLevel
-CBLLog_FileConfig
-CBLLog_SetFileConfig
 CBLLogSinks_SetConsole
 CBLLogSinks_Console
 CBLLogSinks_SetCustom

--- a/src/exports/generated/CBL.exp
+++ b/src/exports/generated/CBL.exp
@@ -113,14 +113,6 @@ _CBLDocument_CreateJSON
 _CBLDocument_SetJSON
 _CBL_Log
 _CBL_LogMessage
-_CBLLog_Callback
-_CBLLog_SetCallback
-_CBLLog_CallbackLevel
-_CBLLog_SetCallbackLevel
-_CBLLog_ConsoleLevel
-_CBLLog_SetConsoleLevel
-_CBLLog_FileConfig
-_CBLLog_SetFileConfig
 _CBLLogSinks_SetConsole
 _CBLLogSinks_Console
 _CBLLogSinks_SetCustom

--- a/src/exports/generated/CBL.gnu
+++ b/src/exports/generated/CBL.gnu
@@ -103,14 +103,6 @@ CBL_C {
 		CBLDocument_SetJSON;
 		CBL_Log;
 		CBL_LogMessage;
-		CBLLog_Callback;
-		CBLLog_SetCallback;
-		CBLLog_CallbackLevel;
-		CBLLog_SetCallbackLevel;
-		CBLLog_ConsoleLevel;
-		CBLLog_SetConsoleLevel;
-		CBLLog_FileConfig;
-		CBLLog_SetFileConfig;
 		CBLLogSinks_SetConsole;
 		CBLLogSinks_Console;
 		CBLLogSinks_SetCustom;

--- a/src/exports/generated/CBL_Android.gnu
+++ b/src/exports/generated/CBL_Android.gnu
@@ -104,14 +104,6 @@ CBL_C {
 		CBLDocument_SetJSON;
 		CBL_Log;
 		CBL_LogMessage;
-		CBLLog_Callback;
-		CBLLog_SetCallback;
-		CBLLog_CallbackLevel;
-		CBLLog_SetCallbackLevel;
-		CBLLog_ConsoleLevel;
-		CBLLog_SetConsoleLevel;
-		CBLLog_FileConfig;
-		CBLLog_SetFileConfig;
 		CBLLogSinks_SetConsole;
 		CBLLogSinks_Console;
 		CBLLogSinks_SetCustom;

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -199,14 +199,6 @@ CBLDocument_CreateJSON
 CBLDocument_SetJSON
 CBL_Log
 CBL_LogMessage
-CBLLog_Callback
-CBLLog_SetCallback
-CBLLog_CallbackLevel
-CBLLog_SetCallbackLevel
-CBLLog_ConsoleLevel
-CBLLog_SetConsoleLevel
-CBLLog_FileConfig
-CBLLog_SetFileConfig
 CBLLogSinks_SetConsole
 CBLLogSinks_Console
 CBLLogSinks_SetCustom

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -208,14 +208,6 @@ _CBLDocument_CreateJSON
 _CBLDocument_SetJSON
 _CBL_Log
 _CBL_LogMessage
-_CBLLog_Callback
-_CBLLog_SetCallback
-_CBLLog_CallbackLevel
-_CBLLog_SetCallbackLevel
-_CBLLog_ConsoleLevel
-_CBLLog_SetConsoleLevel
-_CBLLog_FileConfig
-_CBLLog_SetFileConfig
 _CBLLogSinks_SetConsole
 _CBLLogSinks_Console
 _CBLLogSinks_SetCustom

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -194,14 +194,6 @@ CBL_C {
 		CBLDocument_SetJSON;
 		CBL_Log;
 		CBL_LogMessage;
-		CBLLog_Callback;
-		CBLLog_SetCallback;
-		CBLLog_CallbackLevel;
-		CBLLog_SetCallbackLevel;
-		CBLLog_ConsoleLevel;
-		CBLLog_SetConsoleLevel;
-		CBLLog_FileConfig;
-		CBLLog_SetFileConfig;
 		CBLLogSinks_SetConsole;
 		CBLLogSinks_Console;
 		CBLLogSinks_SetCustom;

--- a/src/exports/generated/CBL_EE_Android.gnu
+++ b/src/exports/generated/CBL_EE_Android.gnu
@@ -195,14 +195,6 @@ CBL_C {
 		CBLDocument_SetJSON;
 		CBL_Log;
 		CBL_LogMessage;
-		CBLLog_Callback;
-		CBLLog_SetCallback;
-		CBLLog_CallbackLevel;
-		CBLLog_SetCallbackLevel;
-		CBLLog_ConsoleLevel;
-		CBLLog_SetConsoleLevel;
-		CBLLog_FileConfig;
-		CBLLog_SetFileConfig;
 		CBLLogSinks_SetConsole;
 		CBLLogSinks_Console;
 		CBLLogSinks_SetCustom;

--- a/test/LogTest_Cpp.cc
+++ b/test/LogTest_Cpp.cc
@@ -58,7 +58,7 @@ TEST_CASE_METHOD(LogTest_Cpp, "Console Log Sink Cpp: Set and Get", "[Log]") {
 }
 
 TEST_CASE_METHOD(LogTest_Cpp, "Custom Log Sink Cpp: Set and Get", "[Log]") {
-    CBLLogCallback callback = [](CBLLogDomain domain, CBLLogLevel level, FLString msg) { };
+    CBLLogSinkCallback callback = [](CBLLogDomain domain, CBLLogLevel level, FLString msg) { };
     LogSinks::setCustom({ kCBLLogVerbose, callback, kCBLLogDomainMaskAll});
     CBLCustomLogSink logSink = LogSinks::custom();
     CHECK(logSink.level == kCBLLogVerbose);


### PR DESCRIPTION
* Removed deprecated Logging API.
* Simplified locking mechanism and how to get and cache C4LogDomain objects in CBLLogSinks.cc.
* Updated tests.