### PR TITLE
CBL-7926 : Include C++ headers in iOS Framework

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -1873,7 +1873,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/scripts/copy_fleece_headers.sh\n";
+			shellScript = "\"${SRCROOT}/scripts/copy_fleece_headers.sh\"\n";
 		};
 		27DBD088246C94B2002FD7A7 /* Merge static libs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1975,7 +1975,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/scripts/copy_fleece_headers.sh\n";
+			shellScript = "\"${SRCROOT}/scripts/copy_fleece_headers.sh\"\n";
 		};
 		40B32FAE2E54034500D48F37 /* Copy CBL_Edition Header */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2013,7 +2013,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/scripts/rewrite_framework_header_includes.sh\n";
+			shellScript = "\"${SRCROOT}/scripts/rewrite_framework_header_includes.sh\"\n";
 		};
 		42F2DAB72655DC4B001C9EC3 /* Rewrite Framework Includes */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2031,7 +2031,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/scripts/rewrite_framework_header_includes.sh\n";
+			shellScript = "\"${SRCROOT}/scripts/rewrite_framework_header_includes.sh\"\n";
 		};
 		93D0AF88262557D200777AFC /* Generate CBL_Edition.h */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -75,13 +75,13 @@
 		27984E2E2249A240000FE777 /* CBLQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A3021CAC98F0045856E /* CBLQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27984E2F2249A240000FE777 /* CBLReplicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A2C21CAC98F0045856E /* CBLReplicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27984E302249A240000FE777 /* CBL_Compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A7021CAD6440045856E /* CBL_Compat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		27984E312249A247000FE777 /* CouchbaseLite.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE5021E6BC2100B60E3C /* CouchbaseLite.hh */; };
-		27984E322249A247000FE777 /* Base.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE3D21DEF0C700B60E3C /* Base.hh */; };
-		27984E332249A247000FE777 /* Blob.hh in Headers */ = {isa = PBXBuildFile; fileRef = 275BC4E22204E6A800DBE7D2 /* Blob.hh */; };
-		27984E342249A247000FE777 /* Database.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61DD821DEEC540027CCDB /* Database.hh */; };
-		27984E352249A247000FE777 /* Document.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4E21DEF54D00B60E3C /* Document.hh */; };
-		27984E362249A247000FE777 /* Query.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4F21E6AB1100B60E3C /* Query.hh */; };
-		27984E372249A247000FE777 /* Replicator.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C9B5F121F7D74A0040BC45 /* Replicator.hh */; };
+		27984E312249A247000FE777 /* CouchbaseLite.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE5021E6BC2100B60E3C /* CouchbaseLite.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E322249A247000FE777 /* Base.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE3D21DEF0C700B60E3C /* Base.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E332249A247000FE777 /* Blob.hh in Headers */ = {isa = PBXBuildFile; fileRef = 275BC4E22204E6A800DBE7D2 /* Blob.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E342249A247000FE777 /* Database.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61DD821DEEC540027CCDB /* Database.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E352249A247000FE777 /* Document.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4E21DEF54D00B60E3C /* Document.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E362249A247000FE777 /* Query.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4F21E6AB1100B60E3C /* Query.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E372249A247000FE777 /* Replicator.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C9B5F121F7D74A0040BC45 /* Replicator.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		27B61D5621D5ABA60027CCDB /* CBLQuery_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27B61D5521D5ABA60027CCDB /* CBLQuery_CAPI.cc */; };
 		27B61D6A21D6B60D0027CCDB /* CBLTest.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61D6821D6B60D0027CCDB /* CBLTest.hh */; };
 		27B61D7D21D6B66F0027CCDB /* libcblite-static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 271C2A2321CAC8920045856E /* libcblite-static.a */; };
@@ -106,7 +106,7 @@
 		400983562D07B8500029F26E /* CBLLogSinks_Internal.hh in Headers */ = {isa = PBXBuildFile; fileRef = 400983532D07B8500029F26E /* CBLLogSinks_Internal.hh */; };
 		4009839E2D0917BB0029F26E /* CBLLogSinks_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4009839D2D0917BB0029F26E /* CBLLogSinks_CAPI.cc */; };
 		400AB0512C2E669F00DB6223 /* VectorSearchTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 400AB0412C2E669500DB6223 /* VectorSearchTest_Cpp.cc */; };
