### PR TITLE
CBL-7980 : Implement Correlation ID API

### DIFF
--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -380,7 +380,12 @@ namespace cbl {
 
         /** Returns the replicator's current status. */
         CBLReplicatorStatus status() const  {return CBLReplicator_Status(ref());}
-        
+
+        /** Returns the ID used to correlate the replication session with the remote endpoint.
+            This value is intended for logging and diagnostics, and is an empty string until the
+            replicator receives a correlation ID from the remote endpoint. */
+        std::string correlationID() const  {return asString(CBLReplicator_CorrelationID(ref()));}
+
         /** Indicates which documents in the given collection have local changes that have not yet been
             pushed to the server by this replicator. This is of course a snapshot, that will go out of date
             as the replicator makes progress and/or documents are saved locally.

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -433,7 +433,7 @@ typedef CBL_ENUM(uint8_t, CBLReplicatorActivityLevel) {
     accurate would require slowing down the replicator and incurring more load on the server.
     It's fine to use in a progress bar, though. */
 typedef struct {
-    float complete;             ///<Very-approximate fractional completion, from 0.0 to 1.0
+    float complete;             ///< Very-approximate fractional completion, from 0.0 to 1.0
     uint64_t documentCount;     ///< Number of documents transferred so far
 } CBLReplicatorProgress;
 
@@ -447,10 +447,18 @@ typedef struct {
 /** Returns the replicator's current status. */
 CBLReplicatorStatus CBLReplicator_Status(CBLReplicator*) CBLAPI;
 
+/** Returns the ID used to correlate the replication session with the remote endpoint.
+    This value is intended for logging and diagnostics, and is a null slice until the
+    replicator receives a correlation ID from the remote endpoint.
+    @note You are responsible for releasing the result by calling \ref FLSliceResult_Release.
+    @return The correlation ID, or a null slice if unavailable. */
+_cbl_warn_unused
+FLStringResult CBLReplicator_CorrelationID(CBLReplicator*) CBLAPI;
+
 /** Indicates which documents in the given collection have local changes that have not yet been
     pushed to the server by this replicator. This is of course a snapshot, that will go out of date
     as the replicator makes progress and/or documents are saved locally.
-    
+
     The result is, effectively, a set of document IDs: a dictionary whose keys are the IDs and
     values are `true`.
     If there are no pending documents, the dictionary is empty.

--- a/src/CBLReplicator_CAPI.cc
+++ b/src/CBLReplicator_CAPI.cc
@@ -86,6 +86,10 @@ CBLReplicatorStatus CBLReplicator_Status(CBLReplicator* repl) noexcept {
     return repl->status();
 }
 
+FLStringResult CBLReplicator_CorrelationID(CBLReplicator* repl) noexcept {
+    return FLStringResult(repl->correlationID());
+}
+
 void CBLReplicator_Start(CBLReplicator* repl, bool reset) noexcept        {repl->start(reset);}
 void CBLReplicator_Stop(CBLReplicator* repl) noexcept                     {repl->stop();}
 void CBLReplicator_SetHostReachable(CBLReplicator* repl, bool r) noexcept {repl->setHostReachable(r);}

--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -288,6 +288,10 @@ public:
     slice getUserAgent() const {
         return _conf.getUserAgent();
     }
+
+    alloc_slice correlationID() const {
+        return _c4repl->correlationID();
+    }
     
     std::string desc() const {
         return _desc;

--- a/src/exports/CBL_Exports.txt
+++ b/src/exports/CBL_Exports.txt
@@ -196,6 +196,7 @@ CBLReplicator_Stop
 CBLReplicator_SetHostReachable
 CBLReplicator_SetSuspended
 CBLReplicator_Status
+CBLReplicator_CorrelationID
 CBLReplicator_PendingDocumentIDs
 CBLReplicator_PendingDocumentIDs2
 CBLReplicator_IsDocumentPending

--- a/src/exports/generated/CBL.def
+++ b/src/exports/generated/CBL.def
@@ -141,6 +141,7 @@ CBLReplicator_Stop
 CBLReplicator_SetHostReachable
 CBLReplicator_SetSuspended
 CBLReplicator_Status
+CBLReplicator_CorrelationID
 CBLReplicator_PendingDocumentIDs
 CBLReplicator_PendingDocumentIDs2
 CBLReplicator_IsDocumentPending

--- a/src/exports/generated/CBL.exp
+++ b/src/exports/generated/CBL.exp
@@ -149,6 +149,7 @@ _CBLReplicator_Stop
 _CBLReplicator_SetHostReachable
 _CBLReplicator_SetSuspended
 _CBLReplicator_Status
+_CBLReplicator_CorrelationID
 _CBLReplicator_PendingDocumentIDs
 _CBLReplicator_PendingDocumentIDs2
 _CBLReplicator_IsDocumentPending

--- a/src/exports/generated/CBL.gnu
+++ b/src/exports/generated/CBL.gnu
@@ -139,6 +139,7 @@ CBL_C {
 		CBLReplicator_SetHostReachable;
 		CBLReplicator_SetSuspended;
 		CBLReplicator_Status;
+		CBLReplicator_CorrelationID;
 		CBLReplicator_PendingDocumentIDs;
 		CBLReplicator_PendingDocumentIDs2;
 		CBLReplicator_IsDocumentPending;

--- a/src/exports/generated/CBL_Android.gnu
+++ b/src/exports/generated/CBL_Android.gnu
@@ -140,6 +140,7 @@ CBL_C {
 		CBLReplicator_SetHostReachable;
 		CBLReplicator_SetSuspended;
 		CBLReplicator_Status;
+		CBLReplicator_CorrelationID;
 		CBLReplicator_PendingDocumentIDs;
 		CBLReplicator_PendingDocumentIDs2;
 		CBLReplicator_IsDocumentPending;

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -235,6 +235,7 @@ CBLReplicator_Stop
 CBLReplicator_SetHostReachable
 CBLReplicator_SetSuspended
 CBLReplicator_Status
+CBLReplicator_CorrelationID
 CBLReplicator_PendingDocumentIDs
 CBLReplicator_PendingDocumentIDs2
 CBLReplicator_IsDocumentPending

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -244,6 +244,7 @@ _CBLReplicator_Stop
 _CBLReplicator_SetHostReachable
 _CBLReplicator_SetSuspended
 _CBLReplicator_Status
+_CBLReplicator_CorrelationID
 _CBLReplicator_PendingDocumentIDs
 _CBLReplicator_PendingDocumentIDs2
 _CBLReplicator_IsDocumentPending

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -230,6 +230,7 @@ CBL_C {
 		CBLReplicator_SetHostReachable;
 		CBLReplicator_SetSuspended;
 		CBLReplicator_Status;
+		CBLReplicator_CorrelationID;
 		CBLReplicator_PendingDocumentIDs;
 		CBLReplicator_PendingDocumentIDs2;
 		CBLReplicator_IsDocumentPending;

--- a/src/exports/generated/CBL_EE_Android.gnu
+++ b/src/exports/generated/CBL_EE_Android.gnu
@@ -231,6 +231,7 @@ CBL_C {
 		CBLReplicator_SetHostReachable;
 		CBLReplicator_SetSuspended;
 		CBLReplicator_Status;
+		CBLReplicator_CorrelationID;
 		CBLReplicator_PendingDocumentIDs;
 		CBLReplicator_PendingDocumentIDs2;
 		CBLReplicator_IsDocumentPending;

--- a/test/ReplicatorCollectionTest.cc
+++ b/test/ReplicatorCollectionTest.cc
@@ -837,4 +837,44 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Collection Document Pending", "[Repl
     CHECK(CBLReplicator_IsDocumentPending(repl, "bar1"_sl, cx[1], &error));
 }
 
+// Note: This test is not an ideal fit for ReplicatorCollectionTest, but it is the best available location for now.
+// TODO: Restructure the replicator tests so both the C and C++ APIs can be tested.
+//
+// Spec: https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0013-CorrelationID.md
+//
+// 1. TestGetCorrelationID
+//
+// Description:
+//   Test get the correlation id from the replicator.
+//   Note: Alternatively this test can be tested DatabaseEndpoint.
+//
+// Steps:
+//   1. Start a URLEndpointListener.
+//   2. Creates a replicator with an endpoint connecting the URLEndpointListener.
+//        - Continuous: No
+//        - Type: Push-and-Pull
+//   3. Gets the correlationID and checks that the value is null.
+//   4. Starts the replicator and wait until the replicator stopped.
+//   5. Gets the correlationID and checks that the value is not null or empty.
+//
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Correlation ID", "[Replicator]") {
+    auto cols = collectionConfigs({cx[0], cx[1]});
+    config.collections = cols.data();
+    config.collectionCount = cols.size();
+    config.replicatorType = kCBLReplicatorTypePushAndPull;
+    
+    CBLError error {};
+    repl = CBLReplicator_Create(&config, &error);
+    
+    FLStringResult correlationID = CBLReplicator_CorrelationID(repl);
+    CHECK(correlationID == kFLSliceNull);
+    FLSliceResult_Release(correlationID);
+    
+    replicate();
+    
+    correlationID = CBLReplicator_CorrelationID(repl);
+    CHECK(correlationID != kFLSliceNull);
+    FLSliceResult_Release(correlationID);
+}
+
 #endif

--- a/test/ReplicatorCollectionTest_Cpp.cc
+++ b/test/ReplicatorCollectionTest_Cpp.cc
@@ -21,7 +21,6 @@
 #include "fleece/Mutable.hh"
 #include <string>
 #include <chrono>
-//#include <iostream>
 #include <thread>
 
 #include "cbl++/CouchbaseLite.hh"
@@ -579,6 +578,38 @@ TEST_CASE_METHOD(ReplicatorCollectionTest_Cpp, "C++ Pending Documents with Colle
     
     CHECK(!repl.isDocumentPending("foo1", col));
     CHECK(!repl.isDocumentPending("foo2", col));
+}
+
+// Note: This test is not an ideal fit for ReplicatorCollectionTest_Cpp, but it is the best available location for now.
+// TODO: Restructure the replicator tests so both the C and C++ APIs can be tested.
+//
+// Spec: https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0013-CorrelationID.md
+//
+// 1. TestGetCorrelationID
+//
+// Description:
+//   Test get the correlation id from the replicator.
+//   Note: Alternatively this test can be tested DatabaseEndpoint.
+//
+// Steps:
+//   1. Start a URLEndpointListener.
+//   2. Creates a replicator with an endpoint connecting the URLEndpointListener.
+//        - Continuous: No
+//        - Type: Push-and-Pull
+//   3. Gets the correlationID and checks that the value is null.
+//   4. Starts the replicator and wait until the replicator stopped.
+//   5. Gets the correlationID and checks that the value is not null or empty.
+//
+TEST_CASE_METHOD(ReplicatorCollectionTest_Cpp, "C++ Correlation ID", "[Replicator]") {
+    createConfigWithCollections({cx[0], cx[1]});
+    config.replicatorType = kCBLReplicatorTypePushAndPull;
+    repl = Replicator(config);
+    
+    CHECK(repl.correlationID().empty());
+    
+    replicate();
+    
+    CHECK(!repl.correlationID().empty());
 }
 
 #endif


### PR DESCRIPTION
- Added correlationID property to replicator both C and C++ API. The correlation ID is used for correlating the replication session with remote endpoint’s session (e.g. Sync Gateway).

- Added a test using DatabaseEndpoint, which is good enough to test the API from the binding perspective.