### PR TITLE
Add an option to skip running tests in Windows build script

### DIFF
--- a/jenkins/ci_build_unix.sh
+++ b/jenkins/ci_build_unix.sh
@@ -43,7 +43,7 @@ echo VERSION=${VERSION}
 
 ln -sf ${WORKSPACE}/couchbase-lite-c-ee/couchbase-lite-core-EE ${WORKSPACE}/couchbase-lite-c/vendor/couchbase-lite-core-EE
 
-if [[ ${EDITION} == 'enterprise'* ]]; then
+if [[ -z ${SKIP_TESTS} ]] && [[ ${EDITION} == 'enterprise'* ]]; then
     echo "==== Download Vector Search Extension for Tests  ==="
     pushd ${project_dir}
     if [[ $OSTYPE == 'darwin'* ]]; then

--- a/jenkins/ci_build_win_desktop.ps1
+++ b/jenkins/ci_build_win_desktop.ps1
@@ -100,13 +100,14 @@ $Build_Dir = "build_${Architecture}"
 Remove-Item -Recurse -Force -ErrorAction Ignore "${env:WORKSPACE}\${Build_Dir}\libcblite-${Version}"
 New-Item -Type Junction -Target ${env:WORKSPACE}/couchbase-lite-c-ee/couchbase-lite-core-EE -Path ${env:WORKSPACE}/couchbase-lite-c/vendor/couchbase-lite-core-EE
 
-if ("${Edition}" -eq "enterprise") {
+# Only download extension and run tests if enterprise edition AND SKIP_TESTS is not set
+if (($Edition -eq "enterprise") -and [string]::IsNullOrEmpty($env:SKIP_TESTS)) {
     DownloadVectorSearchExtension
 }
 
 Build "${env:WORKSPACE}\${Build_Dir}"
 
-if ("${Edition}" -eq "enterprise") {
+if (($Edition -eq "enterprise") -and [string]::IsNullOrEmpty($env:SKIP_TESTS)) {
     Run-UnitTest "${env:WORKSPACE}\${Build_Dir}"
 }
 


### PR DESCRIPTION
* Updated CI build script for windows to have an option to skip running tests using SKIP_TESTS env.

* Updated CI build script for unix platform to also skip downloading vector search extension when SKIP_TEST is enabled.

* This is a temporary workaround until build issue on vector search extension for windows is resolved.