-		400AB0532C2E66B500DB6223 /* QueryIndex.hh in Headers */ = {isa = PBXBuildFile; fileRef = 400AB0522C2E66B500DB6223 /* QueryIndex.hh */; };
+		400AB0532C2E66B500DB6223 /* QueryIndex.hh in Headers */ = {isa = PBXBuildFile; fileRef = 400AB0522C2E66B500DB6223 /* QueryIndex.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		4022546E29355577000FBAC8 /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 4022546D29355576000FBAC8 /* assets */; };
 		4022546F29355577000FBAC8 /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 4022546D29355576000FBAC8 /* assets */; };
 		4022547029355577000FBAC8 /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 4022546D29355576000FBAC8 /* assets */; };
@@ -125,8 +125,8 @@
 		408F030A2DAEC02500522748 /* CBLURLEndpointListener_Internal.hh in Headers */ = {isa = PBXBuildFile; fileRef = 408F03062DAEBB2F00522748 /* CBLURLEndpointListener_Internal.hh */; };
 		408F038A2DAEF90500522748 /* CBLTLSIdentity+Apple_stub.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1BF21B202D8E3ED0009534EC /* CBLTLSIdentity+Apple_stub.mm */; };
 		408F038B2DAEF90A00522748 /* CBLURLEndpointListener_stub.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BF21BBD2D9C5835009534EC /* CBLURLEndpointListener_stub.cc */; };
-		40ACB2392C2F98B200CBE8F2 /* Prediction.hh in Headers */ = {isa = PBXBuildFile; fileRef = 40ACB2382C2F20DA00CBE8F2 /* Prediction.hh */; };
-		40ACB23A2C2F98B600CBE8F2 /* VectorIndex.hh in Headers */ = {isa = PBXBuildFile; fileRef = 400AB0542C2E7AC300DB6223 /* VectorIndex.hh */; };
+		40ACB2392C2F98B200CBE8F2 /* Prediction.hh in Headers */ = {isa = PBXBuildFile; fileRef = 40ACB2382C2F20DA00CBE8F2 /* Prediction.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		40ACB23A2C2F98B600CBE8F2 /* VectorIndex.hh in Headers */ = {isa = PBXBuildFile; fileRef = 400AB0542C2E7AC300DB6223 /* VectorIndex.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32E922E53EA7900D48F37 /* dylib_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27B61D7E21D6B6900027CCDB /* dylib_main.cc */; };
 		40B32E942E53EA7900D48F37 /* libcblite-static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 271C2A2321CAC8920045856E /* libcblite-static.a */; };
 		40B32E952E53EA7900D48F37 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 275B3567234810C400FE9CF0 /* Foundation.framework */; };
@@ -172,33 +172,33 @@
 		40B32F872E54034500D48F37 /* CBLQueryIndexTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 406F8D802C17E3B4000223FC /* CBLQueryIndexTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F882E54034500D48F37 /* CBLBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A2D21CAC98F0045856E /* CBLBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F892E54034500D48F37 /* CBLBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 275BC4CC22012D8700DBE7D2 /* CBLBlob.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40B32F8A2E54034500D48F37 /* Prediction.hh in Headers */ = {isa = PBXBuildFile; fileRef = 40ACB2382C2F20DA00CBE8F2 /* Prediction.hh */; };
