### PR TITLE
CBL-7132 : Fix LogSink API doc header

### DIFF
--- a/include/cbl/CBLLog.h
+++ b/include/cbl/CBLLog.h
@@ -22,7 +22,7 @@
 
 CBL_CAPI_BEGIN
 
-/** \defgroup logging_deprecated   Logging (Deprecated)
+/** \defgroup logging   Logging
      @{
     Managing messages that Couchbase Lite logs at runtime.
  */

--- a/include/cbl/CBLLogSinks.h
+++ b/include/cbl/CBLLogSinks.h
@@ -21,7 +21,7 @@
 
 CBL_CAPI_BEGIN
 
-/** \defgroup logging   Logging (Deprecated)
+/** \defgroup LogSinks   LogSinks
      @{
      Manages Couchbase Lite logging configuration, with three log sinks:
      - **Console Log Sink**: Enabled by default at the **warning** level for all domains.


### PR DESCRIPTION
* The header should be LogSinks instead Logging and shouldn’t be marked as deprecated.

* Removed deprecated from Logging header to avoid confusion in the future if we add a new non-deprecated methods in that section.

* This is a direct port (963ad65) from release/4.0 branch.