### PR TITLE
CBL-7431 : Include native symbols in android released binaries

### DIFF
--- a/jenkins/ci_build_android.sh
+++ b/jenkins/ci_build_android.sh
@@ -81,7 +81,7 @@ function build_variant {
             -DEDITION=$EDITION \
 	    ..
 
-    ${NINJA} install/strip
+    ${NINJA} install
 }
 
 if [ "$EDITION" = "enterprise" ]; then


### PR DESCRIPTION
* CBL-C’s Unix CMake build already inherits the MinSizeRel flag overrides from LiteCore (see [this](https://github.com/couchbase/couchbase-lite-core/blob/master/cmake/platform_unix.cmake#L9-L16)), so no additional changes are required in CBL-C’s CMake.

* Do not strip the native symbols in the android released build script.

* The binary size increased by ~10×. After running `$objcopy --strip-debug libcblite.so`, the resulting libcblite.so is about the same size as the previously stripped binary. 

* Info from using file command :
   - Current Build :
      ```
      libcblite.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[sha1]=35b319272d06750e6ba9c054ebb6346178f0c7a1, with debug_info, not stripped 
      ```
   - Previous Build (Stripped):
      ```
      libcblite.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[sha1]=f039fddb0dafd77aed86eda795261d7f7886aa62, stripped
      ```