+		40B32F8A2E54034500D48F37 /* Prediction.hh in Headers */ = {isa = PBXBuildFile; fileRef = 40ACB2382C2F20DA00CBE8F2 /* Prediction.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F8B2E54034500D48F37 /* CBLDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A2E21CAC98F0045856E /* CBLDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40B32F8C2E54034500D48F37 /* Collection.hh in Headers */ = {isa = PBXBuildFile; fileRef = FCC064BD287CBD95000C5BD7 /* Collection.hh */; };
+		40B32F8C2E54034500D48F37 /* Collection.hh in Headers */ = {isa = PBXBuildFile; fileRef = FCC064BD287CBD95000C5BD7 /* Collection.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F8D2E54034500D48F37 /* CBLCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = FCD988AD2821B0F500512BBD /* CBLCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F8E2E54034500D48F37 /* CBLDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A2F21CAC98F0045856E /* CBLDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F8F2E54034500D48F37 /* URLEndpointListenerTest.hh in Headers */ = {isa = PBXBuildFile; fileRef = 1B49DBCF2DAF106F000F382E /* URLEndpointListenerTest.hh */; };
 		40B32F902E54034500D48F37 /* CBLQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A3021CAC98F0045856E /* CBLQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F912E54034500D48F37 /* CBLReplicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A2C21CAC98F0045856E /* CBLReplicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40B32F922E54034500D48F37 /* CouchbaseLite.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE5021E6BC2100B60E3C /* CouchbaseLite.hh */; };
+		40B32F922E54034500D48F37 /* CouchbaseLite.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE5021E6BC2100B60E3C /* CouchbaseLite.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F932E54034500D48F37 /* CBLPlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 9320630126BDB340006917A5 /* CBLPlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40B32F942E54034500D48F37 /* Base.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE3D21DEF0C700B60E3C /* Base.hh */; };
+		40B32F942E54034500D48F37 /* Base.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE3D21DEF0C700B60E3C /* Base.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F952E54034500D48F37 /* CBLQueryIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = 40FE2DC22C08245E005E99E9 /* CBLQueryIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F962E54034500D48F37 /* CBLPrediction.h in Headers */ = {isa = PBXBuildFile; fileRef = 4083FCB62BA3F6930061509D /* CBLPrediction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40B32F972E54034500D48F37 /* LogSinks.hh in Headers */ = {isa = PBXBuildFile; fileRef = 40E32F3F2D2F3ED4000CED57 /* LogSinks.hh */; };
+		40B32F972E54034500D48F37 /* LogSinks.hh in Headers */ = {isa = PBXBuildFile; fileRef = 40E32F3F2D2F3ED4000CED57 /* LogSinks.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F982E54034500D48F37 /* CBLEncryptable.h in Headers */ = {isa = PBXBuildFile; fileRef = 93C70CD226C4D3F20093E927 /* CBLEncryptable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F992E54034500D48F37 /* CBLTLSIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BF219B92D7F87E2009534EC /* CBLTLSIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40B32F9A2E54034500D48F37 /* VectorIndex.hh in Headers */ = {isa = PBXBuildFile; fileRef = 400AB0542C2E7AC300DB6223 /* VectorIndex.hh */; };
-		40B32F9B2E54034500D48F37 /* Blob.hh in Headers */ = {isa = PBXBuildFile; fileRef = 275BC4E22204E6A800DBE7D2 /* Blob.hh */; };
-		40B32F9C2E54034500D48F37 /* QueryIndex.hh in Headers */ = {isa = PBXBuildFile; fileRef = 400AB0522C2E66B500DB6223 /* QueryIndex.hh */; };
-		40B32F9D2E54034500D48F37 /* Database.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61DD821DEEC540027CCDB /* Database.hh */; };
+		40B32F9A2E54034500D48F37 /* VectorIndex.hh in Headers */ = {isa = PBXBuildFile; fileRef = 400AB0542C2E7AC300DB6223 /* VectorIndex.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		40B32F9B2E54034500D48F37 /* Blob.hh in Headers */ = {isa = PBXBuildFile; fileRef = 275BC4E22204E6A800DBE7D2 /* Blob.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		40B32F9C2E54034500D48F37 /* QueryIndex.hh in Headers */ = {isa = PBXBuildFile; fileRef = 400AB0522C2E66B500DB6223 /* QueryIndex.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		40B32F9D2E54034500D48F37 /* Database.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61DD821DEEC540027CCDB /* Database.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F9E2E54034500D48F37 /* CBLURLEndpointListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32F9F2E54034500D48F37 /* CBLScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FCD829B12835ECE0004AA814 /* CBLScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40B32FA02E54034500D48F37 /* Document.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4E21DEF54D00B60E3C /* Document.hh */; };
+		40B32FA02E54034500D48F37 /* Document.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4E21DEF54D00B60E3C /* Document.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32FA12E54034500D48F37 /* CBLLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 277B77C6245B44BE00B222D3 /* CBLLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32FA22E54034500D48F37 /* CBLQueryTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 406F8D6F2C17E191000223FC /* CBLQueryTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40B32FA32E54034500D48F37 /* Query.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4F21E6AB1100B60E3C /* Query.hh */; };
-		40B32FA42E54034500D48F37 /* Replicator.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C9B5F121F7D74A0040BC45 /* Replicator.hh */; };
+		40B32FA32E54034500D48F37 /* Query.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4F21E6AB1100B60E3C /* Query.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		40B32FA42E54034500D48F37 /* Replicator.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C9B5F121F7D74A0040BC45 /* Replicator.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B32FA62E54034500D48F37 /* dylib_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27B61D7E21D6B6900027CCDB /* dylib_main.cc */; };
 		40B32FA82E54034500D48F37 /* libcblite-static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 271C2A2321CAC8920045856E /* libcblite-static.a */; };
 		40B32FA92E54034500D48F37 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 275B3567234810C400FE9CF0 /* Foundation.framework */; };
@@ -210,8 +210,8 @@
 		40B32FBD2E54049800D48F37 /* libcblite.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 27B61D7021D6B64A0027CCDB /* libcblite.dylib */; };
 		40B330BF2E56925C00D48F37 /* libEnterpriseBits.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 40B330B82E5685FC00D48F37 /* libEnterpriseBits.a */; };
 		40B330C22E56927F00D48F37 /* libEnterpriseBits.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 40B330B82E5685FC00D48F37 /* libEnterpriseBits.a */; };
-		40D1862529B6D1A50061AA85 /* Collection.hh in Headers */ = {isa = PBXBuildFile; fileRef = FCC064BD287CBD95000C5BD7 /* Collection.hh */; };
-		40E32F402D2F3ED4000CED57 /* LogSinks.hh in Headers */ = {isa = PBXBuildFile; fileRef = 40E32F3F2D2F3ED4000CED57 /* LogSinks.hh */; };
+		40D1862529B6D1A50061AA85 /* Collection.hh in Headers */ = {isa = PBXBuildFile; fileRef = FCC064BD287CBD95000C5BD7 /* Collection.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		40E32F402D2F3ED4000CED57 /* LogSinks.hh in Headers */ = {isa = PBXBuildFile; fileRef = 40E32F3F2D2F3ED4000CED57 /* LogSinks.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		40E32F422D2F45A3000CED57 /* LogTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 40E32F412D2F45A3000CED57 /* LogTest_Cpp.cc */; };
 		40E32F432D2F45A3000CED57 /* LogTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 40E32F412D2F45A3000CED57 /* LogTest_Cpp.cc */; };
 		40E32F442D2F45A3000CED57 /* LogTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 40E32F412D2F45A3000CED57 /* LogTest_Cpp.cc */; };
@@ -1427,10 +1427,10 @@
 				27984E052249A126000FE777 /* Headers */,
 				27984E062249A126000FE777 /* Sources */,
 				27984E072249A126000FE777 /* Frameworks */,
-				27984E382249A36A000FE777 /* Copy Fleece Headers */,
-				93D0AFB626255E7300777AFC /* Copy CBL_Editionh */,
 				40F902D72B9F7B09002EA0A0 /* Resources */,
-				42F2DAB72655DC4B001C9EC3 /* Fix Header References */,
+				27984E382249A36A000FE777 /* Copy Fleece Headers */,
+				93D0AFB626255E7300777AFC /* Copy CBL_Edition Header */,
+				42F2DAB72655DC4B001C9EC3 /* Rewrite Framework Includes */,
 			);
 			buildRules = (
 			);
@@ -1526,10 +1526,10 @@
 				40B32F822E54034500D48F37 /* Headers */,
 				40B32FA52E54034500D48F37 /* Sources */,
 				40B32FA72E54034500D48F37 /* Frameworks */,
-				40B32FAD2E54034500D48F37 /* Copy Fleece Headers */,
-				40B32FAE2E54034500D48F37 /* Copy CBL_Editionh */,
 				40B32FAF2E54034500D48F37 /* Resources */,
-				40B32FB12E54034500D48F37 /* Fix Header References */,
+				40B32FAD2E54034500D48F37 /* Copy Fleece Headers */,
+				40B32FAE2E54034500D48F37 /* Copy CBL_Edition Header */,
+				40B32FB12E54034500D48F37 /* Rewrite Framework Includes */,
 			);
 			buildRules = (
 			);
@@ -1865,7 +1865,6 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"vendor/couchbase-lite-core/vendor/fleece/API/fleece/*",
 			);
 			name = "Copy Fleece Headers";
 			outputFileListPaths = (
@@ -1874,7 +1873,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n# Copy Fleece Headers:\ncp -R vendor/couchbase-lite-core/vendor/fleece/API/fleece/ \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\n\n# Remove C++ Headers (Go to the folder to workaroud rm cmd issue with path including spaces): \npushd \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\nrm -f *.hh\n";
+			shellScript = "${SRCROOT}/scripts/copy_fleece_headers.sh\n";
 		};
 		27DBD088246C94B2002FD7A7 /* Merge static libs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1968,7 +1967,6 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"vendor/couchbase-lite-core/vendor/fleece/API/fleece/*",
 			);
 			name = "Copy Fleece Headers";
 			outputFileListPaths = (
@@ -1977,9 +1975,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n# Copy Fleece Headers:\ncp -R vendor/couchbase-lite-core/vendor/fleece/API/fleece/ \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\n\n# Remove C++ Headers (Go to the folder to workaroud rm cmd issue with path including spaces): \npushd \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\nrm -f *.hh\n";
+			shellScript = "${SRCROOT}/scripts/copy_fleece_headers.sh\n";
 		};
-		40B32FAE2E54034500D48F37 /* Copy CBL_Editionh */ = {
+		40B32FAE2E54034500D48F37 /* Copy CBL_Edition Header */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1989,7 +1987,7 @@
 			inputPaths = (
 				"$(DERIVED_FILE_DIR)/CBL_Edition.h",
 			);
-			name = "Copy CBL_Editionh";
+			name = "Copy CBL_Edition Header";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -1999,7 +1997,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\ncp \"$SCRIPT_INPUT_FILE_0\" \"$SCRIPT_OUTPUT_FILE_0\"\n";
 		};
-		40B32FB12E54034500D48F37 /* Fix Header References */ = {
+		40B32FB12E54034500D48F37 /* Rewrite Framework Includes */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2008,16 +2006,16 @@
 			);
 			inputPaths = (
 			);
-			name = "Fix Header References";
+			name = "Rewrite Framework Includes";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\npushd \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\n\nsed -i '' 's/#include \"fleece\\/\\(.*\\)\"/#include <CouchbaseLite\\/\\1>/' * \nsed -i '' 's/#include \"CBL\\(.*\\)\"/#include <CouchbaseLite\\/CBL\\1>/' *\nsed -i '' 's/#include \"FL\\(.*\\)\"/#include <CouchbaseLite\\/FL\\1>/' *\nsed -i '' 's/#include \"CompilerSupport.h\"/#include <CouchbaseLite\\/CompilerSupport.h>/' *\nsed -i '' 's/#.*include \"Fleece+CoreFoundation.h\"/#include <CouchbaseLite\\/Fleece+CoreFoundation.h>/' * \n";
+			shellScript = "${SRCROOT}/scripts/rewrite_framework_header_includes.sh\n";
 		};
-		42F2DAB72655DC4B001C9EC3 /* Fix Header References */ = {
+		42F2DAB72655DC4B001C9EC3 /* Rewrite Framework Includes */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2026,14 +2024,14 @@
 			);
 			inputPaths = (
 			);
-			name = "Fix Header References";
+			name = "Rewrite Framework Includes";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\npushd \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/\"\n\nsed -i '' 's/#include \"fleece\\/\\(.*\\)\"/#include <CouchbaseLite\\/\\1>/' * \nsed -i '' 's/#include \"CBL\\(.*\\)\"/#include <CouchbaseLite\\/CBL\\1>/' *\nsed -i '' 's/#include \"FL\\(.*\\)\"/#include <CouchbaseLite\\/FL\\1>/' *\nsed -i '' 's/#include \"CompilerSupport.h\"/#include <CouchbaseLite\\/CompilerSupport.h>/' *\nsed -i '' 's/#.*include \"Fleece+CoreFoundation.h\"/#include <CouchbaseLite\\/Fleece+CoreFoundation.h>/' * \n";
+			shellScript = "${SRCROOT}/scripts/rewrite_framework_header_includes.sh\n";
 		};
 		93D0AF88262557D200777AFC /* Generate CBL_Edition.h */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2075,7 +2073,7 @@
 			shellPath = /bin/sh;
 			shellScript = "source \"$SCRIPT_INPUT_FILE_0\" \"$SCRIPT_OUTPUT_FILE_0\"\n";
 		};
-		93D0AFB626255E7300777AFC /* Copy CBL_Editionh */ = {
+		93D0AFB626255E7300777AFC /* Copy CBL_Edition Header */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2085,7 +2083,7 @@
 			inputPaths = (
 				"$(DERIVED_FILE_DIR)/CBL_Edition.h",
 			);
-			name = "Copy CBL_Editionh";
+			name = "Copy CBL_Edition Header";
 			outputFileListPaths = (
 			);
 			outputPaths = (

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -26,7 +26,7 @@
 #include <utility>
 
 #if DEBUG
-#   include "cbl/CBLLog.h"
+#include "cbl/CBLLog.h"
 #endif
 
 // VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in

--- a/scripts/copy_fleece_headers.sh
+++ b/scripts/copy_fleece_headers.sh
@@ -6,9 +6,9 @@
 set -e
 
 # Copy Fleece Headers:
-cp -R vendor/couchbase-lite-core/vendor/fleece/API/fleece/ "$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/"
+cp vendor/couchbase-lite-core/vendor/fleece/API/fleece/* "$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/"
 
 # Remove internal headers:
-pushd "$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/"
+cd "$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/"
 rm -f FLExpert.h
 rm -f Expert.hh

--- a/scripts/copy_fleece_headers.sh
+++ b/scripts/copy_fleece_headers.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Copies Fleece public headers into the framework's Headers/ directory,
+# filtering out internal headers that shouldn't be exposed.
+
+set -e
+
+# Copy Fleece Headers:
+cp -R vendor/couchbase-lite-core/vendor/fleece/API/fleece/ "$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/"
+
+# Remove internal headers:
+pushd "$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/"
+rm -f FLExpert.h
+rm -f Expert.hh

--- a/scripts/rewrite_framework_header_includes.sh
+++ b/scripts/rewrite_framework_header_includes.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Rewrites quoted #include directives in the framework's public headers
+# to use framework-style angle-bracket includes.
+# e.g., #include "fleece/FLSlice.h" → #include <CouchbaseLite/FLSlice.h>
+
+set -e
+
+pushd "$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/"
+
+sed -i '' -E 's/#include "([^"]*\/)?([^"]+)"/#include <CouchbaseLite\/\2>/' *

--- a/scripts/rewrite_framework_header_includes.sh
+++ b/scripts/rewrite_framework_header_includes.sh
@@ -6,6 +6,6 @@
 
 set -e
 
-pushd "$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/"
+cd "$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/"
 
 sed -i '' -E 's/#include "([^"]*\/)?([^"]+)"/#include <CouchbaseLite\/\2>/' *


### PR DESCRIPTION
* Made CBL C++ headers avaiable as the public headers.

* Updated the scripts that copy Fleece headers to include C++ headers and filtered out the expert headers.

* Extracted the scripts that copy and rewrite include paths into their own script files and updated the build phrase that build the framework accordingly.