### PR TITLE
CBL-7983: Standardize C++ API

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1B21A7D92D711B29000CA0D5 /* URLEndpointListenerTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B21A7D82D711B29000CA0D5 /* URLEndpointListenerTest.cc */; };
 		1B21A7DA2D711B29000CA0D5 /* URLEndpointListenerTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B21A7D82D711B29000CA0D5 /* URLEndpointListenerTest.cc */; };
 		1B21A7DB2D711B29000CA0D5 /* URLEndpointListenerTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B21A7D82D711B29000CA0D5 /* URLEndpointListenerTest.cc */; };
+		1B4D22B52FAE496B005E24FA /* Encryptable.hh in Headers */ = {isa = PBXBuildFile; fileRef = 1B4D22B42FAE496B005E24FA /* Encryptable.hh */; };
+		1B4D22B62FAE496B005E24FA /* Encryptable.hh in Headers */ = {isa = PBXBuildFile; fileRef = 1B4D22B42FAE496B005E24FA /* Encryptable.hh */; };
 		1B7694AC2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */; };
 		1B7694AD2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */; };
 		1B7694AE2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */; };
@@ -17,6 +19,10 @@
 		1BC5D9602D6E3BD10080153E /* CBLURLEndpointListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1BC5D9612D6E3BD10080153E /* CBLURLEndpointListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1BC5D9662D6E4DA60080153E /* CBLURLEndpointListener_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BC5D9652D6E4DA60080153E /* CBLURLEndpointListener_CAPI.cc */; };
+		1BDEBBF22FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */; };
+		1BDEBBF32FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */; };
+		1BDEBBF42FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */; };
+		1BDEBBF52FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */; };
 		1BF219BA2D7F87E2009534EC /* CBLTLSIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BF219B92D7F87E2009534EC /* CBLTLSIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1BF219BB2D7F87E2009534EC /* CBLTLSIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BF219B92D7F87E2009534EC /* CBLTLSIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1BF219C02D7F930F009534EC /* CBLTLSIdentity_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BF219BF2D7F930F009534EC /* CBLTLSIdentity_CAPI.cc */; };
@@ -555,10 +561,12 @@
 /* Begin PBXFileReference section */
 		1B21A7D82D711B29000CA0D5 /* URLEndpointListenerTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = URLEndpointListenerTest.cc; sourceTree = "<group>"; };
 		1B49DBCF2DAF106F000F382E /* URLEndpointListenerTest.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = URLEndpointListenerTest.hh; sourceTree = "<group>"; };
+		1B4D22B42FAE496B005E24FA /* Encryptable.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Encryptable.hh; sourceTree = "<group>"; };
 		1B7694AA2DA07261006EEEAB /* TLSIdentityTest.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TLSIdentityTest.hh; sourceTree = "<group>"; };
 		1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "TLSIdentityTest+Apple.mm"; sourceTree = "<group>"; };
 		1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLURLEndpointListener.h; sourceTree = "<group>"; };
 		1BC5D9652D6E4DA60080153E /* CBLURLEndpointListener_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLURLEndpointListener_CAPI.cc; sourceTree = "<group>"; };
+		1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EncryptableTest_Cpp.cc; sourceTree = "<group>"; };
 		1BF219B92D7F87E2009534EC /* CBLTLSIdentity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLTLSIdentity.h; sourceTree = "<group>"; };
 		1BF219BF2D7F930F009534EC /* CBLTLSIdentity_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLTLSIdentity_CAPI.cc; sourceTree = "<group>"; };
 		1BF21A3C2D84E419009534EC /* TLSIdentityTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TLSIdentityTest.cc; sourceTree = "<group>"; };
@@ -1047,6 +1055,7 @@
 				FCC064BD287CBD95000C5BD7 /* Collection.hh */,
 				27B61DD821DEEC540027CCDB /* Database.hh */,
 				277FEE4E21DEF54D00B60E3C /* Document.hh */,
+				1B4D22B42FAE496B005E24FA /* Encryptable.hh */,
 				40E32F3F2D2F3ED4000CED57 /* LogSinks.hh */,
 				40ACB2382C2F20DA00CBE8F2 /* Prediction.hh */,
 				277FEE4F21E6AB1100B60E3C /* Query.hh */,
@@ -1077,6 +1086,7 @@
 				277FEE5221E6BCA500B60E3C /* DatabaseTest_Cpp.cc */,
 				FCC063F2285BA641000C5BD7 /* DocumentTest.cc */,
 				FC0907E628AD763600201B07 /* DocumentTest_Cpp.cc */,
+				1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */,
 				93965A6226A7CD50008728EE /* LogTest.cc */,
 				40E32F412D2F45A3000CED57 /* LogTest_Cpp.cc */,
 				275B359D234D064600FE9CF0 /* QueryTest.cc */,
@@ -1296,6 +1306,7 @@
 				1BC5D9612D6E3BD10080153E /* CBLURLEndpointListener.h in Headers */,
 				FCC064212862B851000C5BD7 /* CBLScope.h in Headers */,
 				27984E352249A247000FE777 /* Document.hh in Headers */,
+				1B4D22B62FAE496B005E24FA /* Encryptable.hh in Headers */,
 				27DBD0A9246CA667002FD7A7 /* CBLLog.h in Headers */,
 				405D4F8E2C34714F00221516 /* CBLQueryTypes.h in Headers */,
 				27984E362249A247000FE777 /* Query.hh in Headers */,
@@ -1351,6 +1362,7 @@
 				40B32F9E2E54034500D48F37 /* CBLURLEndpointListener.h in Headers */,
 				40B32F9F2E54034500D48F37 /* CBLScope.h in Headers */,
 				40B32FA02E54034500D48F37 /* Document.hh in Headers */,
+				1B4D22B52FAE496B005E24FA /* Encryptable.hh in Headers */,
 				40B32FA12E54034500D48F37 /* CBLLog.h in Headers */,
 				40B32FA22E54034500D48F37 /* CBLQueryTypes.h in Headers */,
 				40B32FA32E54034500D48F37 /* Query.hh in Headers */,
@@ -2169,6 +2181,7 @@
 				FC645E2E29088211007D5536 /* Platform_Apple.mm in Sources */,
 				1B7694AC2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */,
 				2736A635242E5A74002B9D65 /* ReplicatorEETest.cc in Sources */,
+				1BDEBBF32FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */,
 				93C70D3526D01B5A0093E927 /* BlobTest.cc in Sources */,
 				FC0907E828AD763600201B07 /* DocumentTest_Cpp.cc in Sources */,
 				FC09077C28A5F3EF00201B07 /* CollectionTest_Cpp.cc in Sources */,
@@ -2221,6 +2234,7 @@
 				1B7694AD2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */,
 				27B61DB921D6ECA70027CCDB /* DatabaseTest.cc in Sources */,
 				1BF21A3F2D84E419009534EC /* TLSIdentityTest.cc in Sources */,
+				1BDEBBF42FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */,
 				277FEE5321E6BCA500B60E3C /* DatabaseTest_Cpp.cc in Sources */,
 				FC8678F2289C69690023F34F /* ReplicatorCollectionTest.cc in Sources */,
 				93C70D1826CB535D0093E927 /* ReplicatorPropEncTest.cc in Sources */,
@@ -2265,6 +2279,7 @@
 				40B32EEF2E53EAF600D48F37 /* TLSIdentityTest+Apple.mm in Sources */,
 				40B32EF02E53EAF600D48F37 /* DatabaseTest.cc in Sources */,
 				40B32EF12E53EAF600D48F37 /* TLSIdentityTest.cc in Sources */,
+				1BDEBBF22FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */,
 				40B32EF22E53EAF600D48F37 /* DatabaseTest_Cpp.cc in Sources */,
 				40B32EF32E53EAF600D48F37 /* ReplicatorCollectionTest.cc in Sources */,
 				40B32EF42E53EAF600D48F37 /* ReplicatorPropEncTest.cc in Sources */,
@@ -2315,6 +2330,7 @@
 				FC645E1229085C2E007D5536 /* CollectionTest_Cpp.cc in Sources */,
 				1B21A7D92D711B29000CA0D5 /* URLEndpointListenerTest.cc in Sources */,
 				FC645E2C29087777007D5536 /* Platform_Apple.mm in Sources */,
+				1BDEBBF52FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */,
 				FC645E0E29085C05007D5536 /* CollectionTest.cc in Sources */,
 				FC645E1B29085C87007D5536 /* ReplicatorEETest.cc in Sources */,
 				FC645E1C29085C89007D5536 /* ReplicatorPropEncTest.cc in Sources */,

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -97,11 +97,11 @@ namespace cbl {
         int            code;           ///< Error code, specific to the domain. 0 always means no error.
     };
 
-    struct Base {
-        static std::string asString(FLSlice s)          {return slice(s).asString();}
-        static std::string asString(FLSliceResult &&s)  {return alloc_slice(s).asString();}
+    namespace internal {
+        inline std::string asString(FLSlice s)          {return slice(s).asString();}
+        inline std::string asString(FLSliceResult &&s)  {return alloc_slice(s).asString();}
 
-        static void check(bool ok, CBLError &error) {
+        inline void check(bool ok, CBLError &error) {
             if (!ok) {
                 alloc_slice message = CBLError_Message(&error);
 #if DEBUG
@@ -111,7 +111,7 @@ namespace cbl {
                 throw cbl::Error{error.domain, error.code, message.asString()};
             }
         }
-    };
+    }
 
 // Internal use only: Copy/move ctors and assignment ops that have to be declared in subclasses
 #define CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE(CLASS, SUPER, C_TYPE) \

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -93,7 +93,7 @@ namespace cbl {
         , domain(domain)
         , code(code)
         {}
-        CBLErrorDomain domain;         ///< Domain of errors; a namespace for the `code`.
+        CBLErrorDomain domain;         ///< Domain of errors.
         int            code;           ///< Error code, specific to the domain. 0 always means no error.
     };
 

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -101,6 +101,15 @@ namespace cbl {
         , domain(domain)
         , code(code)
         {}
+        Error()
+        : std::runtime_error("")
+        {}
+        Error& operator=(const Error& other) {
+            std::runtime_error::operator=(other);
+            domain = other.domain;
+            code   = other.code;
+            return *this;
+        }
         CBLErrorDomain domain;         ///< Domain of errors.
         int            code;           ///< Error code, specific to the domain. 0 always means no error.
     };

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -23,6 +23,7 @@
 #include <functional>
 #include <cassert>
 #include <memory>
+#include <stdexcept>
 #include <utility>
 
 #if DEBUG
@@ -72,27 +73,44 @@ namespace cbl {
         }
 
         void clear()                                    {CBL_Release(_ref); _ref = nullptr;}
-        bool valid() const                              {return _ref != nullptr;} \
-        explicit operator bool() const                  {return valid();} \
-
-        static std::string asString(FLSlice s)          {return slice(s).asString();}
-        static std::string asString(FLSliceResult &&s)  {return alloc_slice(s).asString();}
-
-        static void check(bool ok, CBLError &error) {
-            if (!ok) {
-#if DEBUG
-                alloc_slice message = CBLError_Message(&error);
-                CBL_Log(kCBLLogDomainDatabase, kCBLLogError, "API returning error %d/%d: %.*s",
-                        error.domain, error.code, (int)message.size, (char*)message.buf);
-#endif
-                throw error;
-            }
-        }
+        bool valid() const                              {return _ref != nullptr;}
+        explicit operator bool() const                  {return valid();}
 
         CBLRefCounted* _cbl_nullable _ref;
 
         friend class Extension;
         friend class Transaction;
+    };
+
+    /** The exception thrown by the Couchbase Lite C++ API to report a Couchbase Lite failure.
+        It derives from `std::runtime_error` (and thus `std::exception`) and carries the
+        failure's \ref domain and \ref code (the same values as the C API's `CBLError`), plus a
+        human-readable message available via `what()`. Catch this type when you need the
+        structured error information; catch `std::exception` for general handling. */
+    struct Error: std::runtime_error {
+        Error(CBLErrorDomain domain, int code, const std::string& what)
+        : std::runtime_error(what)
+        , domain(domain)
+        , code(code)
+        {}
+        CBLErrorDomain domain;         ///< Domain of errors; a namespace for the `code`.
+        int            code;           ///< Error code, specific to the domain. 0 always means no error.
+    };
+
+    struct Base {
+        static std::string asString(FLSlice s)          {return slice(s).asString();}
+        static std::string asString(FLSliceResult &&s)  {return alloc_slice(s).asString();}
+
+        static void check(bool ok, CBLError &error) {
+            if (!ok) {
+                alloc_slice message = CBLError_Message(&error);
+#if DEBUG
+                CBL_Log(kCBLLogDomainDatabase, kCBLLogError, "API returning error %d/%d: %.*s",
+                        error.domain, error.code, (int)message.size, (char*)message.buf);
+#endif
+                throw cbl::Error{error.domain, error.code, message.asString()};
+            }
+        }
     };
 
 // Internal use only: Copy/move ctors and assignment ops that have to be declared in subclasses

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -106,6 +106,8 @@ namespace cbl {
         {}
         Error()
         : std::runtime_error("")
+        , domain(kCBLDomain)
+        , code(0)
         {}
         Error& operator=(const Error& other) {
             std::runtime_error::operator=(other);
@@ -157,7 +159,7 @@ public: \
     /** A token representing a registered listener; instances are returned from the various
         methods that register listeners, such as \ref Database::addListener.
         When this object goes out of scope, the listener will be unregistered.
-        @note ListenerToken is now allowed to copy. */
+        @note ListenerToken is not allowed to copy. */
     template <class... Args>
     class ListenerToken {
     public:

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -18,6 +18,7 @@
 
 #pragma once
 #include "cbl/CBLBase.h"
+#include "cbl/CBLQueryTypes.h"
 #include "fleece/slice.hh"
 #include <algorithm>
 #include <functional>
@@ -50,6 +51,8 @@ namespace cbl {
     using slice = fleece::slice;
     /** Convenience alias for \ref fleece::alloc_slice, an owning byte buffer. */
     using alloc_slice = fleece::alloc_slice;
+
+    using QueryLanguage = CBLQueryLanguage;
 
     // Artificial base class of the C++ wrapper classes; just manages ref-counting.
     class RefCounted {

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -35,6 +35,8 @@
 
 CBL_ASSUME_NONNULL_BEGIN
 
+/** Equality for two \ref CBLError values. Two errors are equal when both indicate success
+    (`code == 0`), or when they share the same `domain` and `code`. */
 inline bool operator== (const CBLError &e1, const CBLError &e2) {
     if (e1.code != 0)
         return e1.domain == e2.domain && e1.code == e2.code;
@@ -44,7 +46,9 @@ inline bool operator== (const CBLError &e1, const CBLError &e2) {
 
 namespace cbl {
 
+    /** Convenience alias for \ref fleece::slice, a non-owning view of a byte range. */
     using slice = fleece::slice;
+    /** Convenience alias for \ref fleece::alloc_slice, an owning byte buffer. */
     using alloc_slice = fleece::alloc_slice;
 
     // Artificial base class of the C++ wrapper classes; just manages ref-counting.
@@ -88,6 +92,10 @@ namespace cbl {
         human-readable message available via `what()`. Catch this type when you need the
         structured error information; catch `std::exception` for general handling. */
     struct Error: std::runtime_error {
+        /** Constructs an Error.
+            @param domain  The error domain.
+            @param code    The error code, specific to the domain.
+            @param what    The human-readable error message (returned by `what()`). */
         Error(CBLErrorDomain domain, int code, const std::string& what)
         : std::runtime_error(what)
         , domain(domain)
@@ -141,20 +149,29 @@ public: \
     template <class... Args>
     class ListenerToken {
     public:
+        /** The type of the user callback that this token holds. */
         using Callback = std::function<void(Args...)>;
 
+        /** Creates an empty, unregistered token. */
         ListenerToken()                                  =default;
+        /** Unregisters the listener (if any) and releases the token. */
         ~ListenerToken()                                 {CBLListener_Remove(_token);}
 
+        /** Creates a token wrapping the given callback. The token is not yet registered with
+            any listener API; call the appropriate `addListener` method to do that.
+            @param cb  The callback to be invoked when notifications arrive. */
         ListenerToken(Callback cb)
         :_callback(new Callback(cb))
         { }
 
+        /** Move-constructs a token, transferring ownership of the underlying listener registration. */
         ListenerToken(ListenerToken &&other)
         :_token(other._token),
         _callback(std::move(other._callback))
         {other._token = nullptr;}
 
+        /** Move-assigns a token: removes this token's existing listener (if any) and adopts the
+            other token's registration. */
         ListenerToken& operator=(ListenerToken &&other) {
             CBLListener_Remove(_token);
             _token = other._token;
@@ -170,10 +187,17 @@ public: \
             _callback = nullptr;
         }
 
+        /** Returns an opaque pointer used internally as the `context` argument for C-API callbacks. */
         void* _cbl_nullable context() const             {return _callback.get();}
+        /** Returns the underlying \ref CBLListenerToken (the C registration handle), or NULL
+            if not registered. */
         CBLListenerToken* _cbl_nullable token() const   {return _token;}
+        /** Assigns the underlying \ref CBLListenerToken returned from a C-API `AddXxxListener`
+            call. May only be called once on a freshly constructed token. */
         void setToken(CBLListenerToken* token)          {assert(!_token); _token = token;}
 
+        /** Static thunk used as the C-API callback. Forwards the call to the C++ \ref Callback
+            stored in `context` (which must be a pointer returned from \ref context). */
         static void call(void* _cbl_nullable context, Args... args) {
             auto listener = (Callback*)context;
             (*listener)(args...);

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -17,8 +17,10 @@
 //
 
 #pragma once
+#include "cbl++/Base.hh"
 #include "cbl++/Document.hh"
 #include "cbl/CBLBlob.h"
+#include "cbl/CBLDatabase.h"
 #include "fleece/Mutable.hh"
 #include <string>
 
@@ -63,35 +65,50 @@ namespace cbl {
         :RefCounted((CBLRefCounted*) FLDict_GetBlob(d))
         { }
 
+        bool blobEquals(const Blob& other) const    {return CBLBlob_Equals(ref(), other.ref());}
+
         /** Returns the length in bytes of a blob's content (from its `length` property). */
         uint64_t length() const                     {return CBLBlob_Length(ref());}
         
         /** Returns a blob's MIME type, if its metadata has a `content_type` property. */
-        std::string contentType() const             {return asString(CBLBlob_ContentType(ref()));}
+        std::string contentType() const             {return Base::asString(CBLBlob_ContentType(ref()));}
         
         /** Returns the cryptographic digest of a blob's content (from its `digest` property). */
-        std::string digest() const                  {return asString(CBLBlob_Digest(ref()));}
+        std::string digest() const                  {return Base::asString(CBLBlob_Digest(ref()));}
         
         /** Returns a blob's metadata. This includes the `digest`, `length`, `content_type`,
             and `@type` properties, as well as any custom ones that may have been added. */
         fleece::Dict properties() const             {return CBLBlob_Properties(ref());}
 
+        /** Returns the JSON representation of the blob's metadata dictionary. */
+        std::string createJSON() const              {return alloc_slice(CBLBlob_CreateJSON(ref())).asString();}
+
         // Allows Blob to be assigned to mutable Dict/Array item, e.g. `dict["foo"] = blob`
         operator fleece::Dict() const               {return properties();}
 
-        /** Reads the blob's content into memory and returns them. */
+        /** Reads the blob's entire content into memory and returns it.
+            @note  This loads the whole blob at once. For large blobs, prefer
+                   \ref openContentStream to read the content incrementally.
+            @return  The blob's content as an \ref alloc_slice that owns the loaded bytes.
+            @throws cbl::Error  If the content cannot be read (for example, the blob's
+                    data is not available in the database). */
         alloc_slice loadContent() {
             CBLError error;
             fleece::alloc_slice content = CBLBlob_Content(ref(), &error);
-            check(content.buf, error);
+            Base::check(content.buf, error);
             return content;
         }
 
-        /** Opens a stream for reading a blob's content. */
+        /** Opens a stream for reading a blob's content.
+            @note  The caller takes ownership of the returned stream and must `delete` it
+                   (e.g. wrap it in a `std::unique_ptr<BlobReadStream>`).
+            @return  A new \ref BlobReadStream positioned at the start of the blob's content. */
         inline BlobReadStream* openContentStream();
 
     protected:
-        Blob(CBLRefCounted* r)                      :RefCounted(r) { }
+        friend class Database;
+        // !Adopt the RefCounted argument
+        Blob(CBLRefCounted* r)                      {_ref = r;}
 
         CBL_REFCOUNTED_BOILERPLATE(Blob, RefCounted, CBLBlob)
     };
@@ -99,13 +116,16 @@ namespace cbl {
     /** A stream for writing a new blob to the database. */
     class BlobReadStream {
     public:
-        /** Opens a stream for reading a blob's content. */
+        using SeekBase = CBLSeekBase;
+
+        /** Opens a stream for reading a blob's content.
+            @param blob  The blob whose content will be read. */
         BlobReadStream(Blob *blob) {
             CBLError error;
             _stream = CBLBlob_OpenContentStream(blob->ref(), &error);
-            if (!_stream) throw error;
+            Base::check(_stream, error);
         }
-        
+
         ~BlobReadStream() {
             CBLBlobReader_Close(_stream);
         }
@@ -117,16 +137,31 @@ namespace cbl {
         size_t read(void *dst, size_t maxLength) {
             CBLError error;
             int bytesRead = CBLBlobReader_Read(_stream, dst, maxLength, &error);
-            if (bytesRead < 0)
-                throw error;
+            Base::check(bytesRead >= 0, error);
             return size_t(bytesRead);
+        }
+
+        /** Sets the position of a CBLBlobReadStream.
+            @param offset  The byte offset in the stream (relative to the `mode`).
+            @param base    The base position from which the offset is calculated.
+            @return  The new absolute position, or -1 on failure. */
+        int64_t seek(int64_t offset, SeekBase base) {
+            CBLError error{};
+            int64_t ret = CBLBlobReader_Seek(_stream, offset, base, &error);
+            Base::check(ret >= 0, error);
+            return ret;
+        }
+
+        /** Returns the current position of a CBLBlobReadStream. */
+        uint64_t position() {
+            return CBLBlobReader_Position(_stream);
         }
 
     private:
         CBLBlobReadStream* _cbl_nullable _stream {nullptr};
     };
 
-    BlobReadStream* Blob::openContentStream() {
+    inline BlobReadStream* Blob::openContentStream() {
         return new BlobReadStream(this);
     }
 
@@ -137,7 +172,7 @@ namespace cbl {
         BlobWriteStream(Database db) {
             CBLError error;
             _writer = CBLBlobWriter_Create(db.ref(), &error);
-            if (!_writer) throw error;
+            Base::check(_writer, error);
         }
 
         ~BlobWriteStream() {
@@ -156,7 +191,7 @@ namespace cbl {
         void write(const void *src, size_t length) {
             CBLError error;
             if (!CBLBlobWriter_Write(_writer, src, length, &error))
-                throw error;
+                Base::check(false, error);
         }
 
     private:
@@ -167,6 +202,20 @@ namespace cbl {
     inline Blob::Blob(slice contentType, BlobWriteStream& writer) {
         _ref = (CBLRefCounted*) CBLBlob_CreateWithStream(contentType, writer._writer);
         writer._writer = nullptr;
+    }
+
+    inline Blob Database::getBlob(fleece::Dict properties) const {
+        CBLError error{};
+        const CBLBlob* blob = CBLDatabase_GetBlob(this->ref(), properties, &error);
+        // Per the C API: null with error.code==0 is a legitimate "not found";
+        // null with a populated error is a real failure -> throw.
+        Base::check(blob != nullptr || error.code == 0, error);
+        return {(CBLRefCounted*)blob};
+    }
+
+    inline void Database::saveBlob(const Blob& blob) {
+        CBLError error{};
+        Base::check(CBLDatabase_SaveBlob(this->ref(), blob.ref(), &error), error);
     }
 }
 

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -48,18 +48,18 @@ namespace cbl {
         /** Creates a new blob, given its contents as a single block of data.
             @note  The memory pointed to by `contents` is no longer needed after this call completes
                     (it will have been written to the database.)
-            @param contents  The data's address and length.
-            @param contentType  The MIME type (optional). */
-        Blob(slice contents, std::optional<std::string_view> contentType =std::nullopt) {
+            @param contentType  The MIME type (optional).
+            @param contents  The data's address and length. */
+        Blob(std::optional<std::string_view> contentType, slice contents) {
             slice ctype;
             if ( contentType ) ctype = slice(*contentType);
             _ref = (CBLRefCounted*) CBLBlob_CreateWithData(ctype, contents);
         }
 
         /** Creates a new blob from the data written to a \ref CBLBlobWriteStream.
-            @param writer  The blob-writing stream the data was written to.
-            @param contentType  The MIME type (optional). */
-        inline Blob(BlobWriteStream& writer, std::optional<std::string_view> contentType =std::nullopt);
+            @param contentType  The MIME type (optional).
+            @param writer  The blob-writing stream the data was written to. */
+        inline Blob(std::optional<std::string_view> contentType, BlobWriteStream& writer);
 
         /** Creates a Blob instance on an existing blob reference in a document or query result.
             @note If the dict argument is not actually a blob reference, this Blob object will be
@@ -213,7 +213,7 @@ namespace cbl {
         CBLBlobWriteStream* _cbl_nullable _writer {nullptr};
     };
 
-    inline Blob::Blob(BlobWriteStream& writer, std::optional<std::string_view> contentType) {
+    inline Blob::Blob(std::optional<std::string_view> contentType, BlobWriteStream& writer) {
         slice ctype;
         if ( contentType ) ctype = slice(*contentType);
         _ref = (CBLRefCounted*) CBLBlob_CreateWithStream(ctype, writer._writer);

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -71,10 +71,10 @@ namespace cbl {
         uint64_t length() const                     {return CBLBlob_Length(ref());}
         
         /** Returns a blob's MIME type, if its metadata has a `content_type` property. */
-        std::string contentType() const             {return Base::asString(CBLBlob_ContentType(ref()));}
+        std::string contentType() const             {return internal::asString(CBLBlob_ContentType(ref()));}
         
         /** Returns the cryptographic digest of a blob's content (from its `digest` property). */
-        std::string digest() const                  {return Base::asString(CBLBlob_Digest(ref()));}
+        std::string digest() const                  {return internal::asString(CBLBlob_Digest(ref()));}
         
         /** Returns a blob's metadata. This includes the `digest`, `length`, `content_type`,
             and `@type` properties, as well as any custom ones that may have been added. */
@@ -95,7 +95,7 @@ namespace cbl {
         alloc_slice loadContent() {
             CBLError error;
             fleece::alloc_slice content = CBLBlob_Content(ref(), &error);
-            Base::check(content.buf, error);
+            internal::check(content.buf, error);
             return content;
         }
 
@@ -106,11 +106,15 @@ namespace cbl {
         inline BlobReadStream* openContentStream();
 
     protected:
-        friend class Database;
-        // !Adopt the RefCounted argument
-        Blob(CBLRefCounted* r)                      {_ref = r;}
 
         CBL_REFCOUNTED_BOILERPLATE(Blob, RefCounted, CBLBlob)
+
+    private:
+        friend class Database;
+        struct adopt_t {};
+        inline static constexpr adopt_t adopt{};
+
+        Blob(CBLBlob* cObj, adopt_t) { _ref = (CBLRefCounted*)cObj; }
     };
 
     /** A stream for writing a new blob to the database. */
@@ -123,7 +127,7 @@ namespace cbl {
         BlobReadStream(Blob *blob) {
             CBLError error;
             _stream = CBLBlob_OpenContentStream(blob->ref(), &error);
-            Base::check(_stream, error);
+            internal::check(_stream, error);
         }
 
         ~BlobReadStream() {
@@ -137,7 +141,7 @@ namespace cbl {
         size_t read(void *dst, size_t maxLength) {
             CBLError error;
             int bytesRead = CBLBlobReader_Read(_stream, dst, maxLength, &error);
-            Base::check(bytesRead >= 0, error);
+            internal::check(bytesRead >= 0, error);
             return size_t(bytesRead);
         }
 
@@ -148,7 +152,7 @@ namespace cbl {
         int64_t seek(int64_t offset, SeekBase base) {
             CBLError error{};
             int64_t ret = CBLBlobReader_Seek(_stream, offset, base, &error);
-            Base::check(ret >= 0, error);
+            internal::check(ret >= 0, error);
             return ret;
         }
 
@@ -172,7 +176,7 @@ namespace cbl {
         BlobWriteStream(Database db) {
             CBLError error;
             _writer = CBLBlobWriter_Create(db.ref(), &error);
-            Base::check(_writer, error);
+            internal::check(_writer, error);
         }
 
         ~BlobWriteStream() {
@@ -191,7 +195,7 @@ namespace cbl {
         void write(const void *src, size_t length) {
             CBLError error;
             if (!CBLBlobWriter_Write(_writer, src, length, &error))
-                Base::check(false, error);
+                internal::check(false, error);
         }
 
     private:
@@ -209,13 +213,13 @@ namespace cbl {
         const CBLBlob* blob = CBLDatabase_GetBlob(this->ref(), properties, &error);
         // Per the C API: null with error.code==0 is a legitimate "not found";
         // null with a populated error is a real failure -> throw.
-        Base::check(blob != nullptr || error.code == 0, error);
-        return {(CBLRefCounted*)blob};
+        internal::check(blob != nullptr || error.code == 0, error);
+        return {const_cast<CBLBlob*>(blob), Blob::adopt};
     }
 
     inline void Database::saveBlob(const Blob& blob) {
         CBLError error{};
-        Base::check(CBLDatabase_SaveBlob(this->ref(), blob.ref(), &error), error);
+        internal::check(CBLDatabase_SaveBlob(this->ref(), blob.ref(), &error), error);
     }
 }
 

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -67,6 +67,7 @@ namespace cbl {
         :RefCounted((CBLRefCounted*) FLDict_GetBlob(d))
         { }
 
+        /** Compares whether this blob and another are equal based on their content. */
         bool blobEquals(const Blob& other) const    {return CBLBlob_Equals(ref(), other.ref());}
 
         /** Returns the length in bytes of a blob's content (from its `length` property). */
@@ -85,7 +86,8 @@ namespace cbl {
         /** Returns the JSON representation of the blob's metadata dictionary. */
         std::string createJSON() const              {return alloc_slice(CBLBlob_CreateJSON(ref())).asString();}
 
-        // Allows Blob to be assigned to mutable Dict/Array item, e.g. `dict["foo"] = blob`
+        /** Implicit conversion to the blob's underlying Fleece dictionary.
+            This lets a Blob be assigned to a mutable Dict/Array item, e.g. `dict["foo"] = blob`. */
         operator fleece::Dict() const               {return properties();}
 
         /** Reads the blob's content into memory and returns it.
@@ -122,6 +124,7 @@ namespace cbl {
     /** A stream for writing a new blob to the database. */
     class BlobReadStream {
     public:
+        /** Alias for the C \ref CBLSeekBase enum describing the reference point used by \ref seek. */
         using SeekBase = CBLSeekBase;
 
         /** Opens a stream for reading a blob's content.
@@ -132,6 +135,7 @@ namespace cbl {
             internal::check(_stream, error);
         }
 
+        /** Closes the underlying read stream. */
         ~BlobReadStream() {
             CBLBlobReader_Close(_stream);
         }
@@ -181,6 +185,8 @@ namespace cbl {
             internal::check(_writer, error);
         }
 
+        /** Closes the blob-writing stream if it has not been handed off to a \ref Blob
+            constructor. Safe to call after the stream has been consumed by a Blob. */
         ~BlobWriteStream() {
             CBLBlobWriter_Close(_writer);
         }

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -22,7 +22,9 @@
 #include "cbl/CBLBlob.h"
 #include "cbl/CBLDatabase.h"
 #include "fleece/Mutable.hh"
+#include <optional>
 #include <string>
+#include <string_view>
 
 // VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
 // future releases.

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -144,7 +144,7 @@ namespace cbl {
         /** Sets the position of a CBLBlobReadStream.
             @param offset  The byte offset in the stream (relative to the `mode`).
             @param base    The base position from which the offset is calculated.
-            @return  The new absolute position, or -1 on failure. */
+            @return  The new absolute position, or throw on failure. */
         int64_t seek(int64_t offset, SeekBase base) {
             CBLError error{};
             int64_t ret = CBLBlobReader_Seek(_stream, offset, base, &error);

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -46,28 +46,18 @@ namespace cbl {
         /** Creates a new blob, given its contents as a single block of data.
             @note  The memory pointed to by `contents` is no longer needed after this call completes
                     (it will have been written to the database.)
-            @param contents  The data's address and length. */
-        Blob(slice contents) {
-            _ref = (CBLRefCounted*) CBLBlob_CreateWithData(fleece::nullslice, contents);
-        }
-        Blob(std::nullptr_t, slice contents) = delete;
-        /** Creates a new blob, given its contents as a single block of data.
-            @note  The memory pointed to by `contents` is no longer needed after this call completes
-                    (it will have been written to the database.)
-            @param contentType  The MIME type.
-            @param contents  The data's address and length. */
-        Blob(std::string_view contentType, slice contents) {
-            _ref = (CBLRefCounted*) CBLBlob_CreateWithData(slice(contentType), contents);
+            @param contents  The data's address and length.
+            @param contentType  The MIME type (optional). */
+        Blob(slice contents, std::optional<std::string_view> contentType =std::nullopt) {
+            slice ctype;
+            if ( contentType ) ctype = slice(*contentType);
+            _ref = (CBLRefCounted*) CBLBlob_CreateWithData(ctype, contents);
         }
 
         /** Creates a new blob from the data written to a \ref CBLBlobWriteStream.
-            @param writer  The blob-writing stream the data was written to. */
-        Blob(BlobWriteStream& writer);
-        Blob(std::nullptr_t, BlobWriteStream& writer) = delete;
-        /** Creates a new blob from the data written to a \ref CBLBlobWriteStream.
-            @param contentType  The MIME type.
-            @param writer  The blob-writing stream the data was written to. */
-        Blob(std::string_view contentType, BlobWriteStream& writer);
+            @param writer  The blob-writing stream the data was written to.
+            @param contentType  The MIME type (optional). */
+        inline Blob(BlobWriteStream& writer, std::optional<std::string_view> contentType =std::nullopt);
 
         /** Creates a Blob instance on an existing blob reference in a document or query result.
             @note If the dict argument is not actually a blob reference, this Blob object will be
@@ -215,12 +205,10 @@ namespace cbl {
         CBLBlobWriteStream* _cbl_nullable _writer {nullptr};
     };
 
-    inline Blob::Blob(BlobWriteStream& writer) {
-        _ref = (CBLRefCounted*) CBLBlob_CreateWithStream(fleece::nullslice, writer._writer);
-        writer._writer = nullptr;
-    }
-    inline Blob::Blob(std::string_view contentType, BlobWriteStream& writer) {
-        _ref = (CBLRefCounted*) CBLBlob_CreateWithStream(slice(contentType), writer._writer);
+    inline Blob::Blob(BlobWriteStream& writer, std::optional<std::string_view> contentType) {
+        slice ctype;
+        if ( contentType ) ctype = slice(*contentType);
+        _ref = (CBLRefCounted*) CBLBlob_CreateWithStream(ctype, writer._writer);
         writer._writer = nullptr;
     }
 

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -86,7 +86,7 @@ namespace cbl {
         // Allows Blob to be assigned to mutable Dict/Array item, e.g. `dict["foo"] = blob`
         operator fleece::Dict() const               {return properties();}
 
-        /** Reads the blob's entire content into memory and returns it.
+        /** Reads the blob's content into memory and returns it.
             @note  This loads the whole blob at once. For large blobs, prefer
                    \ref openContentStream to read the content incrementally.
             @return  The blob's content as an \ref alloc_slice that owns the loaded bytes.

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -46,16 +46,28 @@ namespace cbl {
         /** Creates a new blob, given its contents as a single block of data.
             @note  The memory pointed to by `contents` is no longer needed after this call completes
                     (it will have been written to the database.)
-            @param contentType  The MIME type (optional).
             @param contents  The data's address and length. */
-        Blob(slice contentType, slice contents) {
-            _ref = (CBLRefCounted*) CBLBlob_CreateWithData(contentType, contents);
+        Blob(slice contents) {
+            _ref = (CBLRefCounted*) CBLBlob_CreateWithData(fleece::nullslice, contents);
+        }
+        Blob(std::nullptr_t, slice contents) = delete;
+        /** Creates a new blob, given its contents as a single block of data.
+            @note  The memory pointed to by `contents` is no longer needed after this call completes
+                    (it will have been written to the database.)
+            @param contentType  The MIME type.
+            @param contents  The data's address and length. */
+        Blob(std::string_view contentType, slice contents) {
+            _ref = (CBLRefCounted*) CBLBlob_CreateWithData(slice(contentType), contents);
         }
 
         /** Creates a new blob from the data written to a \ref CBLBlobWriteStream.
-            @param contentType  The MIME type (optional).
             @param writer  The blob-writing stream the data was written to. */
-        inline Blob(slice contentType, BlobWriteStream& writer);
+        Blob(BlobWriteStream& writer);
+        Blob(std::nullptr_t, BlobWriteStream& writer) = delete;
+        /** Creates a new blob from the data written to a \ref CBLBlobWriteStream.
+            @param contentType  The MIME type.
+            @param writer  The blob-writing stream the data was written to. */
+        Blob(std::string_view contentType, BlobWriteStream& writer);
 
         /** Creates a Blob instance on an existing blob reference in a document or query result.
             @note If the dict argument is not actually a blob reference, this Blob object will be
@@ -203,8 +215,12 @@ namespace cbl {
         CBLBlobWriteStream* _cbl_nullable _writer {nullptr};
     };
 
-    inline Blob::Blob(slice contentType, BlobWriteStream& writer) {
-        _ref = (CBLRefCounted*) CBLBlob_CreateWithStream(contentType, writer._writer);
+    inline Blob::Blob(BlobWriteStream& writer) {
+        _ref = (CBLRefCounted*) CBLBlob_CreateWithStream(fleece::nullslice, writer._writer);
+        writer._writer = nullptr;
+    }
+    inline Blob::Blob(std::string_view contentType, BlobWriteStream& writer) {
+        _ref = (CBLRefCounted*) CBLBlob_CreateWithStream(slice(contentType), writer._writer);
         writer._writer = nullptr;
     }
 

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -65,15 +65,15 @@ namespace cbl {
         // Accessors:
         
         /** The collection's name. */
-        std::string name() const                        {return Base::asString(CBLCollection_Name(ref()));}
+        std::string name() const                        {return internal::asString(CBLCollection_Name(ref()));}
         
         /** The collection's fully qualified name in the '<scope-name>.<collection-name>' format. */
-        std::string fullName() const                    {return Base::asString(CBLCollection_FullName(ref()));}
+        std::string fullName() const                    {return internal::asString(CBLCollection_FullName(ref()));}
         
         /** The scope's name. */
         std::string scopeName() const {
             auto scope = CBLCollection_Scope(ref());
-            auto scopeName = Base::asString(CBLScope_Name(scope));
+            auto scopeName = internal::asString(CBLScope_Name(scope));
             CBLScope_Release(scope);
             return scopeName;
         }
@@ -154,7 +154,7 @@ namespace cbl {
             CBLError error;
             bool purged = CBLCollection_PurgeDocumentByID(ref(), docID, &error);
             if (!purged && error.code != 0)
-                Base::check(false, error);
+                internal::check(false, error);
             return purged;
         }
         
@@ -167,7 +167,7 @@ namespace cbl {
         time_t getDocumentExpiration(slice docID) const {
             CBLError error;
             time_t exp = CBLCollection_GetDocumentExpiration(ref(), docID, &error);
-            Base::check(exp >= 0, error);
+            internal::check(exp >= 0, error);
             return exp;
         }
 
@@ -177,7 +177,7 @@ namespace cbl {
                               or 0 if the document should never expire. */
         void setDocumentExpiration(slice docID, time_t expiration) {
             CBLError error;
-            Base::check(CBLCollection_SetDocumentExpiration(ref(), docID, expiration, &error), error);
+            internal::check(CBLCollection_SetDocumentExpiration(ref(), docID, expiration, &error), error);
         }
         
         // Indexes:
@@ -190,7 +190,7 @@ namespace cbl {
             @param config  The value index config. */
         void createValueIndex(slice name, CBLValueIndexConfiguration config) {
             CBLError error;
-            Base::check(CBLCollection_CreateValueIndex(ref(), name, config, &error), error);
+            internal::check(CBLCollection_CreateValueIndex(ref(), name, config, &error), error);
         }
         
         /** Creates a full-text index in the collection.
@@ -201,7 +201,7 @@ namespace cbl {
             @param config  The full-text index config. */
         void createFullTextIndex(slice name, CBLFullTextIndexConfiguration config) {
             CBLError error;
-            Base::check(CBLCollection_CreateFullTextIndex(ref(), name, config, &error), error);
+            internal::check(CBLCollection_CreateFullTextIndex(ref(), name, config, &error), error);
         }
         
         /** Creates an array index for use with UNNEST queries in the collection.
@@ -212,7 +212,7 @@ namespace cbl {
             @param config  The array index config. */
         void createArrayIndex(slice name, CBLArrayIndexConfiguration config) {
             CBLError error;
-            Base::check(CBLCollection_CreateArrayIndex(ref(), name, config, &error), error);
+            internal::check(CBLCollection_CreateArrayIndex(ref(), name, config, &error), error);
         }
         
 #ifdef COUCHBASE_ENTERPRISE
@@ -229,14 +229,14 @@ namespace cbl {
         /** Deletes an index given its name from the collection. */
         void deleteIndex(slice name) {
             CBLError error;
-            Base::check(CBLCollection_DeleteIndex(ref(), name, &error), error);
+            internal::check(CBLCollection_DeleteIndex(ref(), name, &error), error);
         }
 
         /** Returns the names of the indexes in the collection, as a Fleece array of strings. */
         fleece::RetainedArray getIndexNames() {
             CBLError error{};
             FLMutableArray flNames = CBLCollection_GetIndexNames(ref(), &error);
-            Base::check(error.code == 0, error);
+            internal::check(error.code == 0, error);
             fleece::RetainedArray names(flNames);
             FLArray_Release(flNames);
             return names;
@@ -277,10 +277,9 @@ namespace cbl {
         }
         
     protected:
-        
+
         static Collection adopt(const CBLCollection* _cbl_nullable d, CBLError *error) {
-            if (!d && error->code != 0)
-                Base::check(false, *error);
+            internal::check(d != nullptr || error->code == 0, *error);
             Collection col;
             col._ref = (CBLRefCounted*)d;
             return col;

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -47,7 +47,7 @@ namespace cbl {
         /** The language used in the expressions (Required). */
         QueryLanguage expressionLanguage;
 
-        /** The expressions describing each coloumn of the index (Required).
+        /** The expressions describing each column of the index (Required).
             The expressions could be specified in a JSON Array or in N1QL syntax
             using comma delimiter, depending on expressionLanguage. */
         std::string expressions;

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -42,9 +42,75 @@ namespace cbl {
     /** Conflict handler used when saving a document. */
     using CollectionConflictHandler  = std::function<bool(MutableDocument documentBeingSaved,
                                                           Document conflictingDocument)>;
-    using FullTextIndexConfiguration = CBLFullTextIndexConfiguration;
-    using ValueIndexConfiguration    = CBLValueIndexConfiguration;
-    using ArrayIndexConfiguration    = CBLArrayIndexConfiguration;
+    /** Value Index Configuration. */
+    struct ValueIndexConfiguration {
+        /** The language used in the expressions (Required). */
+        QueryLanguage expressionLanguage;
+
+        /** The expressions describing each coloumn of the index (Required).
+            The expressions could be specified in a JSON Array or in N1QL syntax
+            using comma delimiter, depending on expressionLanguage. */
+        std::string expressions;
+
+        /** A predicate expression defining conditions for indexing documents.
+            Only documents satisfying the predicate are included, enabling partial indexes.
+            The expression can be JSON or N1QL/SQL++ syntax, depending on expressionLanguage. */
+        std::string where;
+    };
+
+    /** Full-Text Index Configuration. */
+    struct FullTextIndexConfiguration {
+        /** The language used in the expressions (Required). */
+        QueryLanguage expressionLanguage;
+
+        /** The expressions describing each coloumn of the index (Required).
+            The expressions could be specified in a JSON Array or in N1QL syntax
+            using comma delimiter, depending on expressionLanguage. */
+        std::string expressions;
+
+        /** Should diacritical marks (accents) be ignored?
+            Defaults to  \ref kCBLDefaultFullTextIndexIgnoreAccents.
+            Generally this should be left `false` for non-English text. */
+        bool ignoreAccents;
+
+        /** The dominant language. Setting this enables word stemming, i.e.
+            matching different cases of the same word ("big" and "bigger", for instance) and ignoring
+            common "stop-words" ("the", "a", "of", etc.)
+
+            Can be an ISO-639 language code or a lowercase (English) language name; supported
+            languages are: da/danish, nl/dutch, en/english, fi/finnish, fr/french, de/german,
+            hu/hungarian, it/italian, no/norwegian, pt/portuguese, ro/romanian, ru/russian,
+            es/spanish, sv/swedish, tr/turkish.
+
+            If left null,  or set to an unrecognized language, no language-specific behaviors
+            such as stemming and stop-word removal occur. */
+        std::string language;
+
+        /** A predicate expression defining conditions for indexing documents.
+            Only documents satisfying the predicate are included, enabling partial indexes.
+            The expression can be JSON or N1QL/SQL++ syntax, depending on expressionLanguage. */
+        std::string where;
+    };
+
+    /** Array Index Configuration for indexing property values within arrays
+        in documents, intended for use with the UNNEST query. */
+    struct ArrayIndexConfiguration {
+        /** The language used in the expressions (Required). */
+        QueryLanguage expressionLanguage;
+
+        /** Path to the array, which can be nested to be indexed (Required).
+            Use "[]" to represent a property that is an array of each nested array level.
+            For a single array or the last level array, the "[]" is optional. For instance,
+            use "contacts[].phones" to specify an array of phones within each contact. */
+        std::string path;
+
+        /** Optional expressions representing the values within the array to be
+            indexed. The expressions could be specified in a JSON Array or in N1QL syntax
+            using comma delimiter, depending on expressionLanguage.
+            If the array specified by the path contains scalar values, the expressions
+            should be left unset or set to null. */
+        std::string expressions;
+    };
 
     /**
      A Collection class represent a collection which is a container for documents.
@@ -182,7 +248,7 @@ namespace cbl {
             CBLError error;
             internal::check(CBLCollection_SetDocumentExpiration(ref(), slice(docID), expiration, &error), error);
         }
-        
+
         // Indexes:
 
         /** Creates a value index in the collection.
@@ -193,7 +259,11 @@ namespace cbl {
             @param config  The value index config. */
         void createValueIndex(std::string_view name, ValueIndexConfiguration config) {
             CBLError error;
-            internal::check(CBLCollection_CreateValueIndex(ref(), slice(name), config, &error), error);
+            internal::check(CBLCollection_CreateValueIndex(ref(), slice(name), {
+                config.expressionLanguage,
+                slice(config.expressions),
+                slice(config.where)
+            }, &error), error);
         }
         
         /** Creates a full-text index in the collection.
@@ -204,9 +274,15 @@ namespace cbl {
             @param config  The full-text index config. */
         void createFullTextIndex(std::string_view name, FullTextIndexConfiguration config) {
             CBLError error;
-            internal::check(CBLCollection_CreateFullTextIndex(ref(), slice(name), config, &error), error);
+            internal::check(CBLCollection_CreateFullTextIndex(ref(), slice(name), {
+                config.expressionLanguage,
+                slice(config.expressions),
+                config.ignoreAccents,
+                slice(config.language),
+                slice(config.where)
+            }, &error), error);
         }
-        
+
         /** Creates an array index for use with UNNEST queries in the collection.
             Indexes are persistent.
             If an identical index with that name already exists, nothing happens (and no error is returned.)
@@ -215,9 +291,13 @@ namespace cbl {
             @param config  The array index config. */
         void createArrayIndex(std::string_view name, ArrayIndexConfiguration config) {
             CBLError error;
-            internal::check(CBLCollection_CreateArrayIndex(ref(), slice(name), config, &error), error);
+            internal::check(CBLCollection_CreateArrayIndex(ref(), slice(name), {
+                config.expressionLanguage,
+                slice(config.path),
+                slice(config.expressions)
+            }, &error), error);
         }
-        
+
 #ifdef COUCHBASE_ENTERPRISE
         /** ENTERPRISE EDITION ONLY
          
@@ -226,7 +306,7 @@ namespace cbl {
             If a non-identical index with that name already exists, it is deleted and re-created.
             @param name  The index name.
             @param config  The vector index config. */
-        inline void createVectorIndex(std::string_view name, const VectorIndexConfiguration &config);
+        inline void createVectorIndex(std::string_view name, VectorIndexConfiguration config);
 #endif
 
         /** Deletes an index given its name from the collection. */

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -65,15 +65,15 @@ namespace cbl {
         // Accessors:
         
         /** The collection's name. */
-        std::string name() const                        {return asString(CBLCollection_Name(ref()));}
+        std::string name() const                        {return Base::asString(CBLCollection_Name(ref()));}
         
         /** The collection's fully qualified name in the '<scope-name>.<collection-name>' format. */
-        std::string fullName() const                    {return asString(CBLCollection_FullName(ref()));}
+        std::string fullName() const                    {return Base::asString(CBLCollection_FullName(ref()));}
         
         /** The scope's name. */
         std::string scopeName() const {
             auto scope = CBLCollection_Scope(ref());
-            auto scopeName = asString(CBLScope_Name(scope));
+            auto scopeName = Base::asString(CBLScope_Name(scope));
             CBLScope_Release(scope);
             return scopeName;
         }
@@ -89,13 +89,17 @@ namespace cbl {
         /** Reads a document from the collection in an immutable form.
             @note If you are reading the document in order to make changes to it, call \ref Collection::getMutableDocument() instead.
             @param docID  The ID of the document.
-            @return A new \ref Document instance, or NULL if the doc doesn't exist, or throws if an error occurred. */
+            @return A new \ref Document instance, or a falsy Document if the doc doesn't exist.
+            @throws cbl::Error  On a database error. Note a non-existent document is not an
+                    error — that returns a falsy Document rather than throwing. */
         inline Document getDocument(slice docID) const;
         
         /** Reads a document from the collection in mutable form that can be updated and saved.
             (This function is otherwise identical to \ref Collection::getDocument(slice docID).)
             @param docID  The ID of the document.
-            @return A new \ref Document instance, or NULL if the doc doesn't exist, or throws if an error occurred. */
+            @return A new \ref Document instance, or a falsy Document if the doc doesn't exist.
+            @throws cbl::Error  On a database error. Note a non-existent document is not an
+                    error — that returns a falsy Document rather than throwing. */
         inline MutableDocument getMutableDocument(slice docID) const;
 
         /** Saves a (mutable) document to the collection.
@@ -150,7 +154,7 @@ namespace cbl {
             CBLError error;
             bool purged = CBLCollection_PurgeDocumentByID(ref(), docID, &error);
             if (!purged && error.code != 0)
-                throw error;
+                Base::check(false, error);
             return purged;
         }
         
@@ -159,11 +163,11 @@ namespace cbl {
             to set a document's expiration time.
             @param docID  The ID of the document.
             @return The expiration time as a CBLTimestamp (milliseconds since Unix epoch),
-                  or 0 if the document does not have an expiration */
+                  or 0 if the document does not have an expiration. */
         time_t getDocumentExpiration(slice docID) const {
             CBLError error;
             time_t exp = CBLCollection_GetDocumentExpiration(ref(), docID, &error);
-            check(exp >= 0, error);
+            Base::check(exp >= 0, error);
             return exp;
         }
 
@@ -173,7 +177,7 @@ namespace cbl {
                               or 0 if the document should never expire. */
         void setDocumentExpiration(slice docID, time_t expiration) {
             CBLError error;
-            check(CBLCollection_SetDocumentExpiration(ref(), docID, expiration, &error), error);
+            Base::check(CBLCollection_SetDocumentExpiration(ref(), docID, expiration, &error), error);
         }
         
         // Indexes:
@@ -186,7 +190,7 @@ namespace cbl {
             @param config  The value index config. */
         void createValueIndex(slice name, CBLValueIndexConfiguration config) {
             CBLError error;
-            check(CBLCollection_CreateValueIndex(ref(), name, config, &error), error);
+            Base::check(CBLCollection_CreateValueIndex(ref(), name, config, &error), error);
         }
         
         /** Creates a full-text index in the collection.
@@ -197,7 +201,7 @@ namespace cbl {
             @param config  The full-text index config. */
         void createFullTextIndex(slice name, CBLFullTextIndexConfiguration config) {
             CBLError error;
-            check(CBLCollection_CreateFullTextIndex(ref(), name, config, &error), error);
+            Base::check(CBLCollection_CreateFullTextIndex(ref(), name, config, &error), error);
         }
         
         /** Creates an array index for use with UNNEST queries in the collection.
@@ -208,7 +212,7 @@ namespace cbl {
             @param config  The array index config. */
         void createArrayIndex(slice name, CBLArrayIndexConfiguration config) {
             CBLError error;
-            check(CBLCollection_CreateArrayIndex(ref(), name, config, &error), error);
+            Base::check(CBLCollection_CreateArrayIndex(ref(), name, config, &error), error);
         }
         
 #ifdef COUCHBASE_ENTERPRISE
@@ -225,20 +229,20 @@ namespace cbl {
         /** Deletes an index given its name from the collection. */
         void deleteIndex(slice name) {
             CBLError error;
-            check(CBLCollection_DeleteIndex(ref(), name, &error), error);
+            Base::check(CBLCollection_DeleteIndex(ref(), name, &error), error);
         }
 
         /** Returns the names of the indexes in the collection, as a Fleece array of strings. */
         fleece::RetainedArray getIndexNames() {
-            CBLError error;
+            CBLError error{};
             FLMutableArray flNames = CBLCollection_GetIndexNames(ref(), &error);
-            check(flNames, error);
+            Base::check(error.code == 0, error);
             fleece::RetainedArray names(flNames);
             FLArray_Release(flNames);
             return names;
         }
         
-        /** Get an index by name. If the index doesn't exist, the NULL QueryIndex object will be returned. */
+        /** Get an index by name. If the index doesn't exist, a falsy QueryIndex object will be returned. */
         inline QueryIndex getIndex(slice name);
         
         // Listeners:
@@ -276,7 +280,7 @@ namespace cbl {
         
         static Collection adopt(const CBLCollection* _cbl_nullable d, CBLError *error) {
             if (!d && error->code != 0)
-                throw *error;
+                Base::check(false, *error);
             Collection col;
             col._ref = (CBLRefCounted*)d;
             return col;

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -40,8 +40,11 @@ namespace cbl {
     class VectorIndexConfiguration;
 
     /** Conflict handler used when saving a document. */
-    using CollectionConflictHandler = std::function<bool(MutableDocument documentBeingSaved,
-                                                         Document conflictingDocument)>;
+    using CollectionConflictHandler  = std::function<bool(MutableDocument documentBeingSaved,
+                                                          Document conflictingDocument)>;
+    using FullTextIndexConfiguration = CBLFullTextIndexConfiguration;
+    using ValueIndexConfiguration    = CBLValueIndexConfiguration;
+    using ArrayIndexConfiguration    = CBLArrayIndexConfiguration;
 
     /**
      A Collection class represent a collection which is a container for documents.
@@ -188,7 +191,7 @@ namespace cbl {
             If a non-identical index with that name already exists, it is deleted and re-created.
             @param name  The index name.
             @param config  The value index config. */
-        void createValueIndex(std::string_view name, CBLValueIndexConfiguration config) {
+        void createValueIndex(std::string_view name, ValueIndexConfiguration config) {
             CBLError error;
             internal::check(CBLCollection_CreateValueIndex(ref(), slice(name), config, &error), error);
         }
@@ -199,7 +202,7 @@ namespace cbl {
             If a non-identical index with that name already exists, it is deleted and re-created.
             @param name  The index name.
             @param config  The full-text index config. */
-        void createFullTextIndex(std::string_view name, CBLFullTextIndexConfiguration config) {
+        void createFullTextIndex(std::string_view name, FullTextIndexConfiguration config) {
             CBLError error;
             internal::check(CBLCollection_CreateFullTextIndex(ref(), slice(name), config, &error), error);
         }
@@ -210,7 +213,7 @@ namespace cbl {
             If a non-identical index with that name already exists, it is deleted and re-created.
             @param name  The index name.
             @param config  The array index config. */
-        void createArrayIndex(std::string_view name, CBLArrayIndexConfiguration config) {
+        void createArrayIndex(std::string_view name, ArrayIndexConfiguration config) {
             CBLError error;
             internal::check(CBLCollection_CreateArrayIndex(ref(), slice(name), config, &error), error);
         }
@@ -342,14 +345,16 @@ namespace cbl {
 
     // Database method bodies:
 
-    inline Collection Database::getCollection(std::string_view collectionName, std::string_view scopeName) const {
+    inline Collection Database::getCollection(std::string_view collectionName, std::optional<std::string_view> optScopeName) const {
         CBLError error {};
+        slice scopeName = optScopeName.value_or(slice(kCBLDefaultScopeName));
         return Collection::adopt(CBLDatabase_Collection(ref(), slice(collectionName), slice(scopeName), &error), &error) ;
     }
 
-    inline Collection Database::createCollection(std::string_view collectionName, std::string_view scopeName) {
+    inline Collection Database::createCollection(std::string_view collectionName, std::optional<std::string_view> optScopeName) {
         CBLError error {};
-        return Collection::adopt(CBLDatabase_CreateCollection(ref(), slice(collectionName), slice(scopeName), &error), &error) ;
+        slice scopeName = optScopeName.value_or(slice(kCBLDefaultScopeName));
+        return Collection::adopt(CBLDatabase_CreateCollection(ref(), slice(collectionName), scopeName, &error), &error) ;
     }
 
     inline Collection Database::getDefaultCollection() const {

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -144,16 +144,17 @@ namespace cbl {
             Purges are _not_ replicated. If the document is changed on a server, it will be re-created
             when pulled.
             @note If you don't have the document in memory already, \ref purgeDocument(slice docID) is a simpler shortcut.
-            @param doc  The document to purge. */
-        inline void purgeDocument(Document &doc);
-        
+            @param doc  The document to purge.
+            @return True if the document was purged, false if it doesn't exist. */
+        inline bool purgeDocument(Document &doc);
+
         /** Purges a document by its ID from the collection.
             @param docID  The document ID to purge.
             @return True if the document was purged, false if it doesn't exist. */
         bool purgeDocument(slice docID) {
             CBLError error;
             bool purged = CBLCollection_PurgeDocumentByID(ref(), docID, &error);
-            if (!purged && error.code != 0)
+            if ( !purged && !(error.domain == kCBLDomain && error.code == kCBLErrorNotFound) )
                 internal::check(false, error);
             return purged;
         }

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -92,7 +92,7 @@ namespace cbl {
             @return A new \ref Document instance, or a falsy Document if the doc doesn't exist.
             @throws cbl::Error  On a database error. Note a non-existent document is not an
                     error — that returns a falsy Document rather than throwing. */
-        inline Document getDocument(slice docID) const;
+        inline Document getDocument(std::string_view docID) const;
         
         /** Reads a document from the collection in mutable form that can be updated and saved.
             (This function is otherwise identical to \ref Collection::getDocument(slice docID).)
@@ -100,7 +100,7 @@ namespace cbl {
             @return A new \ref Document instance, or a falsy Document if the doc doesn't exist.
             @throws cbl::Error  On a database error. Note a non-existent document is not an
                     error — that returns a falsy Document rather than throwing. */
-        inline MutableDocument getMutableDocument(slice docID) const;
+        inline MutableDocument getMutableDocument(std::string_view docID) const;
 
         /** Saves a (mutable) document to the collection.
             @warning If a newer revision has been saved since \p doc was loaded, it will be overwritten by
@@ -151,9 +151,9 @@ namespace cbl {
         /** Purges a document by its ID from the collection.
             @param docID  The document ID to purge.
             @return True if the document was purged, false if it doesn't exist. */
-        bool purgeDocument(slice docID) {
+        bool purgeDocument(std::string_view docID) {
             CBLError error;
-            bool purged = CBLCollection_PurgeDocumentByID(ref(), docID, &error);
+            bool purged = CBLCollection_PurgeDocumentByID(ref(), slice(docID), &error);
             if ( !purged && !(error.domain == kCBLDomain && error.code == kCBLErrorNotFound) )
                 internal::check(false, error);
             return purged;
@@ -165,9 +165,9 @@ namespace cbl {
             @param docID  The ID of the document.
             @return The expiration time as a CBLTimestamp (milliseconds since Unix epoch),
                   or 0 if the document does not have an expiration. */
-        time_t getDocumentExpiration(slice docID) const {
+        time_t getDocumentExpiration(std::string_view docID) const {
             CBLError error;
-            time_t exp = CBLCollection_GetDocumentExpiration(ref(), docID, &error);
+            time_t exp = CBLCollection_GetDocumentExpiration(ref(), slice(docID), &error);
             internal::check(exp >= 0, error);
             return exp;
         }
@@ -176,9 +176,9 @@ namespace cbl {
             @param docID  The ID of the document.
             @param expiration  The expiration time as a CBLTimestamp (milliseconds since Unix epoch),
                               or 0 if the document should never expire. */
-        void setDocumentExpiration(slice docID, time_t expiration) {
+        void setDocumentExpiration(std::string_view docID, time_t expiration) {
             CBLError error;
-            internal::check(CBLCollection_SetDocumentExpiration(ref(), docID, expiration, &error), error);
+            internal::check(CBLCollection_SetDocumentExpiration(ref(), slice(docID), expiration, &error), error);
         }
         
         // Indexes:
@@ -189,9 +189,9 @@ namespace cbl {
             If a non-identical index with that name already exists, it is deleted and re-created.
             @param name  The index name.
             @param config  The value index config. */
-        void createValueIndex(slice name, CBLValueIndexConfiguration config) {
+        void createValueIndex(std::string_view name, CBLValueIndexConfiguration config) {
             CBLError error;
-            internal::check(CBLCollection_CreateValueIndex(ref(), name, config, &error), error);
+            internal::check(CBLCollection_CreateValueIndex(ref(), slice(name), config, &error), error);
         }
         
         /** Creates a full-text index in the collection.
@@ -200,9 +200,9 @@ namespace cbl {
             If a non-identical index with that name already exists, it is deleted and re-created.
             @param name  The index name.
             @param config  The full-text index config. */
-        void createFullTextIndex(slice name, CBLFullTextIndexConfiguration config) {
+        void createFullTextIndex(std::string_view name, CBLFullTextIndexConfiguration config) {
             CBLError error;
-            internal::check(CBLCollection_CreateFullTextIndex(ref(), name, config, &error), error);
+            internal::check(CBLCollection_CreateFullTextIndex(ref(), slice(name), config, &error), error);
         }
         
         /** Creates an array index for use with UNNEST queries in the collection.
@@ -211,9 +211,9 @@ namespace cbl {
             If a non-identical index with that name already exists, it is deleted and re-created.
             @param name  The index name.
             @param config  The array index config. */
-        void createArrayIndex(slice name, CBLArrayIndexConfiguration config) {
+        void createArrayIndex(std::string_view name, CBLArrayIndexConfiguration config) {
             CBLError error;
-            internal::check(CBLCollection_CreateArrayIndex(ref(), name, config, &error), error);
+            internal::check(CBLCollection_CreateArrayIndex(ref(), slice(name), config, &error), error);
         }
         
 #ifdef COUCHBASE_ENTERPRISE
@@ -224,13 +224,13 @@ namespace cbl {
             If a non-identical index with that name already exists, it is deleted and re-created.
             @param name  The index name.
             @param config  The vector index config. */
-        inline void createVectorIndex(slice name, const VectorIndexConfiguration &config);
+        inline void createVectorIndex(std::string_view name, const VectorIndexConfiguration &config);
 #endif
 
         /** Deletes an index given its name from the collection. */
-        void deleteIndex(slice name) {
+        void deleteIndex(std::string_view name) {
             CBLError error;
-            internal::check(CBLCollection_DeleteIndex(ref(), name, &error), error);
+            internal::check(CBLCollection_DeleteIndex(ref(), slice(name), &error), error);
         }
 
         /** Returns the names of the indexes in the collection, as a Fleece array of strings. */
@@ -244,7 +244,7 @@ namespace cbl {
         }
         
         /** Get an index by name. If the index doesn't exist, a falsy QueryIndex object will be returned. */
-        inline QueryIndex getIndex(slice name);
+        inline QueryIndex getIndex(std::string_view name);
         
         // Listeners:
         
@@ -269,11 +269,11 @@ namespace cbl {
             @param docID  The ID of the document to observe.
             @param callback  The callback to be invoked.
             @return A Change Listener Token. Call \ref ListenerToken::remove() method to remove the listener. */
-        [[nodiscard]] CollectionDocumentChangeListener addDocumentChangeListener(slice docID,
+        [[nodiscard]] CollectionDocumentChangeListener addDocumentChangeListener(std::string_view docID,
                                                                                  CollectionDocumentChangeListener::Callback callback)
         {
             auto l = CollectionDocumentChangeListener(callback);
-            l.setToken( CBLCollection_AddDocumentChangeListener(ref(), docID, &_callDocListener, l.context()) );
+            l.setToken( CBLCollection_AddDocumentChangeListener(ref(), slice(docID), &_callDocListener, l.context()) );
             return l;
         }
         
@@ -330,9 +330,9 @@ namespace cbl {
         slice& docID()                              {return _docID;}
 
         /** Internal API. */
-        DocumentChange(Collection collection, slice docID)
+        DocumentChange(Collection collection, std::string_view docID)
         :_collection(std::move(collection))
-        ,_docID(std::move(docID))
+        ,_docID(slice(docID))
         { }
         
     private:
@@ -343,14 +343,14 @@ namespace cbl {
 
     // Database method bodies:
 
-    inline Collection Database::getCollection(slice collectionName, slice scopeName) const {
+    inline Collection Database::getCollection(std::string_view collectionName, std::string_view scopeName) const {
         CBLError error {};
-        return Collection::adopt(CBLDatabase_Collection(ref(), collectionName, scopeName, &error), &error) ;
+        return Collection::adopt(CBLDatabase_Collection(ref(), slice(collectionName), slice(scopeName), &error), &error) ;
     }
 
-    inline Collection Database::createCollection(slice collectionName, slice scopeName) {
+    inline Collection Database::createCollection(std::string_view collectionName, std::string_view scopeName) {
         CBLError error {};
-        return Collection::adopt(CBLDatabase_CreateCollection(ref(), collectionName, scopeName, &error), &error) ;
+        return Collection::adopt(CBLDatabase_CreateCollection(ref(), slice(collectionName), slice(scopeName), &error), &error) ;
     }
 
     inline Collection Database::getDefaultCollection() const {

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -144,9 +144,8 @@ namespace cbl {
             Purges are _not_ replicated. If the document is changed on a server, it will be re-created
             when pulled.
             @note If you don't have the document in memory already, \ref purgeDocument(slice docID) is a simpler shortcut.
-            @param doc  The document to purge.
-            @return True if the document was purged, false if it doesn't exist. */
-        inline bool purgeDocument(Document &doc);
+            @param doc  The document to purge. */
+        inline void purgeDocument(Document &doc);
 
         /** Purges a document by its ID from the collection.
             @param docID  The document ID to purge.

--- a/include/cbl++/CouchbaseLite.hh
+++ b/include/cbl++/CouchbaseLite.hh
@@ -19,11 +19,39 @@
 // VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
 // future releases.
 
+/** \defgroup cbl_cpp Couchbase Lite C++ API
+    @{
+
+    \section error_handling Error handling
+
+    On failure, functions in this API report errors by throwing exceptions derived from
+    `std::exception`, so callers should be prepared to catch `std::exception`.
+
+    Couchbase Lite-specific failures are thrown as \ref cbl::Error, a subclass of
+    `std::runtime_error` that encapsulates the failure's `domain`, `code`, and message.
+    Catch `cbl::Error` when you need that structured information; catch `std::exception`
+    for general handling.
+    (The raw C-API `CBLError` status struct is wrapped by `cbl::Error` and is never
+    thrown directly across this API.)
+
+    `noexcept` is applied only to special member functions (copy/move constructors and
+    assignment operators, and destructors), where the no-throw guarantee is structural and
+    permanent. It is deliberately omitted from other methods — even ones that cannot throw
+    today — so that their implementations remain free to throw in a future release without
+    a breaking API change. Do not infer anything from the absence of `noexcept`; assume any
+    method may throw `cbl::Error` (or another `std::exception`) on failure. Individual
+    functions add an `@throws cbl::Error` note only when the specific trigger, or a
+    non-throwing outcome worth contrasting (such as a lookup that returns an empty result
+    instead of throwing when an item doesn't exist), is not obvious from the signature.
+
+    @} */
+
 #pragma once
 #include "Blob.hh"
 #include "Collection.hh"
 #include "Database.hh"
 #include "Document.hh"
+#include "Encryptable.hh"
 #include "LogSinks.hh"
 #include "Prediction.hh"
 #include "Query.hh"

--- a/include/cbl++/CouchbaseLite.hh
+++ b/include/cbl++/CouchbaseLite.hh
@@ -24,25 +24,15 @@
 
     \section error_handling Error handling
 
-    On failure, functions in this API report errors by throwing exceptions derived from
-    `std::exception`, so callers should be prepared to catch `std::exception`.
+    Functions in the Couchbase Lite C++ API report Couchbase Lite-specific failures by
+    throwing \ref cbl::Error, a subclass of `std::runtime_error` that provides the error
+    domain, error code, and a human-readable message from `what()`.
 
-    Couchbase Lite-specific failures are thrown as \ref cbl::Error, a subclass of
-    `std::runtime_error` that encapsulates the failure's `domain`, `code`, and message.
-    Catch `cbl::Error` when you need that structured information; catch `std::exception`
-    for general handling.
-    (The raw C-API `CBLError` status struct is wrapped by `cbl::Error` and is never
-    thrown directly across this API.)
+    Catch \ref cbl::Error when you need Couchbase Lite-specific error details. Catch
+    `std::exception` for general error handling.
 
-    `noexcept` is applied only to special member functions (copy/move constructors and
-    assignment operators, and destructors), where the no-throw guarantee is structural and
-    permanent. It is deliberately omitted from other methods — even ones that cannot throw
-    today — so that their implementations remain free to throw in a future release without
-    a breaking API change. Do not infer anything from the absence of `noexcept`; assume any
-    method may throw `cbl::Error` (or another `std::exception`) on failure. Individual
-    functions add an `@throws cbl::Error` note only when the specific trigger, or a
-    non-throwing outcome worth contrasting (such as a lookup that returns an empty result
-    instead of throwing when an item doesn't exist), is not obvious from the signature.
+    `noexcept` marks functions that are guaranteed not to throw. All other functions
+    should be treated as potentially throwing on failure, unless otherwise documented.
 
     @} */
 

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -317,7 +317,7 @@ namespace cbl {
         /** Returns the names of all collections in the scope.
             @param scopeName  The name of the scope.
             @return The names of all collections in the scope, or throws if an error occurred. */
-        fleece::MutableArray getCollectionNames(slice scopeName =kCBLDefaultScopeName) const {
+        fleece::MutableArray getCollectionNames(slice scopeName = kCBLDefaultScopeName) const {
             CBLError error {};
             FLMutableArray flNames = CBLDatabase_CollectionNames(ref(), scopeName, &error);
             internal::check(error.code == 0, error);
@@ -332,7 +332,7 @@ namespace cbl {
             @return The \ref Collection, or a falsy Collection if it doesn't exist.
             @throws cbl::Error  On a database error. Note a non-existent collection is not an
                     error — that returns a falsy Collection rather than throwing. */
-        inline Collection getCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName) const;
+        inline Collection getCollection(slice collectionName, slice scopeName = kCBLDefaultScopeName) const;
         
         /** Create a new collection.
             The naming rules of the collections and scopes are as follows:
@@ -344,13 +344,13 @@ namespace cbl {
             @param collectionName  The name of the collection.
             @param scopeName  The name of the scope.
             @return A \ref Collection instance. */
-        inline Collection createCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName);
+        inline Collection createCollection(slice collectionName, slice scopeName = kCBLDefaultScopeName);
         
         /** Delete an existing collection.
             @note The default collection cannot be deleted.
             @param collectionName  The name of the collection.
             @param scopeName  The name of the scope. */
-        inline void deleteCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName) {
+        inline void deleteCollection(slice collectionName, slice scopeName = kCBLDefaultScopeName) {
             CBLError error {};
             internal::check(CBLDatabase_DeleteCollection(ref(), collectionName, scopeName, &error), error);
         }
@@ -405,7 +405,7 @@ namespace cbl {
         CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE(Database, RefCounted, CBLDatabase)
 
     private:
-        void open(slice& name, const CBLDatabaseConfiguration* _cbl_nullable config) {
+        void open(slice name, const CBLDatabaseConfiguration* _cbl_nullable config) {
             CBLError error {};
             _ref = (CBLRefCounted*)CBLDatabase_Open(name, config, &error);
             internal::check(_ref != nullptr, error);

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -24,11 +24,13 @@
 #include "cbl/CBLQuery.h"
 #include "cbl/CBLLog.h"
 #include "cbl/CBLScope.h"
+#include "fleece/Fleece.hh"
 #include "fleece/Mutable.hh"
 #include <exception>
 #include <functional>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 // VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
@@ -37,6 +39,7 @@
 CBL_ASSUME_NONNULL_BEGIN
 
 namespace cbl {
+    class Blob;
     class Collection;
     class Document;
     class MutableDocument;
@@ -59,10 +62,87 @@ namespace cbl {
             @note Must be called before opening a database that intends to use the vector search extension. */
         static void enableVectorSearch(slice path) {
             CBLError error {};
-            RefCounted::check(CBL_EnableVectorSearch(path, &error), error);
+            Base::check(CBL_EnableVectorSearch(path, &error), error);
         }
     };
+
+    using EncryptionAlgorithm = CBLEncryptionAlgorithm;
+    using EncryptionKeySize   = CBLEncryptionKeySize;
+
+    /** ENTERPRISE EDITION ONLY
+
+        A database encryption key, used in \ref DatabaseConfiguration to open or create an
+        encrypted database. */
+    struct EncryptionKey : public CBLEncryptionKey {
+        /** Creates an empty key (algorithm \ref kCBLEncryptionNone, i.e. no encryption). */
+        EncryptionKey()
+        : CBLEncryptionKey()
+        {}
+
+        /** Creates a key from an existing C \ref CBLEncryptionKey.
+            @param k  The C encryption key to copy. */
+        EncryptionKey(const CBLEncryptionKey& k)
+        : CBLEncryptionKey(k)
+        {}
+
+        /** Derives an AES-256 key from a password.
+            @param password  The password to derive the key from.
+            @param old  If true, uses the legacy (SHA-1-based) derivation; otherwise uses the
+                        current (SHA-256-based) derivation. Pass true only to open databases
+                        created with the older algorithm. */
+        EncryptionKey(slice password, bool old = false) {
+            if ( old ) CBLEncryptionKey_FromPasswordOld(this, password);
+            else CBLEncryptionKey_FromPassword(this, password);
+        }
+
+        /** Assigns from an existing C \ref CBLEncryptionKey. */
+        EncryptionKey& operator=(const CBLEncryptionKey& k) {
+            CBLEncryptionKey::operator=(k);
+            return *this;
+        }
+    };
+
 #endif
+
+    /** Database configuration options. */
+    struct DatabaseConfiguration {
+        std::string_view directory;      ///< The parent directory of the database
+    #ifdef COUCHBASE_ENTERPRISE
+        EncryptionKey encryptionKey;     ///< The database's encryption key (if any)
+    #endif
+        /** As Couchbase Lite normally configures its databases, There is a very
+            small (though non-zero) chance that a power failure at just the wrong
+            time could cause the most recently committed transaction's changes to
+            be lost. This would cause the database to appear as it did immediately
+            before that transaction.
+
+            Setting this mode true ensures that an operating system crash or
+            power failure will not cause the loss of any data.  FULL synchronous
+            is very safe but it is also dramatically slower. */
+        bool fullSync;
+
+        DatabaseConfiguration(const CBLDatabaseConfiguration& cblConfig) {
+            directory = (slice)cblConfig.directory;
+#ifdef COUCHBASE_ENTERPRISE
+            encryptionKey = cblConfig.encryptionKey;
+#endif
+            fullSync = cblConfig.fullSync;
+        }
+
+        operator CBLDatabaseConfiguration() const {
+            return CBLDatabaseConfiguration{(slice)directory,
+#ifdef COUCHBASE_ENTERPRISE
+                encryptionKey,
+#endif
+                fullSync};
+        }
+
+        /** Returns a configuration initialized with the default settings (default directory,
+            no encryption, full-sync off). */
+        inline static DatabaseConfiguration defaultConfiguration() {
+            return CBLDatabaseConfiguration_Default();
+        }
+    };
 
     /** Couchbase Lite Database. */
     class Database : private RefCounted {
@@ -87,8 +167,8 @@ namespace cbl {
                                  slice toName)
         {
             CBLError error;
-            check( CBL_CopyDatabase(fromPath, toName,
-                                    nullptr, &error), error );
+            Base::check( CBL_CopyDatabase(fromPath, toName,
+                                          nullptr, &error), error );
         }
 
         /** Copies a database file to a new location, and assigns it a new internal UUID to distinguish
@@ -98,11 +178,12 @@ namespace cbl {
             @param config  The database configuration (directory and encryption option.) */
         static void copyDatabase(slice fromPath,
                                  slice toName,
-                                 const CBLDatabaseConfiguration& config)
+                                 const DatabaseConfiguration& config)
         {
             CBLError error;
-            check( CBL_CopyDatabase(fromPath, toName,
-                                    &config, &error), error );
+            CBLDatabaseConfiguration cblConfig = config;
+            Base::check( CBL_CopyDatabase(fromPath, toName,
+                                          &cblConfig, &error), error );
         }
 
         /** Deletes a database file. If the database file is open, an error will be thrown.
@@ -116,7 +197,7 @@ namespace cbl {
             if (!CBL_DeleteDatabase(name,
                                     inDirectory,
                                     &error) && error.code != 0)
-                check(false, error);
+                Base::check(false, error);
         }
 
         // Lifecycle:
@@ -135,40 +216,81 @@ namespace cbl {
             @param name  The database name (without the ".cblite2" extension.)
             @param config  The database configuration (directory and encryption option.) */
         Database(slice name,
-                 const CBLDatabaseConfiguration& config)
+                 const DatabaseConfiguration& config)
         {
-            open(name, &config);
+            CBLDatabaseConfiguration cblConfig = config;
+            open(name, &cblConfig);
         }
 
         /** Closes an open database. */
         void close() {
             CBLError error;
-            check(CBLDatabase_Close(ref(), &error), error);
+            Base::check(CBLDatabase_Close(ref(), &error), error);
         }
 
         /** Closes and deletes a database. */
         void deleteDatabase() {
             CBLError error;
-            check(CBLDatabase_Delete(ref(), &error), error);
+            Base::check(CBLDatabase_Delete(ref(), &error), error);
         }
         
         /** Performs database maintenance.
             @param type  The database maintenance type. */
         void performMaintenance(CBLMaintenanceType type) {
             CBLError error;
-            check(CBLDatabase_PerformMaintenance(ref(), type, &error), error);
+            Base::check(CBLDatabase_PerformMaintenance(ref(), type, &error), error);
         }
+
+#ifdef COUCHBASE_ENTERPRISE
+        /** Encrypts or decrypts a database, or changes its encryption key.
+
+            If \p newKey is NULL, or its \p algorithm is \ref kCBLEncryptionNone, the database will be decrypted.
+            Otherwise the database will be encrypted with that key; if it was already encrypted, it will be
+            re-encrypted with the new key. */
+        void changeEncryptionKey(const EncryptionKey* _cbl_nullable newKey) {
+            CBLError error{};
+            Base::check(CBLDatabase_ChangeEncryptionKey(ref(), newKey, &error), error);
+        }
+#endif
 
         // Accessors:
         
         /** Returns the database's name. */
-        std::string name() const                        {return asString(CBLDatabase_Name(ref()));}
+        std::string name() const                        {return Base::asString(CBLDatabase_Name(ref()));}
         
         /** Returns the database's full filesystem path, or an empty string if the database is closed or deleted. */
-        std::string path() const                        {return asString(CBLDatabase_Path(ref()));}
+        std::string path() const                        {return Base::asString(CBLDatabase_Path(ref()));}
         
         /** Returns the database's configuration, as given when it was opened. */
-        CBLDatabaseConfiguration config() const         {return CBLDatabase_Config(ref());}
+        DatabaseConfiguration config() const            {return CBLDatabase_Config(ref());}
+
+        /** Get a \ref Blob from the database using the \ref Blob properties.
+
+            The \ref Blob properties is a blob's metadata containing two required fields
+            which are a special marker property `"@type":"blob"`, and property `digest` whose value
+            is a hex SHA-1 digest of the blob's data. The other optional properties are `length` and
+            `content_type`. To obtain the \ref Blob properties from a \ref Blob,
+            call \ref Blob::properties function.
+
+            @param properties   The properties for getting the \ref Blob object.
+            @return  The \ref Blob, or a falsy Blob if no blob with the given digest exists.
+            @throws cbl::Error  On a database error (such as malformed blob properties). Note a
+                    non-existent blob is not an error — that returns a falsy Blob rather than throwing. */
+        inline Blob getBlob(fleece::Dict properties) const;
+
+        /** Save a new \ref Blob object into the database without associating it with
+            any documents. The properties of the saved \ref Blob object will include
+            information necessary for referencing the \ref Blob object in the properties
+            of the document to be saved into the database.
+
+            Normally you do not need to use this function unless you are in the situation
+            (e.g. developing javascript binding) that you cannot retain the \ref CBLBlob
+            object until the document containing the \ref CBLBlob object is successfully
+            saved into the database.
+            \note The saved \ref Blob objects that are not associated with any documents
+                  will be removed from the database when compacting the database.
+            @param blob The Blob to save. */
+        inline void saveBlob(const Blob& blob);
 
         // Collections:
         
@@ -179,7 +301,7 @@ namespace cbl {
         fleece::MutableArray getScopeNames() const {
             CBLError error {};
             FLMutableArray flNames = CBLDatabase_ScopeNames(ref(), &error);
-            check(flNames, error);
+            Base::check(error.code == 0, error);
             fleece::MutableArray names(flNames);
             FLMutableArray_Release(flNames);
             return names;
@@ -191,7 +313,7 @@ namespace cbl {
         fleece::MutableArray getCollectionNames(slice scopeName =kCBLDefaultScopeName) const {
             CBLError error {};
             FLMutableArray flNames = CBLDatabase_CollectionNames(ref(), scopeName, &error);
-            check(flNames, error);
+            Base::check(error.code == 0, error);
             fleece::MutableArray names(flNames);
             FLMutableArray_Release(flNames);
             return names;
@@ -200,7 +322,9 @@ namespace cbl {
         /** Returns the existing collection with the given name and scope.
             @param collectionName  The name of the collection.
             @param scopeName  The name of the scope.
-            @return A \ref Collection instance, or NULL if the collection doesn't exist, or throws if an error occurred. */
+            @return The \ref Collection, or a falsy Collection if it doesn't exist.
+            @throws cbl::Error  On a database error. Note a non-existent collection is not an
+                    error — that returns a falsy Collection rather than throwing. */
         inline Collection getCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName) const;
         
         /** Create a new collection.
@@ -212,7 +336,7 @@ namespace cbl {
             @note If the collection already exists, the existing collection will be returned.
             @param collectionName  The name of the collection.
             @param scopeName  The name of the scope.
-            @return A \ref Collection instance, or throws if an error occurred. */
+            @return A \ref Collection instance. */
         inline Collection createCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName);
         
         /** Delete an existing collection.
@@ -221,7 +345,7 @@ namespace cbl {
             @param scopeName  The name of the scope. */
         inline void deleteCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName) {
             CBLError error {};
-            check(CBLDatabase_DeleteCollection(ref(), collectionName, scopeName, &error), error);
+            Base::check(CBLDatabase_DeleteCollection(ref(), collectionName, scopeName, &error), error);
         }
         
         /** Returns the default collection. */
@@ -277,7 +401,7 @@ namespace cbl {
         void open(slice& name, const CBLDatabaseConfiguration* _cbl_nullable config) {
             CBLError error {};
             _ref = (CBLRefCounted*)CBLDatabase_Open(name, config, &error);
-            check(_ref != nullptr, error);
+            Base::check(_ref != nullptr, error);
             
             _notificationReadyCallbackAccess = std::make_shared<NotificationsReadyCallbackAccess>();
         }
@@ -350,8 +474,8 @@ namespace cbl {
         { }
 
         explicit Transaction (CBLDatabase *db) {
-            CBLError error;
-            RefCounted::check(CBLDatabase_BeginTransaction(db, &error), error);
+            CBLError error{};
+            Base::check(CBLDatabase_BeginTransaction(db, &error), error);
             _db = db;
         }
 
@@ -377,7 +501,7 @@ namespace cbl {
                         CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
                                 "Transaction::end failed, while handling an exception");
                     else
-                        RefCounted::check(false, error);
+                        Base::check(false, error);
                 }
             }
         }

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -60,9 +60,9 @@ namespace cbl {
             This function must be called before opening a database that intends to use the vector search extension.
             @param path The file system path of the directory that contains the Vector Search extension library.
             @note Must be called before opening a database that intends to use the vector search extension. */
-        static void enableVectorSearch(slice path) {
+        static void enableVectorSearch(std::string_view path) {
             CBLError error {};
-            internal::check(CBL_EnableVectorSearch(path, &error), error);
+            internal::check(CBL_EnableVectorSearch(slice(path), &error), error);
         }
     };
 
@@ -90,9 +90,9 @@ namespace cbl {
             @param old  If true, uses the legacy (SHA-1-based) derivation; otherwise uses the
                         current (SHA-256-based) derivation. Pass true only to open databases
                         created with the older algorithm. */
-        EncryptionKey(slice password, bool old = false) {
-            if ( old ) CBLEncryptionKey_FromPasswordOld(this, password);
-            else CBLEncryptionKey_FromPassword(this, password);
+        EncryptionKey(std::string_view password, bool old = false) {
+            if ( old ) CBLEncryptionKey_FromPasswordOld(this, slice(password));
+            else CBLEncryptionKey_FromPassword(this, slice(password));
         }
 
         /** Assigns from an existing C \ref CBLEncryptionKey. */
@@ -144,24 +144,28 @@ namespace cbl {
         // Static database-file operations:
 
         /** Returns true if a database with the given name exists in the given directory.
+            @param name  The database name (without the ".cblite2" extension.) It must be an absolute
+                        or relative path to the database. */
+        static bool exists(std::string_view name) {
+            return CBL_DatabaseExists(slice(name), fleece::nullslice);
+        }
+        static bool exists(std::string_view name, std::nullptr_t) = delete;
+        /** Returns true if a database with the given name exists in the given directory.
             @param name  The database name (without the ".cblite2" extension.)
-            @param inDirectory  The directory containing the database. If NULL, `name` must be an
-                               absolute or relative path to the database. */
-        static bool exists(slice name,
-                           slice inDirectory)
-        {
-            return CBL_DatabaseExists(name, inDirectory);
+            @param inDirectory  The directory containing the database. */
+        static bool exists(std::string_view name, std::string_view inDirectory) {
+            return CBL_DatabaseExists(slice(name), slice(inDirectory));
         }
 
         /** Copies a database file to a new location, and assigns it a new internal UUID to distinguish
             it from the original database when replicating.
             @param fromPath  The full filesystem path to the original database (including extension).
             @param toName  The new database name (without the ".cblite2" extension.) */
-        static void copyDatabase(slice fromPath,
-                                 slice toName)
+        static void copyDatabase(std::string_view fromPath,
+                                 std::string_view toName)
         {
             CBLError error;
-            internal::check( CBL_CopyDatabase(fromPath, toName,
+            internal::check( CBL_CopyDatabase(slice(fromPath), slice(toName),
                                               nullptr, &error), error );
         }
 
@@ -170,8 +174,8 @@ namespace cbl {
             @param fromPath  The full filesystem path to the original database (including extension).
             @param toName  The new database name (without the ".cblite2" extension.)
             @param config  The database configuration (directory and encryption option.) */
-        static void copyDatabase(slice fromPath,
-                                 slice toName,
+        static void copyDatabase(std::string_view fromPath,
+                                 std::string_view toName,
                                  const DatabaseConfiguration& config)
         {
             CBLError error;
@@ -182,21 +186,25 @@ namespace cbl {
 #endif
                 config.fullSync
             };
-            internal::check( CBL_CopyDatabase(fromPath, toName,
+            internal::check( CBL_CopyDatabase(slice(fromPath), slice(toName),
                                               &cblConfig, &error), error );
         }
 
         /** Deletes a database file. If the database file is open, an error will be thrown.
-            @param name  The database name (without the ".cblite2" extension.)
-            @param inDirectory  The directory containing the database. If NULL, `name` must be an
-                                absolute or relative path to the database. */
-        static void deleteDatabase(slice name,
-                                   slice inDirectory)
-        {
+            @param name  The database name (without the ".cblite2" extension.) It must be an
+                        absolute or relative path to the database. */
+        static void deleteDatabase(std::string_view name) {
             CBLError error;
-            if (!CBL_DeleteDatabase(name,
-                                    inDirectory,
-                                    &error) && error.code != 0)
+            if (!CBL_DeleteDatabase(slice(name), fleece::nullslice, &error) && error.code != 0)
+                internal::check(false, error);
+        }
+        static void deleteDatabase(std::string_view name, std::nullptr_t) = delete;
+        /** Deletes a database file. If the database file is open, an error will be thrown.
+            @param name  The database name (without the ".cblite2" extension.)
+            @param inDirectory  The directory containing the database. */
+        static void deleteDatabase(std::string_view name, std::string_view inDirectory) {
+            CBLError error;
+            if (!CBL_DeleteDatabase(slice(name), slice(inDirectory), &error) && error.code != 0)
                 internal::check(false, error);
         }
 
@@ -206,7 +214,7 @@ namespace cbl {
             It's OK to open the same database file multiple times. Each \ref Database instance is
             independent of the others (and must be separately closed and released.)
             @param name  The database name (without the ".cblite2" extension.) */
-        Database(slice name) {
+        Database(std::string_view name) {
             open(name, nullptr);
         }
 
@@ -215,7 +223,7 @@ namespace cbl {
             independent of the others (and must be separately closed and released.)
             @param name  The database name (without the ".cblite2" extension.)
             @param config  The database configuration (directory and encryption option.) */
-        Database(slice name,
+        Database(std::string_view name,
                  const DatabaseConfiguration& config)
         {
             CBLDatabaseConfiguration cblConfig{
@@ -316,9 +324,9 @@ namespace cbl {
         /** Returns the names of all collections in the scope.
             @param scopeName  The name of the scope.
             @return The names of all collections in the scope, or throws if an error occurred. */
-        fleece::MutableArray getCollectionNames(slice scopeName =kCBLDefaultScopeName) const {
+        fleece::MutableArray getCollectionNames(std::string_view scopeName = (std::string_view)slice(kCBLDefaultScopeName)) const {
             CBLError error {};
-            FLMutableArray flNames = CBLDatabase_CollectionNames(ref(), scopeName, &error);
+            FLMutableArray flNames = CBLDatabase_CollectionNames(ref(), slice(scopeName), &error);
             internal::check(error.code == 0, error);
             fleece::MutableArray names(flNames);
             FLMutableArray_Release(flNames);
@@ -331,7 +339,7 @@ namespace cbl {
             @return The \ref Collection, or a falsy Collection if it doesn't exist.
             @throws cbl::Error  On a database error. Note a non-existent collection is not an
                     error — that returns a falsy Collection rather than throwing. */
-        inline Collection getCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName) const;
+        inline Collection getCollection(std::string_view collectionName, std::string_view scopeName = (std::string_view)slice(kCBLDefaultScopeName)) const;
         
         /** Create a new collection.
             The naming rules of the collections and scopes are as follows:
@@ -343,15 +351,15 @@ namespace cbl {
             @param collectionName  The name of the collection.
             @param scopeName  The name of the scope.
             @return A \ref Collection instance. */
-        inline Collection createCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName);
+        inline Collection createCollection(std::string_view collectionName, std::string_view scopeName = (std::string_view)slice(kCBLDefaultScopeName));
         
         /** Delete an existing collection.
             @note The default collection cannot be deleted.
             @param collectionName  The name of the collection.
             @param scopeName  The name of the scope. */
-        inline void deleteCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName) {
+        inline void deleteCollection(std::string_view collectionName, std::string_view scopeName = (std::string_view)slice(kCBLDefaultScopeName)) {
             CBLError error {};
-            internal::check(CBLDatabase_DeleteCollection(ref(), collectionName, scopeName, &error), error);
+            internal::check(CBLDatabase_DeleteCollection(ref(), slice(collectionName), slice(scopeName), &error), error);
         }
         
         /** Returns the default collection. */
@@ -369,7 +377,7 @@ namespace cbl {
                     [N1QL](https://docs.couchbase.com/server/4.0/n1ql/n1ql-language-reference/index.html).
             @param queryString  The query string.
             @return  The new query object. */
-        inline Query createQuery(CBLQueryLanguage language, slice queryString);
+        inline Query createQuery(CBLQueryLanguage language, std::string_view queryString);
 
         // Notifications:
         
@@ -404,9 +412,9 @@ namespace cbl {
         CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE(Database, RefCounted, CBLDatabase)
 
     private:
-        void open(slice name, const CBLDatabaseConfiguration* _cbl_nullable config) {
+        void open(std::string_view name, const CBLDatabaseConfiguration* _cbl_nullable config) {
             CBLError error {};
-            _ref = (CBLRefCounted*)CBLDatabase_Open(name, config, &error);
+            _ref = (CBLRefCounted*)CBLDatabase_Open(slice(name), config, &error);
             internal::check(_ref != nullptr, error);
             
             _notificationReadyCallbackAccess = std::make_shared<NotificationsReadyCallbackAccess>();

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -162,7 +162,7 @@ namespace cbl {
         {
             CBLError error;
             internal::check( CBL_CopyDatabase(fromPath, toName,
-                                          nullptr, &error), error );
+                                              nullptr, &error), error );
         }
 
         /** Copies a database file to a new location, and assigns it a new internal UUID to distinguish
@@ -182,9 +182,8 @@ namespace cbl {
 #endif
                 config.fullSync
             };
-
             internal::check( CBL_CopyDatabase(fromPath, toName,
-                                          &cblConfig, &error), error );
+                                              &cblConfig, &error), error );
         }
 
         /** Deletes a database file. If the database file is open, an error will be thrown.
@@ -317,7 +316,7 @@ namespace cbl {
         /** Returns the names of all collections in the scope.
             @param scopeName  The name of the scope.
             @return The names of all collections in the scope, or throws if an error occurred. */
-        fleece::MutableArray getCollectionNames(slice scopeName = kCBLDefaultScopeName) const {
+        fleece::MutableArray getCollectionNames(slice scopeName =kCBLDefaultScopeName) const {
             CBLError error {};
             FLMutableArray flNames = CBLDatabase_CollectionNames(ref(), scopeName, &error);
             internal::check(error.code == 0, error);
@@ -332,7 +331,7 @@ namespace cbl {
             @return The \ref Collection, or a falsy Collection if it doesn't exist.
             @throws cbl::Error  On a database error. Note a non-existent collection is not an
                     error — that returns a falsy Collection rather than throwing. */
-        inline Collection getCollection(slice collectionName, slice scopeName = kCBLDefaultScopeName) const;
+        inline Collection getCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName) const;
         
         /** Create a new collection.
             The naming rules of the collections and scopes are as follows:
@@ -344,13 +343,13 @@ namespace cbl {
             @param collectionName  The name of the collection.
             @param scopeName  The name of the scope.
             @return A \ref Collection instance. */
-        inline Collection createCollection(slice collectionName, slice scopeName = kCBLDefaultScopeName);
+        inline Collection createCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName);
         
         /** Delete an existing collection.
             @note The default collection cannot be deleted.
             @param collectionName  The name of the collection.
             @param scopeName  The name of the scope. */
-        inline void deleteCollection(slice collectionName, slice scopeName = kCBLDefaultScopeName) {
+        inline void deleteCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName) {
             CBLError error {};
             internal::check(CBLDatabase_DeleteCollection(ref(), collectionName, scopeName, &error), error);
         }

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -144,17 +144,13 @@ namespace cbl {
         // Static database-file operations:
 
         /** Returns true if a database with the given name exists in the given directory.
-            @param name  The database name (without the ".cblite2" extension.) It must be an absolute
-                        or relative path to the database. */
-        static bool exists(std::string_view name) {
-            return CBL_DatabaseExists(slice(name), fleece::nullslice);
-        }
-        static bool exists(std::string_view name, std::nullptr_t) = delete;
-        /** Returns true if a database with the given name exists in the given directory.
             @param name  The database name (without the ".cblite2" extension.)
-            @param inDirectory  The directory containing the database. */
-        static bool exists(std::string_view name, std::string_view inDirectory) {
-            return CBL_DatabaseExists(slice(name), slice(inDirectory));
+            @param inDirectory  The directory containing the database. If not provided, `name` must be an
+                absolute or relative path to the database. */
+        static bool exists(std::string_view name, std::optional<std::string_view> inDirectory=std::nullopt) {
+            slice inDir;
+            if ( inDirectory ) inDir = slice(*inDirectory);
+            return CBL_DatabaseExists(slice(name), inDir);
         }
 
         /** Copies a database file to a new location, and assigns it a new internal UUID to distinguish
@@ -191,20 +187,14 @@ namespace cbl {
         }
 
         /** Deletes a database file. If the database file is open, an error will be thrown.
-            @param name  The database name (without the ".cblite2" extension.) It must be an
-                        absolute or relative path to the database. */
-        static void deleteDatabase(std::string_view name) {
-            CBLError error;
-            if (!CBL_DeleteDatabase(slice(name), fleece::nullslice, &error) && error.code != 0)
-                internal::check(false, error);
-        }
-        static void deleteDatabase(std::string_view name, std::nullptr_t) = delete;
-        /** Deletes a database file. If the database file is open, an error will be thrown.
             @param name  The database name (without the ".cblite2" extension.)
-            @param inDirectory  The directory containing the database. */
-        static void deleteDatabase(std::string_view name, std::string_view inDirectory) {
+            @param inDirectory  The directory containing the database(optional), If not provided, `name` must be an
+                absolute or relative path to the database. */
+        static void deleteDatabase(std::string_view name, std::optional<std::string_view> inDirectory =std::nullopt) {
             CBLError error;
-            if (!CBL_DeleteDatabase(slice(name), slice(inDirectory), &error) && error.code != 0)
+            slice inDir;
+            if ( inDirectory ) inDir = slice(*inDirectory);
+            if (!CBL_DeleteDatabase(slice(name), inDir, &error) && error.code != 0)
                 internal::check(false, error);
         }
 
@@ -357,9 +347,11 @@ namespace cbl {
             @note The default collection cannot be deleted.
             @param collectionName  The name of the collection.
             @param scopeName  The name of the scope. */
-        inline void deleteCollection(std::string_view collectionName, std::string_view scopeName = (std::string_view)slice(kCBLDefaultScopeName)) {
+        inline void deleteCollection(std::string_view collectionName, std::optional<std::string_view> scopeName =slice(kCBLDefaultScopeName)) {
             CBLError error {};
-            internal::check(CBLDatabase_DeleteCollection(ref(), slice(collectionName), slice(scopeName), &error), error);
+            slice sname;
+            if ( scopeName ) sname = *scopeName;
+            internal::check(CBLDatabase_DeleteCollection(ref(), slice(collectionName), sname, &error), error);
         }
         
         /** Returns the default collection. */

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -66,7 +66,9 @@ namespace cbl {
         }
     };
 
+    /** Alias for the C \ref CBLEncryptionAlgorithm enum identifying an encryption algorithm. */
     using EncryptionAlgorithm = CBLEncryptionAlgorithm;
+    /** Alias for the C \ref CBLEncryptionKeySize enum giving the required key size for an algorithm. */
     using EncryptionKeySize   = CBLEncryptionKeySize;
 
     /** ENTERPRISE EDITION ONLY
@@ -121,6 +123,9 @@ namespace cbl {
             is very safe but it is also dramatically slower. */
         bool fullSync{false};
 
+        /** Constructs a configuration from a C \ref CBLDatabaseConfiguration, copying the
+            directory and (in EE) encryption key out of it.
+            @param cblConfig  The C configuration to copy from. */
         DatabaseConfiguration(const CBLDatabaseConfiguration& cblConfig) {
             directory = ((slice)cblConfig.directory).asString();
 #ifdef COUCHBASE_ENTERPRISE
@@ -129,6 +134,7 @@ namespace cbl {
             fullSync = cblConfig.fullSync;
         }
 
+        /** Default constructor: empty directory, no encryption, full-sync off. */
         DatabaseConfiguration() = default;
 
         /** Returns a configuration initialized with the default settings (default directory,
@@ -392,7 +398,9 @@ namespace cbl {
         }
         
         // Destructors:
-        
+
+        /** Releases the underlying database handle. The database remains open if other
+            \ref Database references to it exist. */
         ~Database() {
             clear();
         }
@@ -458,6 +466,9 @@ namespace cbl {
             return *this;
         }
         
+        /** Releases the underlying C \ref CBLDatabase handle and drops the buffered-notification
+            callback. After this call the object is empty (\ref operator bool returns false).
+            @note Other \ref Database references to the same database file remain valid. */
         void clear() {
             // Reset _notificationReadyCallbackAccess the releasing the _ref to
             // ensure that CBLDatabase is deleted before _notificationReadyCallbackAccess.
@@ -479,6 +490,9 @@ namespace cbl {
         :Transaction(db.ref())
         { }
 
+        /** Begins a batch operation on the given C database handle. Provided for callers
+            that hold a raw \ref CBLDatabase pointer rather than a C++ \ref Database wrapper.
+            @param db  The database to begin a transaction on. */
         explicit Transaction (CBLDatabase *db) {
             CBLError error{};
             internal::check(CBLDatabase_BeginTransaction(db, &error), error);
@@ -491,6 +505,7 @@ namespace cbl {
         /** Ends the transaction, rolling back changes. */
         void abort()    {end(false);}
 
+        /** Ends the transaction, rolling back any changes that have not been committed. */
         ~Transaction()  {end(false);}
 
     private:

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -62,7 +62,7 @@ namespace cbl {
             @note Must be called before opening a database that intends to use the vector search extension. */
         static void enableVectorSearch(slice path) {
             CBLError error {};
-            Base::check(CBL_EnableVectorSearch(path, &error), error);
+            internal::check(CBL_EnableVectorSearch(path, &error), error);
         }
     };
 
@@ -106,7 +106,7 @@ namespace cbl {
 
     /** Database configuration options. */
     struct DatabaseConfiguration {
-        std::string_view directory;      ///< The parent directory of the database
+        std::string      directory;      ///< The parent directory of the database
     #ifdef COUCHBASE_ENTERPRISE
         EncryptionKey encryptionKey;     ///< The database's encryption key (if any)
     #endif
@@ -119,27 +119,21 @@ namespace cbl {
             Setting this mode true ensures that an operating system crash or
             power failure will not cause the loss of any data.  FULL synchronous
             is very safe but it is also dramatically slower. */
-        bool fullSync;
+        bool fullSync{false};
 
         DatabaseConfiguration(const CBLDatabaseConfiguration& cblConfig) {
-            directory = (slice)cblConfig.directory;
+            directory = ((slice)cblConfig.directory).asString();
 #ifdef COUCHBASE_ENTERPRISE
             encryptionKey = cblConfig.encryptionKey;
 #endif
             fullSync = cblConfig.fullSync;
         }
 
-        operator CBLDatabaseConfiguration() const {
-            return CBLDatabaseConfiguration{(slice)directory,
-#ifdef COUCHBASE_ENTERPRISE
-                encryptionKey,
-#endif
-                fullSync};
-        }
+        DatabaseConfiguration() = default;
 
         /** Returns a configuration initialized with the default settings (default directory,
             no encryption, full-sync off). */
-        inline static DatabaseConfiguration defaultConfiguration() {
+        static DatabaseConfiguration defaultConfiguration() {
             return CBLDatabaseConfiguration_Default();
         }
     };
@@ -167,7 +161,7 @@ namespace cbl {
                                  slice toName)
         {
             CBLError error;
-            Base::check( CBL_CopyDatabase(fromPath, toName,
+            internal::check( CBL_CopyDatabase(fromPath, toName,
                                           nullptr, &error), error );
         }
 
@@ -181,8 +175,15 @@ namespace cbl {
                                  const DatabaseConfiguration& config)
         {
             CBLError error;
-            CBLDatabaseConfiguration cblConfig = config;
-            Base::check( CBL_CopyDatabase(fromPath, toName,
+            CBLDatabaseConfiguration cblConfig{
+                (slice)config.directory,
+#ifdef COUCHBASE_ENTERPRISE
+                config.encryptionKey,
+#endif
+                config.fullSync
+            };
+
+            internal::check( CBL_CopyDatabase(fromPath, toName,
                                           &cblConfig, &error), error );
         }
 
@@ -197,7 +198,7 @@ namespace cbl {
             if (!CBL_DeleteDatabase(name,
                                     inDirectory,
                                     &error) && error.code != 0)
-                Base::check(false, error);
+                internal::check(false, error);
         }
 
         // Lifecycle:
@@ -218,27 +219,33 @@ namespace cbl {
         Database(slice name,
                  const DatabaseConfiguration& config)
         {
-            CBLDatabaseConfiguration cblConfig = config;
+            CBLDatabaseConfiguration cblConfig{
+                (slice)config.directory,
+#ifdef COUCHBASE_ENTERPRISE
+                config.encryptionKey,
+#endif
+                config.fullSync
+            };
             open(name, &cblConfig);
         }
 
         /** Closes an open database. */
         void close() {
             CBLError error;
-            Base::check(CBLDatabase_Close(ref(), &error), error);
+            internal::check(CBLDatabase_Close(ref(), &error), error);
         }
 
         /** Closes and deletes a database. */
         void deleteDatabase() {
             CBLError error;
-            Base::check(CBLDatabase_Delete(ref(), &error), error);
+            internal::check(CBLDatabase_Delete(ref(), &error), error);
         }
         
         /** Performs database maintenance.
             @param type  The database maintenance type. */
         void performMaintenance(CBLMaintenanceType type) {
             CBLError error;
-            Base::check(CBLDatabase_PerformMaintenance(ref(), type, &error), error);
+            internal::check(CBLDatabase_PerformMaintenance(ref(), type, &error), error);
         }
 
 #ifdef COUCHBASE_ENTERPRISE
@@ -249,17 +256,17 @@ namespace cbl {
             re-encrypted with the new key. */
         void changeEncryptionKey(const EncryptionKey* _cbl_nullable newKey) {
             CBLError error{};
-            Base::check(CBLDatabase_ChangeEncryptionKey(ref(), newKey, &error), error);
+            internal::check(CBLDatabase_ChangeEncryptionKey(ref(), newKey, &error), error);
         }
 #endif
 
         // Accessors:
         
         /** Returns the database's name. */
-        std::string name() const                        {return Base::asString(CBLDatabase_Name(ref()));}
+        std::string name() const                        {return internal::asString(CBLDatabase_Name(ref()));}
         
         /** Returns the database's full filesystem path, or an empty string if the database is closed or deleted. */
-        std::string path() const                        {return Base::asString(CBLDatabase_Path(ref()));}
+        std::string path() const                        {return internal::asString(CBLDatabase_Path(ref()));}
         
         /** Returns the database's configuration, as given when it was opened. */
         DatabaseConfiguration config() const            {return CBLDatabase_Config(ref());}
@@ -301,7 +308,7 @@ namespace cbl {
         fleece::MutableArray getScopeNames() const {
             CBLError error {};
             FLMutableArray flNames = CBLDatabase_ScopeNames(ref(), &error);
-            Base::check(error.code == 0, error);
+            internal::check(error.code == 0, error);
             fleece::MutableArray names(flNames);
             FLMutableArray_Release(flNames);
             return names;
@@ -313,7 +320,7 @@ namespace cbl {
         fleece::MutableArray getCollectionNames(slice scopeName =kCBLDefaultScopeName) const {
             CBLError error {};
             FLMutableArray flNames = CBLDatabase_CollectionNames(ref(), scopeName, &error);
-            Base::check(error.code == 0, error);
+            internal::check(error.code == 0, error);
             fleece::MutableArray names(flNames);
             FLMutableArray_Release(flNames);
             return names;
@@ -345,7 +352,7 @@ namespace cbl {
             @param scopeName  The name of the scope. */
         inline void deleteCollection(slice collectionName, slice scopeName =kCBLDefaultScopeName) {
             CBLError error {};
-            Base::check(CBLDatabase_DeleteCollection(ref(), collectionName, scopeName, &error), error);
+            internal::check(CBLDatabase_DeleteCollection(ref(), collectionName, scopeName, &error), error);
         }
         
         /** Returns the default collection. */
@@ -401,11 +408,11 @@ namespace cbl {
         void open(slice& name, const CBLDatabaseConfiguration* _cbl_nullable config) {
             CBLError error {};
             _ref = (CBLRefCounted*)CBLDatabase_Open(name, config, &error);
-            Base::check(_ref != nullptr, error);
+            internal::check(_ref != nullptr, error);
             
             _notificationReadyCallbackAccess = std::make_shared<NotificationsReadyCallbackAccess>();
         }
-        
+
         class NotificationsReadyCallbackAccess {
         public:
             void setCallback(NotificationsReadyCallback callback) {
@@ -475,7 +482,7 @@ namespace cbl {
 
         explicit Transaction (CBLDatabase *db) {
             CBLError error{};
-            Base::check(CBLDatabase_BeginTransaction(db, &error), error);
+            internal::check(CBLDatabase_BeginTransaction(db, &error), error);
             _db = db;
         }
 
@@ -501,7 +508,7 @@ namespace cbl {
                         CBL_Log(kCBLLogDomainDatabase, kCBLLogWarning,
                                 "Transaction::end failed, while handling an exception");
                     else
-                        Base::check(false, error);
+                        internal::check(false, error);
                 }
             }
         }

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -76,7 +76,8 @@ namespace cbl {
 
         A database encryption key, used in \ref DatabaseConfiguration to open or create an
         encrypted database. */
-    struct EncryptionKey : public CBLEncryptionKey {
+    class EncryptionKey : public CBLEncryptionKey {
+    public:
         /** Creates an empty key (algorithm \ref kCBLEncryptionNone, i.e. no encryption). */
         EncryptionKey()
         : CBLEncryptionKey()
@@ -108,7 +109,8 @@ namespace cbl {
 #endif
 
     /** Database configuration options. */
-    struct DatabaseConfiguration {
+    class DatabaseConfiguration {
+    public:
         std::string      directory;      ///< The parent directory of the database
     #ifdef COUCHBASE_ENTERPRISE
         EncryptionKey encryptionKey;     ///< The database's encryption key (if any)
@@ -332,12 +334,12 @@ namespace cbl {
         
         /** Returns the existing collection with the given name and scope.
             @param collectionName  The name of the collection.
-            @param scopeName  The name of the scope.
+            @param scopeName  The name of the scope (optional). If not supplied, the default scope name will be used.
             @return The \ref Collection, or a falsy Collection if it doesn't exist.
             @throws cbl::Error  On a database error. Note a non-existent collection is not an
                     error — that returns a falsy Collection rather than throwing. */
-        inline Collection getCollection(std::string_view collectionName, std::string_view scopeName = (std::string_view)slice(kCBLDefaultScopeName)) const;
-        
+        inline Collection getCollection(std::string_view collectionName, std::optional<std::string_view> scopeName = std::nullopt) const;
+
         /** Create a new collection.
             The naming rules of the collections and scopes are as follows:
                 - Must be between 1 and 251 characters in length.
@@ -346,26 +348,26 @@ namespace cbl {
                 - Both scope and collection names are case sensitive.
             @note If the collection already exists, the existing collection will be returned.
             @param collectionName  The name of the collection.
-            @param scopeName  The name of the scope.
+            @param scopeName  The name of the scope (optional).  If not supplied, the default scope name will be used.
             @return A \ref Collection instance. */
-        inline Collection createCollection(std::string_view collectionName, std::string_view scopeName = (std::string_view)slice(kCBLDefaultScopeName));
+        inline Collection createCollection(std::string_view collectionName, std::optional<std::string_view> scopeName =std::nullopt);
         
         /** Delete an existing collection.
             @note The default collection cannot be deleted.
             @param collectionName  The name of the collection.
-            @param scopeName  The name of the scope. */
-        inline void deleteCollection(std::string_view collectionName, std::optional<std::string_view> scopeName =slice(kCBLDefaultScopeName)) {
+            @param scopeName  The name of the scope (optional). If not supplied, the default scope name will be used. */
+        void deleteCollection(std::string_view collectionName, std::optional<std::string_view> scopeName =std::nullopt) {
             CBLError error {};
-            slice sname;
+            slice sname = scopeName.value_or(slice(kCBLDefaultScopeName));
             if ( scopeName ) sname = *scopeName;
             internal::check(CBLDatabase_DeleteCollection(ref(), slice(collectionName), sname, &error), error);
         }
-        
+
         /** Returns the default collection. */
         inline Collection getDefaultCollection() const;
         
         // Query:
-        
+
         /** Creates a new query by compiling the input string.
             This is fast, but not instantaneous. If you need to run the same query many times, keep the
             \ref Query object around instead of compiling it each time. If you need to run related queries
@@ -376,7 +378,7 @@ namespace cbl {
                     [N1QL](https://docs.couchbase.com/server/4.0/n1ql/n1ql-language-reference/index.html).
             @param queryString  The query string.
             @return  The new query object. */
-        inline Query createQuery(CBLQueryLanguage language, std::string_view queryString);
+        inline Query createQuery(QueryLanguage language, std::string_view queryString);
 
         // Notifications:
         

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -29,6 +29,7 @@
 #include <exception>
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -228,12 +228,9 @@ namespace cbl {
             CBLCollection_DeleteDocumentWithConcurrencyControl(ref(), doc.ref(), cc, &error), error);
     }
 
-    inline bool Collection::purgeDocument(Document &doc) {
-        CBLError error;
-        bool purged = CBLCollection_PurgeDocument(ref(), doc.ref(), &error);
-        if ( !purged && !(error.domain == kCBLDomain && error.code == kCBLErrorNotFound) )
-            internal::check(false, error);
-        return purged;
+    inline void Collection::purgeDocument(Document &doc) {
+        CBLError error{};
+        internal::check(CBLCollection_PurgeDocument(ref(), doc.ref(), &error), error);
     }
 }
 

--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -37,11 +37,11 @@ namespace cbl {
         // Metadata:
 
         /** A document's ID */
-        std::string id() const                     {return asString(CBLDocument_ID(ref()));}
+        std::string id() const                     {return Base::asString(CBLDocument_ID(ref()));}
 
         /** A document's revision ID, which is a short opaque string that's guaranteed to be unique to every change made to
             the document. If the document doesn't exist yet, this function returns an empty string.  */
-        std::string revisionID() const             {return asString(CBLDocument_RevisionID(ref()));}
+        std::string revisionID() const             {return Base::asString(CBLDocument_RevisionID(ref()));}
         
         /** The hybrid logical timestamp in nanoseconds since epoch that the revision was created. */
         uint64_t timestamp() const                 {return CBLDocument_Timestamp(ref());}
@@ -82,7 +82,7 @@ namespace cbl {
 
         static Document adopt(const CBLDocument* _cbl_nullable d, CBLError *error) {
             if (!d && error->code != 0)
-                throw *error;
+                Base::check(false, *error);
             Document doc;
             doc._ref = (CBLRefCounted*)d;
             return doc;
@@ -91,10 +91,11 @@ namespace cbl {
         static bool checkSave(bool saveResult, CBLError &error) {
             if (saveResult)
                 return true;
-            else if (error.code == kCBLErrorConflict && error.domain == kCBLDomain)
+            else {
+                bool notThrow = (error.code == kCBLErrorConflict && error.domain == kCBLDomain);
+                Base::check(notThrow, error);
                 return false;
-            else
-                throw error;
+            }
         }
         
         CBL_REFCOUNTED_BOILERPLATE(Document, RefCounted, const CBLDocument)
@@ -153,17 +154,15 @@ namespace cbl {
 
         /** Sets a mutable document's properties from a JSON Dictionary string.
             Call \ref Collection::saveDocument(MutableDocument &doc) to persist the changes.
-            @param json  A JSON Dictionaryt string */
+            @param json  A JSON Dictionary string. */
         void setPropertiesAsJSON(slice json) {
             CBLError error;
-            if (!CBLDocument_SetJSON(ref(), json, &error))
-                throw error;
+            Base::check(CBLDocument_SetJSON(ref(), json, &error), error);
         }
 
     protected:
         static MutableDocument adopt(CBLDocument* _cbl_nullable d, CBLError *error) {
-            if (!d && error->code != 0)
-                throw *error;            
+            Base::check(d != nullptr || error->code == 0, *error);
             MutableDocument doc;
             doc._ref = (CBLRefCounted*)d;
             return doc;
@@ -229,7 +228,7 @@ namespace cbl {
 
     inline void Collection::purgeDocument(Document &doc) {
         CBLError error;
-        check(CBLCollection_PurgeDocument(ref(), doc.ref(), &error), error);
+        Base::check(CBLCollection_PurgeDocument(ref(), doc.ref(), &error), error);
     }
 }
 

--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -64,7 +64,7 @@ namespace cbl {
         alloc_slice propertiesAsJSON() const       {return alloc_slice(CBLDocument_CreateJSON(ref()));}
 
         /** A subscript operator to access a document's property value by key. */
-        fleece::Value operator[] (slice key) const {return properties()[key];}
+        fleece::Value operator[] (std::string_view key) const {return properties()[slice(key)];}
 
         // Operations:
         
@@ -107,15 +107,17 @@ namespace cbl {
     public:
         /** Creates a new, empty document in memory, with a randomly-generated unique ID.
             It will not be added to a database until saved. */
-        explicit MutableDocument(nullptr_t)             {_ref = (CBLRefCounted*)CBLDocument_CreateWithID(fleece::nullslice);}
-        
+        explicit MutableDocument(std::nullptr_t)        {_ref = (CBLRefCounted*)CBLDocument_CreateWithID(fleece::nullslice);}
+
         /** Creates a new, empty document in memory, with the given ID.
             It will not be added to a database until saved.
             @note If the given ID conflicts with a document already in the database, that will not
                   be apparent until this document is saved. At that time, the result depends on the
                   conflict handling mode used when saving; see the save functions for details.
             @param docID  The ID of the new document, or NULL to assign a new unique ID. */
-        explicit MutableDocument(slice docID)           {_ref = (CBLRefCounted*)CBLDocument_CreateWithID(docID);}
+        explicit MutableDocument(std::string_view docID) {
+            _ref = (CBLRefCounted*)CBLDocument_CreateWithID(slice(docID));
+        }
 
         /** Returns a mutable document's properties as a mutable dictionary.
             You may modify this dictionary and then call \ref Collection::saveDocument(MutableDocument &doc) to persist the changes.
@@ -126,7 +128,7 @@ namespace cbl {
         /** Sets a property key and value.
             Call \ref Collection::saveDocument(MutableDocument &doc) to persist the changes. */
         template <typename V>
-        void set(slice key, const V &val)               {properties().set(key, val);}
+        void set(std::string_view key, const V &val)    {properties().set(slice(key), val);}
         
         /** Sets a property key and value.
             Call \ref Collection::saveDocument(MutableDocument &doc) to persist the changes. */
@@ -135,8 +137,8 @@ namespace cbl {
 
         /** A subscript operator to access a document's property value by key for either getting or setting the value.
             Call \ref Collection::saveDocument(MutableDocument &doc) to persist the changes. */
-        fleece::keyref<fleece::MutableDict,fleece::slice> operator[] (slice key)
-                                                        {return properties()[key];}
+        fleece::keyref<fleece::MutableDict,fleece::slice> operator[] (std::string_view key)
+                                                        {return properties()[slice(key)];}
 
         /** Sets a mutable document's properties.
             Call \ref Collection::saveDocument(MutableDocument &doc) to persist the changes.
@@ -155,9 +157,9 @@ namespace cbl {
         /** Sets a mutable document's properties from a JSON Dictionary string.
             Call \ref Collection::saveDocument(MutableDocument &doc) to persist the changes.
             @param json  A JSON Dictionary string. */
-        void setPropertiesAsJSON(slice json) {
+        void setPropertiesAsJSON(std::string_view json) {
             CBLError error;
-            internal::check(CBLDocument_SetJSON(ref(), json, &error), error);
+            internal::check(CBLDocument_SetJSON(ref(), slice(json), &error), error);
         }
 
     protected:
@@ -184,14 +186,14 @@ namespace cbl {
 
     // Collection method bodies:
 
-    inline Document Collection::getDocument(slice id) const {
+    inline Document Collection::getDocument(std::string_view id) const {
         CBLError error;
-        return Document::adopt(CBLCollection_GetDocument(ref(), id, &error), &error);
+        return Document::adopt(CBLCollection_GetDocument(ref(), slice(id), &error), &error);
     }
 
-    inline MutableDocument Collection::getMutableDocument(slice id) const {
+    inline MutableDocument Collection::getMutableDocument(std::string_view id) const {
         CBLError error;
-        return MutableDocument::adopt(CBLCollection_GetMutableDocument(ref(), id, &error), &error);
+        return MutableDocument::adopt(CBLCollection_GetMutableDocument(ref(), slice(id), &error), &error);
     }
 
     inline void Collection::saveDocument(MutableDocument &doc) {

--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -37,11 +37,11 @@ namespace cbl {
         // Metadata:
 
         /** A document's ID */
-        std::string id() const                     {return Base::asString(CBLDocument_ID(ref()));}
+        std::string id() const                     {return internal::asString(CBLDocument_ID(ref()));}
 
         /** A document's revision ID, which is a short opaque string that's guaranteed to be unique to every change made to
             the document. If the document doesn't exist yet, this function returns an empty string.  */
-        std::string revisionID() const             {return Base::asString(CBLDocument_RevisionID(ref()));}
+        std::string revisionID() const             {return internal::asString(CBLDocument_RevisionID(ref()));}
         
         /** The hybrid logical timestamp in nanoseconds since epoch that the revision was created. */
         uint64_t timestamp() const                 {return CBLDocument_Timestamp(ref());}
@@ -82,7 +82,7 @@ namespace cbl {
 
         static Document adopt(const CBLDocument* _cbl_nullable d, CBLError *error) {
             if (!d && error->code != 0)
-                Base::check(false, *error);
+                internal::check(false, *error);
             Document doc;
             doc._ref = (CBLRefCounted*)d;
             return doc;
@@ -92,12 +92,12 @@ namespace cbl {
             if (saveResult)
                 return true;
             else {
-                bool notThrow = (error.code == kCBLErrorConflict && error.domain == kCBLDomain);
-                Base::check(notThrow, error);
+                bool good = (error.code == kCBLErrorConflict && error.domain == kCBLDomain);
+                internal::check(good, error);
                 return false;
             }
         }
-        
+
         CBL_REFCOUNTED_BOILERPLATE(Document, RefCounted, const CBLDocument)
     };
 
@@ -157,12 +157,12 @@ namespace cbl {
             @param json  A JSON Dictionary string. */
         void setPropertiesAsJSON(slice json) {
             CBLError error;
-            Base::check(CBLDocument_SetJSON(ref(), json, &error), error);
+            internal::check(CBLDocument_SetJSON(ref(), json, &error), error);
         }
 
     protected:
         static MutableDocument adopt(CBLDocument* _cbl_nullable d, CBLError *error) {
-            Base::check(d != nullptr || error->code == 0, *error);
+            internal::check(d != nullptr || error->code == 0, *error);
             MutableDocument doc;
             doc._ref = (CBLRefCounted*)d;
             return doc;
@@ -228,7 +228,7 @@ namespace cbl {
 
     inline void Collection::purgeDocument(Document &doc) {
         CBLError error;
-        Base::check(CBLCollection_PurgeDocument(ref(), doc.ref(), &error), error);
+        internal::check(CBLCollection_PurgeDocument(ref(), doc.ref(), &error), error);
     }
 }
 

--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -92,8 +92,8 @@ namespace cbl {
             if (saveResult)
                 return true;
             else {
-                bool good = (error.code == kCBLErrorConflict && error.domain == kCBLDomain);
-                internal::check(good, error);
+                bool permittedError = (error.code == kCBLErrorConflict && error.domain == kCBLDomain);
+                internal::check(permittedError, error); // throw if not permittedError
                 return false;
             }
         }

--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -226,9 +226,12 @@ namespace cbl {
             CBLCollection_DeleteDocumentWithConcurrencyControl(ref(), doc.ref(), cc, &error), error);
     }
 
-    inline void Collection::purgeDocument(Document &doc) {
+    inline bool Collection::purgeDocument(Document &doc) {
         CBLError error;
-        internal::check(CBLCollection_PurgeDocument(ref(), doc.ref(), &error), error);
+        bool purged = CBLCollection_PurgeDocument(ref(), doc.ref(), &error);
+        if ( !purged && !(error.domain == kCBLDomain && error.code == kCBLErrorNotFound) )
+            internal::check(false, error);
+        return purged;
     }
 }
 

--- a/include/cbl++/Encryptable.hh
+++ b/include/cbl++/Encryptable.hh
@@ -84,10 +84,10 @@ public:
     }
 
     /** Returns the value to be encrypted by the push replicator. */
-    fleece::Value value()     {return CBLEncryptable_Value(ref());}
+    fleece::Value value() const     {return CBLEncryptable_Value(ref());}
 
     /** Returns the Encryptable's underlying dictionary representation (its persistent form). */
-    fleece::Dict properties() {return CBLEncryptable_Properties(ref());}
+    fleece::Dict properties() const {return CBLEncryptable_Properties(ref());}
 
     /** Returns true if the given dictionary is the persistent form of an Encryptable.
         @param dict  The dictionary to test. */

--- a/include/cbl++/Encryptable.hh
+++ b/include/cbl++/Encryptable.hh
@@ -1,0 +1,121 @@
+//
+// Encryptable.hh
+//
+// Copyright (c) 2026 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#pragma once
+
+#ifdef COUCHBASE_ENTERPRISE
+
+#include "cbl++/Base.hh"
+#include "cbl/CBLEncryptable.h"
+#include "fleece/Fleece.hh"
+#include <string_view>
+
+
+// VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
+// future releases.
+
+CBL_ASSUME_NONNULL_BEGIN
+
+namespace cbl {
+
+    /** A reference to an encryptable value associated with a document.
+        An Encryptable wraps a value (null, bool, number, string, array, dict) that should
+        be encrypted by the push replicator and decrypted by the pull replicator. Its
+        persistent form is a special dictionary in the document properties; construct an
+        Encryptable from such a dictionary via Encryptable::getEncryptableValue. */
+class Encryptable : protected RefCounted {
+public:
+    /** Creates an Encryptable wrapping an arbitrary Fleece value.
+        @param value  The value to be encrypted. */
+    Encryptable(fleece::Value value)    : Encryptable(CBLEncryptable_CreateWithValue(value), adopt){}
+
+    /** Creates an Encryptable wrapping a string value.
+        @param value  The string to be encrypted. */
+    Encryptable(std::string_view value) : Encryptable(CBLEncryptable_CreateWithString((slice)value), adopt){}
+
+    /** Creates an Encryptable wrapping a null value. */
+    static Encryptable createWithNull() {
+        return {CBLEncryptable_CreateWithNull(), adopt};
+    }
+
+    /** Creates an Encryptable wrapping a boolean value.
+        @param value  The value to be encrypted. */
+    static Encryptable createWithBool(bool value) {
+        return {CBLEncryptable_CreateWithBool(value), adopt};
+    }
+
+    /** Creates an Encryptable wrapping a signed integer value.
+        @param value  The value to be encrypted. */
+    static Encryptable createWithInt(int64_t value) {
+        return {CBLEncryptable_CreateWithInt(value), adopt};
+    }
+
+    /** Creates an Encryptable wrapping an unsigned integer value.
+        @param value  The value to be encrypted. */
+    static Encryptable createWithUInt(uint64_t value) {
+        return {CBLEncryptable_CreateWithUInt(value), adopt};
+    }
+
+    /** Creates an Encryptable wrapping a float value.
+        @param value  The value to be encrypted. */
+    static Encryptable createWithFloat(float value) {
+        return {CBLEncryptable_CreateWithFloat(value), adopt};
+    }
+
+    /** Creates an Encryptable wrapping a double value.
+        @param value  The value to be encrypted. */
+    static Encryptable createWithDouble(double value) {
+        return {CBLEncryptable_CreateWithDouble(value), adopt};
+    }
+
+    /** Returns the value to be encrypted by the push replicator. */
+    fleece::Value value()     {return CBLEncryptable_Value(ref());}
+
+    /** Returns the Encryptable's underlying dictionary representation (its persistent form). */
+    fleece::Dict properties() {return CBLEncryptable_Properties(ref());}
+
+    /** Returns true if the given dictionary is the persistent form of an Encryptable.
+        @param dict  The dictionary to test. */
+    static bool isEncryptableValue(fleece::Dict dict) {
+        return FLDict_IsEncryptableValue(dict);
+    }
+
+    /** Returns the Encryptable that the given value represents, if any.
+        @param value  A value from a document, expected to be an encryptable dictionary.
+        @return  The corresponding Encryptable, or a falsy Encryptable if the value is not one. */
+    static Encryptable getEncryptableValue(fleece::Value value) {
+        return Encryptable{const_cast<CBLEncryptable*>(FLValue_GetEncryptableValue(value))};
+    }
+
+    protected:
+        CBL_REFCOUNTED_BOILERPLATE(Encryptable, RefCounted, CBLEncryptable)
+
+    private:
+        struct adopt_t {};
+        inline static constexpr adopt_t adopt{};
+
+        void adoptCObj(CBLEncryptable* cObj) { _ref = (CBLRefCounted*)cObj;}
+
+        Encryptable(CBLEncryptable* cObj, adopt_t) {adoptCObj(cObj);}
+    };
+
+}
+
+CBL_ASSUME_NONNULL_END
+
+#endif // COUCHBASE_ENTERPRISE

--- a/include/cbl++/Encryptable.hh
+++ b/include/cbl++/Encryptable.hh
@@ -38,47 +38,53 @@ namespace cbl {
         be encrypted by the push replicator and decrypted by the pull replicator. Its
         persistent form is a special dictionary in the document properties; construct an
         Encryptable from such a dictionary via Encryptable::getEncryptableValue. */
-class Encryptable : protected RefCounted {
-public:
+    class Encryptable : protected RefCounted {
+    public:
     /** Creates an Encryptable wrapping an arbitrary Fleece value.
         @param value  The value to be encrypted. */
-    Encryptable(fleece::Value value)    : Encryptable(CBLEncryptable_CreateWithValue(value), adopt){}
+    explicit Encryptable(fleece::Value value) : Encryptable(CBLEncryptable_CreateWithValue(value), adopt){}
 
     /** Creates an Encryptable wrapping a string value.
         @param value  The string to be encrypted. */
-    Encryptable(std::string_view value) : Encryptable(CBLEncryptable_CreateWithString((slice)value), adopt){}
+    explicit Encryptable(std::string_view value) : Encryptable(CBLEncryptable_CreateWithString((slice)value), adopt){}
 
-    /** Creates an Encryptable wrapping a null value. */
+    /** Creates an Encryptable wrapping a null value.
+        @note Use factory method to avoid ambiguity. */
     static Encryptable createWithNull() {
         return {CBLEncryptable_CreateWithNull(), adopt};
     }
 
     /** Creates an Encryptable wrapping a boolean value.
-        @param value  The value to be encrypted. */
+        @param value  The value to be encrypted.
+        @note Use factory method to avoid ambiguity. */
     static Encryptable createWithBool(bool value) {
         return {CBLEncryptable_CreateWithBool(value), adopt};
     }
 
     /** Creates an Encryptable wrapping a signed integer value.
-        @param value  The value to be encrypted. */
+        @param value  The value to be encrypted.
+        @note Use factory method to avoid ambiguity. */
     static Encryptable createWithInt(int64_t value) {
         return {CBLEncryptable_CreateWithInt(value), adopt};
     }
 
     /** Creates an Encryptable wrapping an unsigned integer value.
-        @param value  The value to be encrypted. */
+        @param value  The value to be encrypted.
+        @note Use factory method to avoid ambiguity. */
     static Encryptable createWithUInt(uint64_t value) {
         return {CBLEncryptable_CreateWithUInt(value), adopt};
     }
 
     /** Creates an Encryptable wrapping a float value.
-        @param value  The value to be encrypted. */
+        @param value  The value to be encrypted.
+        @note Use factory method to avoid ambiguity. */
     static Encryptable createWithFloat(float value) {
         return {CBLEncryptable_CreateWithFloat(value), adopt};
     }
 
     /** Creates an Encryptable wrapping a double value.
-        @param value  The value to be encrypted. */
+        @param value  The value to be encrypted.
+        @note Use factory method to avoid ambiguity. */
     static Encryptable createWithDouble(double value) {
         return {CBLEncryptable_CreateWithDouble(value), adopt};
     }
@@ -109,9 +115,7 @@ public:
         struct adopt_t {};
         inline static constexpr adopt_t adopt{};
 
-        void adoptCObj(CBLEncryptable* cObj) { _ref = (CBLRefCounted*)cObj;}
-
-        Encryptable(CBLEncryptable* cObj, adopt_t) {adoptCObj(cObj);}
+        Encryptable(CBLEncryptable* cObj, adopt_t) {_ref = (CBLRefCounted*)cObj;}
     };
 
 }

--- a/include/cbl++/LogSinks.hh
+++ b/include/cbl++/LogSinks.hh
@@ -25,9 +25,84 @@
 CBL_ASSUME_NONNULL_BEGIN
 
 namespace cbl {
-    using ConsoleLogSink = CBLConsoleLogSink;
-    using CustomLogSink  = CBLCustomLogSink;
-    using FileLogSink    = CBLFileLogSink;
+
+    enum class LogLevel : uint8_t {
+        Debug,     ///< Debug-level messages with highly detailed information, Available only in debug builds of Couchbase Lite.
+        Verbose,   ///< Verbose messages providing detailed operational information.
+        Info,      ///< Info messages about normal application behavior.
+        Warning,   ///< Warning messages indicating potential issues or unusual conditions.
+        Error,     ///< Error messages indicating a failure or problem that occurred.
+        None       ///< Disables logging entirely. No messages will be logged.
+    };
+
+    /** Subsystems for logging messages. */
+    enum class LogDomain : uint8_t {
+        Database,      ///< Logging domain for the database subsystem.
+        Query,         ///< Logging domain for the query subsystem.
+        Replicator,    ///< Logging domain for the replicator subsystem.
+        Network,       ///< Logging domain for the network subsystem.
+        Listener       ///< Logging domain for the listener subsystem.
+    };
+
+    using LogDomainMask   = CBLLogDomainMask;
+    using LogSinkCallback = CBLLogSinkCallback;
+
+    /** Console log sink configuration for logging to the cosole. */
+    struct ConsoleLogSink {
+        LogLevel level = LogLevel::None;           ///< The minimum level of message to write (Required).
+        LogDomainMask domains;                     ///< Bitmask for enabled log domains. Use zero for all domains.
+
+        static ConsoleLogSink fromCConfiguration(const CBLConsoleLogSink& cSink) {
+            return { LogLevel(cSink.level), cSink.domains};
+        }
+
+        operator CBLConsoleLogSink() const {
+            return {(CBLLogLevel)(uint8_t)level, domains};
+        }
+    };
+
+    /** Custom log sink configuration for logging to a user-defined callback. */
+    struct CustomLogSink {
+        LogLevel level = LogLevel::None;         ///< The minimum level of message to write (Required).
+        LogSinkCallback callback;                ///< Custom log callback (Required).
+        LogDomainMask domains;                   ///< Bitmask for enabled log domains. Use zero for all domains.
+
+        static CustomLogSink fromCConfiguration(const CBLCustomLogSink& cSink) {
+            return { LogLevel(cSink.level), cSink.callback, cSink.domains};
+        }
+
+        operator CBLCustomLogSink() const {
+            return {(CBLLogLevel)(uint8_t)level, callback, domains};
+        }
+    };
+
+    /** File log sink configuration for logging to files. */
+    struct FileLogSink {
+        LogLevel level = LogLevel::None;         ///< The minimum level of message to write (Required).
+        std::string directory;                   ///< The directory where log files will be created (Required).
+
+        /** The maximum number of files to save per log level.
+            The default is \ref kCBLDefaultFileLogSinkMaxKeptFiles. */
+        uint32_t maxKeptFiles;
+
+        /** The size in bytes at which a file will be rotated out (best effort).
+            The default is \ref kCBLDefaultFileLogSinkMaxSize. */
+        size_t maxSize;
+
+        /** Whether or not to log in plaintext as opposed to binary. Plaintext logging is slower and bigger.
+            The default is \ref kCBLDefaultFileLogSinkUsePlaintext. */
+        bool usePlaintext;
+
+        static FileLogSink fromCConfiguration(const CBLFileLogSink& cSink) {
+            return {
+                LogLevel(cSink.level),
+                std::string(cSink.directory),
+                cSink.maxKeptFiles,
+                cSink.maxSize,
+                cSink.usePlaintext
+            };
+        }
+    };
 
     /** Controls where Couchbase Lite writes its log messages. There are three independent
         sinks — console, custom (a user callback), and file — each configured separately.
@@ -43,7 +118,7 @@ namespace cbl {
         /** Returns the current console log sink. It is enabled at the warning level for all
             domains by default. */
         static ConsoleLogSink console() {
-            return CBLLogSinks_Console();
+            return ConsoleLogSink::fromCConfiguration(CBLLogSinks_Console());
         }
 
         /** Sets the custom log sink, whose callback receives each log message. To disable it,
@@ -55,19 +130,25 @@ namespace cbl {
 
         /** Returns the current custom log sink. It is disabled by default. */
         static CustomLogSink custom() {
-            return CBLLogSinks_CustomSink();
+            return CustomLogSink::fromCConfiguration(CBLLogSinks_CustomSink());
         }
 
         /** Sets the file log sink, which writes log messages to files in a directory. To disable
             it, set the sink's log level to \ref kCBLLogNone.
             @param sink  The file log sink configuration. */
-        static void setFile(const FileLogSink& sink) {
-            CBLLogSinks_SetFile(sink);
+        static void setFile(FileLogSink sink) {
+            CBLLogSinks_SetFile({
+                (CBLLogLevel)(uint8_t)sink.level,
+                slice(sink.directory),
+                sink.maxKeptFiles,
+                sink.maxSize,
+                sink.usePlaintext
+            });
         }
 
         /** Returns the current file log sink. It is disabled by default. */
         static FileLogSink file() {
-            return CBLLogSinks_File();
+            return FileLogSink::fromCConfiguration(CBLLogSinks_File());
         }
     };
 }

--- a/include/cbl++/LogSinks.hh
+++ b/include/cbl++/LogSinks.hh
@@ -25,28 +25,43 @@
 CBL_ASSUME_NONNULL_BEGIN
 
 namespace cbl {
+    /** Controls where Couchbase Lite writes its log messages. There are three independent
+        sinks — console, custom (a user callback), and file — each configured separately.
+        Disable a sink by setting its log level to \ref kCBLLogNone. */
     class LogSinks {
     public:
+        /** Sets the console log sink. To disable it, set the sink's log level to \ref kCBLLogNone.
+            @param sink  The console log sink configuration. */
         static void setConsole(const CBLConsoleLogSink& sink) {
             CBLLogSinks_SetConsole(sink);
         }
-        
+
+        /** Returns the current console log sink. It is enabled at the warning level for all
+            domains by default. */
         static CBLConsoleLogSink console() {
             return CBLLogSinks_Console();
         }
-        
+
+        /** Sets the custom log sink, whose callback receives each log message. To disable it,
+            set the sink's log level to \ref kCBLLogNone.
+            @param sink  The custom log sink configuration. */
         static void setCustom(const CBLCustomLogSink& sink) {
             CBLLogSinks_SetCustom(sink);
         }
-                
+
+        /** Returns the current custom log sink. It is disabled by default. */
         static CBLCustomLogSink custom() {
             return CBLLogSinks_CustomSink();
         }
-                
+
+        /** Sets the file log sink, which writes log messages to files in a directory. To disable
+            it, set the sink's log level to \ref kCBLLogNone.
+            @param sink  The file log sink configuration. */
         static void setFile(const CBLFileLogSink& sink) {
             CBLLogSinks_SetFile(sink);
         }
-                
+
+        /** Returns the current file log sink. It is disabled by default. */
         static CBLFileLogSink file() {
             return CBLLogSinks_File();
         }

--- a/include/cbl++/LogSinks.hh
+++ b/include/cbl++/LogSinks.hh
@@ -26,35 +26,15 @@ CBL_ASSUME_NONNULL_BEGIN
 
 namespace cbl {
 
-    enum class LogLevel : uint8_t {
-        Debug,     ///< Debug-level messages with highly detailed information, Available only in debug builds of Couchbase Lite.
-        Verbose,   ///< Verbose messages providing detailed operational information.
-        Info,      ///< Info messages about normal application behavior.
-        Warning,   ///< Warning messages indicating potential issues or unusual conditions.
-        Error,     ///< Error messages indicating a failure or problem that occurred.
-        None       ///< Disables logging entirely. No messages will be logged.
-    };
-
-    /** Subsystems for logging messages. */
-    enum class LogDomain : uint8_t {
-        Database,      ///< Logging domain for the database subsystem.
-        Query,         ///< Logging domain for the query subsystem.
-        Replicator,    ///< Logging domain for the replicator subsystem.
-        Network,       ///< Logging domain for the network subsystem.
-        Listener       ///< Logging domain for the listener subsystem.
-    };
-
     using LogDomainMask   = CBLLogDomainMask;
     using LogSinkCallback = CBLLogSinkCallback;
+    using LogLevel        = CBLLogLevel;
+    using LogDomain       = CBLLogDomain;
 
     /** Console log sink configuration for logging to the cosole. */
     struct ConsoleLogSink {
-        LogLevel level = LogLevel::None;           ///< The minimum level of message to write (Required).
-        LogDomainMask domains;                     ///< Bitmask for enabled log domains. Use zero for all domains.
-
-        static ConsoleLogSink fromCConfiguration(const CBLConsoleLogSink& cSink) {
-            return { LogLevel(cSink.level), cSink.domains};
-        }
+        LogLevel level = kCBLLogNone;           ///< The minimum level of message to write (Required).
+        LogDomainMask domains;                  ///< Bitmask for enabled log domains. Use zero for all domains.
 
         operator CBLConsoleLogSink() const {
             return {(CBLLogLevel)(uint8_t)level, domains};
@@ -63,22 +43,18 @@ namespace cbl {
 
     /** Custom log sink configuration for logging to a user-defined callback. */
     struct CustomLogSink {
-        LogLevel level = LogLevel::None;         ///< The minimum level of message to write (Required).
+        LogLevel level = kCBLLogNone   ;         ///< The minimum level of message to write (Required).
         LogSinkCallback callback;                ///< Custom log callback (Required).
         LogDomainMask domains;                   ///< Bitmask for enabled log domains. Use zero for all domains.
 
-        static CustomLogSink fromCConfiguration(const CBLCustomLogSink& cSink) {
-            return { LogLevel(cSink.level), cSink.callback, cSink.domains};
-        }
-
         operator CBLCustomLogSink() const {
-            return {(CBLLogLevel)(uint8_t)level, callback, domains};
+            return {level, callback, domains};
         }
     };
 
     /** File log sink configuration for logging to files. */
     struct FileLogSink {
-        LogLevel level = LogLevel::None;         ///< The minimum level of message to write (Required).
+        LogLevel level = kCBLLogNone;            ///< The minimum level of message to write (Required).
         std::string directory;                   ///< The directory where log files will be created (Required).
 
         /** The maximum number of files to save per log level.
@@ -92,16 +68,6 @@ namespace cbl {
         /** Whether or not to log in plaintext as opposed to binary. Plaintext logging is slower and bigger.
             The default is \ref kCBLDefaultFileLogSinkUsePlaintext. */
         bool usePlaintext;
-
-        static FileLogSink fromCConfiguration(const CBLFileLogSink& cSink) {
-            return {
-                LogLevel(cSink.level),
-                std::string(cSink.directory),
-                cSink.maxKeptFiles,
-                cSink.maxSize,
-                cSink.usePlaintext
-            };
-        }
     };
 
     /** Controls where Couchbase Lite writes its log messages. There are three independent
@@ -118,7 +84,7 @@ namespace cbl {
         /** Returns the current console log sink. It is enabled at the warning level for all
             domains by default. */
         static ConsoleLogSink console() {
-            return ConsoleLogSink::fromCConfiguration(CBLLogSinks_Console());
+            return fromCConfiguration(CBLLogSinks_Console());
         }
 
         /** Sets the custom log sink, whose callback receives each log message. To disable it,
@@ -130,7 +96,7 @@ namespace cbl {
 
         /** Returns the current custom log sink. It is disabled by default. */
         static CustomLogSink custom() {
-            return CustomLogSink::fromCConfiguration(CBLLogSinks_CustomSink());
+            return fromCConfiguration(CBLLogSinks_CustomSink());
         }
 
         /** Sets the file log sink, which writes log messages to files in a directory. To disable
@@ -148,7 +114,26 @@ namespace cbl {
 
         /** Returns the current file log sink. It is disabled by default. */
         static FileLogSink file() {
-            return FileLogSink::fromCConfiguration(CBLLogSinks_File());
+            return fromCConfiguration(CBLLogSinks_File());
+        }
+
+    private:
+        static ConsoleLogSink fromCConfiguration(const CBLConsoleLogSink& cSink) {
+            return { cSink.level, cSink.domains};
+        }
+
+        static CustomLogSink fromCConfiguration(const CBLCustomLogSink& cSink) {
+            return { cSink.level, cSink.callback, cSink.domains};
+        }
+
+        static FileLogSink fromCConfiguration(const CBLFileLogSink& cSink) {
+            return {
+                cSink.level,
+                std::string(cSink.directory),
+                cSink.maxKeptFiles,
+                cSink.maxSize,
+                cSink.usePlaintext
+            };
         }
     };
 }

--- a/include/cbl++/LogSinks.hh
+++ b/include/cbl++/LogSinks.hh
@@ -25,6 +25,10 @@
 CBL_ASSUME_NONNULL_BEGIN
 
 namespace cbl {
+    using ConsoleLogSink = CBLConsoleLogSink;
+    using CustomLogSink  = CBLCustomLogSink;
+    using FileLogSink    = CBLFileLogSink;
+
     /** Controls where Couchbase Lite writes its log messages. There are three independent
         sinks — console, custom (a user callback), and file — each configured separately.
         Disable a sink by setting its log level to \ref kCBLLogNone. */
@@ -32,37 +36,37 @@ namespace cbl {
     public:
         /** Sets the console log sink. To disable it, set the sink's log level to \ref kCBLLogNone.
             @param sink  The console log sink configuration. */
-        static void setConsole(const CBLConsoleLogSink& sink) {
+        static void setConsole(const ConsoleLogSink& sink) {
             CBLLogSinks_SetConsole(sink);
         }
 
         /** Returns the current console log sink. It is enabled at the warning level for all
             domains by default. */
-        static CBLConsoleLogSink console() {
+        static ConsoleLogSink console() {
             return CBLLogSinks_Console();
         }
 
         /** Sets the custom log sink, whose callback receives each log message. To disable it,
             set the sink's log level to \ref kCBLLogNone.
             @param sink  The custom log sink configuration. */
-        static void setCustom(const CBLCustomLogSink& sink) {
+        static void setCustom(const CustomLogSink& sink) {
             CBLLogSinks_SetCustom(sink);
         }
 
         /** Returns the current custom log sink. It is disabled by default. */
-        static CBLCustomLogSink custom() {
+        static CustomLogSink custom() {
             return CBLLogSinks_CustomSink();
         }
 
         /** Sets the file log sink, which writes log messages to files in a directory. To disable
             it, set the sink's log level to \ref kCBLLogNone.
             @param sink  The file log sink configuration. */
-        static void setFile(const CBLFileLogSink& sink) {
+        static void setFile(const FileLogSink& sink) {
             CBLLogSinks_SetFile(sink);
         }
 
         /** Returns the current file log sink. It is disabled by default. */
-        static CBLFileLogSink file() {
+        static FileLogSink file() {
             return CBLLogSinks_File();
         }
     };

--- a/include/cbl++/LogSinks.hh
+++ b/include/cbl++/LogSinks.hh
@@ -21,6 +21,8 @@
 
 #pragma once
 #include "cbl/CBLLogSinks.h"
+#include "cbl++/Base.hh"
+#include "cbl/CBLDefaults.h"
 
 CBL_ASSUME_NONNULL_BEGIN
 
@@ -31,7 +33,7 @@ namespace cbl {
     using LogLevel        = CBLLogLevel;
     using LogDomain       = CBLLogDomain;
 
-    /** Console log sink configuration for logging to the cosole. */
+    /** Console log sink configuration for logging to the console. */
     struct ConsoleLogSink {
         LogLevel level = kCBLLogNone;           ///< The minimum level of message to write (Required).
         LogDomainMask domains;                  ///< Bitmask for enabled log domains. Use zero for all domains.
@@ -59,15 +61,15 @@ namespace cbl {
 
         /** The maximum number of files to save per log level.
             The default is \ref kCBLDefaultFileLogSinkMaxKeptFiles. */
-        uint32_t maxKeptFiles;
+        uint32_t maxKeptFiles = kCBLDefaultFileLogSinkMaxKeptFiles;
 
         /** The size in bytes at which a file will be rotated out (best effort).
             The default is \ref kCBLDefaultFileLogSinkMaxSize. */
-        size_t maxSize;
+        size_t maxSize = kCBLDefaultFileLogSinkMaxSize;
 
         /** Whether or not to log in plaintext as opposed to binary. Plaintext logging is slower and bigger.
             The default is \ref kCBLDefaultFileLogSinkUsePlaintext. */
-        bool usePlaintext;
+        bool usePlaintext = kCBLDefaultFileLogSinkUsePlaintext;
     };
 
     /** Controls where Couchbase Lite writes its log messages. There are three independent

--- a/include/cbl++/Prediction.hh
+++ b/include/cbl++/Prediction.hh
@@ -54,13 +54,14 @@ namespace cbl {
         virtual ~PredictiveModel() = default;
     };
 
-    static std::unordered_map<slice, std::unique_ptr<PredictiveModel>> _sPredictiveModels;
-
     /** Predictive Model Registation 
         This class provides static methods to register and unregister predictive models. */
     class Prediction {
     public:
-        /** Registers a predictive model with the given name. */
+        /** Registers a predictive model with the given name.
+            @param name  The name used to refer to the model in a query's PREDICTION() function.
+            @param model  The model implementation; ownership is transferred to the registry until
+                          it is unregistered. */
         static void registerModel(slice name, std::unique_ptr<PredictiveModel> model) {
             auto prediction = [](void* context, FLDict input) {
                 auto m = (PredictiveModel*)context;
@@ -75,11 +76,15 @@ namespace cbl {
             _sPredictiveModels[name] = std::move(model);
         }
         
-        /** Unregisters the predictive model with the given name. */
+        /** Unregisters the predictive model with the given name.
+            @param name  The name the model was registered under. */
         static void unregisterModel(slice name) {
             CBL_UnregisterPredictiveModel(name);
             _sPredictiveModels.erase(name);
         }
+
+    private:
+        inline static std::unordered_map<slice, std::unique_ptr<PredictiveModel>> _sPredictiveModels;
     };
 }
 

--- a/include/cbl++/Prediction.hh
+++ b/include/cbl++/Prediction.hh
@@ -24,8 +24,6 @@
 #pragma once
 #include "cbl++/Base.hh"
 #include "cbl/CBLPrediction.h"
-#include <memory>
-#include <unordered_map>
 
 // VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
 // future releases.
@@ -41,50 +39,35 @@ namespace cbl {
         @note The predictive index feature is not supported by Couchbase Lite for C.
               The Predictive Model is currently for creating vector indexes using the PREDICTION() function,
               which will call the specified predictive model for computing the vectors. */
-    class PredictiveModel {
-    public:
-        /** Predicts and returns a mutable dictionary based on the input dictionary.
-            Override this function  for the implementation.
-            @param input The input dictionary corresponding to the input dictionary expression given in the query's PREDICTION() function
-            @return The output dictionary.
-                    - To create a new dictionary for returning, use fleece::MutableDict::newDict().
-                    - To create a null result to evaluate as MISSING, use fleece::MutableDict(). */
-        virtual fleece::MutableDict prediction(fleece::Dict input) noexcept = 0;
-        
-        virtual ~PredictiveModel() = default;
-    };
 
-    /** Predictive Model Registation 
-        This class provides static methods to register and unregister predictive models. */
+    /** A predictive model callable, invoked by queries via the PREDICTION() function.
+        Given an input dictionary, return the output dictionary. */
+    using PredictiveModel = std::function<fleece::MutableDict(fleece::Dict)>;
+
+    /** Registers/unregisters predictive models by name. */
     class Prediction {
     public:
         /** Registers a predictive model with the given name.
             @param name  The name used to refer to the model in a query's PREDICTION() function.
-            @param model  The model implementation; ownership is transferred to the registry until
-                          it is unregistered. */
-        static void registerModel(slice name, std::unique_ptr<PredictiveModel> model) {
-            auto prediction = [](void* context, FLDict input) {
-                auto m = (PredictiveModel*)context;
-                return FLMutableDict_Retain((FLMutableDict) m->prediction(input));
+            @param model  The model implementation. Any matching callable is accepted (lambda, functor, ...). */
+        static void registerModel(slice name, PredictiveModel model) {
+            auto* holder = new PredictiveModel(std::move(model));
+            CBLPredictiveModel config{};
+            config.context      = holder;
+            config.prediction   = [](void* ctx, FLDict input) -> FLMutableDict {
+                auto& fn = *static_cast<PredictiveModel*>(ctx);
+                return FLMutableDict_Retain((FLMutableDict)fn(fleece::Dict(input)));
             };
-
-            CBLPredictiveModel config { };
-            config.context = model.get();
-            config.prediction = prediction;
+            config.unregistered = [](void* ctx) {
+                delete static_cast<PredictiveModel*>(ctx);
+            };
             CBL_RegisterPredictiveModel(name, config);
-
-            _sPredictiveModels[name] = std::move(model);
         }
-        
-        /** Unregisters the predictive model with the given name.
-            @param name  The name the model was registered under. */
+
+        /** Unregisters the model; LiteCore fires `unregistered` which frees the model. */
         static void unregisterModel(slice name) {
             CBL_UnregisterPredictiveModel(name);
-            _sPredictiveModels.erase(name);
         }
-
-    private:
-        inline static std::unordered_map<slice, std::unique_ptr<PredictiveModel>> _sPredictiveModels;
     };
 }
 

--- a/include/cbl++/Prediction.hh
+++ b/include/cbl++/Prediction.hh
@@ -67,12 +67,12 @@ namespace cbl {
                 auto m = (PredictiveModel*)context;
                 return FLMutableDict_Retain((FLMutableDict) m->prediction(input));
             };
-            
+
             CBLPredictiveModel config { };
             config.context = model.get();
             config.prediction = prediction;
             CBL_RegisterPredictiveModel(name, config);
-            
+
             _sPredictiveModels[name] = std::move(model);
         }
         

--- a/include/cbl++/Prediction.hh
+++ b/include/cbl++/Prediction.hh
@@ -56,8 +56,19 @@ namespace cbl {
             CBLPredictiveModel config{};
             config.context      = holder;
             config.prediction   = [](void* ctx, FLDict input) -> FLMutableDict {
-                auto& fn = *static_cast<PredictiveModel*>(ctx);
-                return FLMutableDict_Retain((FLMutableDict)fn(fleece::Dict(input)));
+                try {
+                    auto& fn = *static_cast<PredictiveModel*>(ctx);
+                    return FLMutableDict_Retain((FLMutableDict)fn(fleece::Dict(input)));
+                } catch (const cbl::Error& error) {
+                    CBL_Log(kCBLLogDomainDatabase, kCBLLogError, "Prediction function throws error %d/%d: %s",
+                            error.domain, error.code, error.what());
+                } catch (const std::exception& error) {
+                    CBL_Log(kCBLLogDomainDatabase, kCBLLogError, "Prediction function throws error %s",
+                            error.what());
+                } catch (...) {
+                    CBL_Log(kCBLLogDomainDatabase, kCBLLogError, "Prediction function throws unknown exception");
+                }
+                return FLMutableDict_New();
             };
             config.unregistered = [](void* ctx) {
                 delete static_cast<PredictiveModel*>(ctx);

--- a/include/cbl++/Prediction.hh
+++ b/include/cbl++/Prediction.hh
@@ -24,6 +24,7 @@
 #pragma once
 #include "cbl++/Base.hh"
 #include "cbl/CBLPrediction.h"
+#include <string_view>
 
 // VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
 // future releases.
@@ -50,7 +51,7 @@ namespace cbl {
         /** Registers a predictive model with the given name.
             @param name  The name used to refer to the model in a query's PREDICTION() function.
             @param model  The model implementation. Any matching callable is accepted (lambda, functor, ...). */
-        static void registerModel(slice name, PredictiveModel model) {
+        static void registerModel(std::string_view name, PredictiveModel model) {
             auto* holder = new PredictiveModel(std::move(model));
             CBLPredictiveModel config{};
             config.context      = holder;
@@ -61,12 +62,12 @@ namespace cbl {
             config.unregistered = [](void* ctx) {
                 delete static_cast<PredictiveModel*>(ctx);
             };
-            CBL_RegisterPredictiveModel(name, config);
+            CBL_RegisterPredictiveModel(slice(name), config);
         }
 
         /** Unregisters the model; LiteCore fires `unregistered` which frees the model. */
-        static void unregisterModel(slice name) {
-            CBL_UnregisterPredictiveModel(name);
+        static void unregisterModel(std::string_view name) {
+            CBL_UnregisterPredictiveModel(slice(name));
         }
     };
 }

--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -174,15 +174,21 @@ namespace cbl {
         CBL_REFCOUNTED_BOILERPLATE(ResultSet, RefCounted, CBLResultSet)
     };
 
-    // Implementation of ResultSet::iterator
+    /** Forward iterator over a \ref ResultSet, yielding each \ref Result in turn.
+        Obtained via \ref ResultSet::begin and \ref ResultSet::end. */
     class ResultSetIterator {
     public:
+        /** Returns the current \ref Result. */
         const Result& operator*()  const {return _result;}
+        /** Allows access to the current \ref Result via `->`. */
         const Result& operator->() const {return _result;}
 
+        /** Returns true if both iterators reference the same underlying result set position. */
         bool operator== (const ResultSetIterator &i) const {return _rs == i._rs;}
+        /** Returns true if the iterators differ. */
         bool operator!= (const ResultSetIterator &i) const {return _rs != i._rs;}
 
+        /** Advances to the next result, or to end-of-results if there are no more. */
         ResultSetIterator& operator++() {
             if (!CBLResultSet_Next(_rs.ref()))
                 _rs = ResultSet{};
@@ -226,8 +232,12 @@ namespace cbl {
         \ref ListenerToken::remove() is called. */
     class Query::ChangeListener : public ListenerToken<Change> {
     public:
+        /** Creates an empty, uninitialized change listener token. */
         ChangeListener(): ListenerToken<Change>() { }
 
+        /** Creates a change listener token bound to a specific query and callback.
+            @param query  The query whose changes are being listened to.
+            @param cb     The callback that will receive change notifications. */
         ChangeListener(Query query, Callback cb)
         :ListenerToken<Change>(cb)
         ,_query(std::move(query))
@@ -257,6 +267,7 @@ namespace cbl {
     /** The change passed to a live query's listener callback, giving access to the updated results. */
     class Query::Change {
     public:
+        /** Copy constructor. */
         Change(const Change& src) : _query(src._query), _token(src._token) {}
 
         /** Returns the query's results as of this change. */

--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -51,7 +51,7 @@ namespace cbl {
         Query(const Database& db, CBLQueryLanguage language, slice queryString) {
             CBLError error;
             auto q = CBLDatabase_CreateQuery(db.ref(), language, queryString, nullptr, &error);
-            check(q, error);
+            Base::check(q, error);
             _ref = (CBLRefCounted*)q;
         }
 
@@ -155,7 +155,11 @@ namespace cbl {
     class ResultSet : private RefCounted {
     public:
         using iterator = ResultSetIterator;
+
+        /** Returns an iterator positioned at the first result. */
         inline iterator begin();
+
+        /** Returns an iterator marking the end of the results. */
         inline iterator end();
 
     private:
@@ -212,19 +216,24 @@ namespace cbl {
     inline ResultSet Query::execute() {
         CBLError error;
         auto rs = CBLQuery_Execute(ref(), &error);
-        check(rs, error);
+        Base::check(rs, error);
         return ResultSet::adopt(rs);
     }
 
+    /** The token returned by \ref Query::addChangeListener for a live query. It holds the
+        listener registration, which is removed when this token is destroyed or
+        \ref ListenerToken::remove() is called. */
     class Query::ChangeListener : public ListenerToken<Change> {
     public:
         ChangeListener(): ListenerToken<Change>() { }
-        
+
         ChangeListener(Query query, Callback cb)
         :ListenerToken<Change>(cb)
         ,_query(std::move(query))
         { }
 
+        /** Returns the most recent results computed by the live query.
+            @throws std::runtime_error  If called on an uninitialized (default-constructed) listener. */
         ResultSet results() {
             if (!_query) {
                 throw std::runtime_error("Not allowed to call on uninitialized ChangeListeners");
@@ -236,7 +245,7 @@ namespace cbl {
         static ResultSet getResults(Query query, CBLListenerToken* token) {
             CBLError error;
             auto rs = CBLQuery_CopyCurrentResults(query.ref(), token, &error);
-            check(rs, error);
+            Base::check(rs, error);
             return ResultSet::adopt(rs);
         }
 
@@ -244,14 +253,17 @@ namespace cbl {
         friend Change;
     };
 
+    /** The change passed to a live query's listener callback, giving access to the updated results. */
     class Query::Change {
     public:
         Change(const Change& src) : _query(src._query), _token(src._token) {}
 
+        /** Returns the query's results as of this change. */
         ResultSet results() {
             return ChangeListener::getResults(_query, _token);
         }
 
+        /** Returns the query that produced this change. */
         Query query() {
             return _query;
         }

--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -34,6 +34,8 @@ namespace cbl {
     class ResultSet;
     class ResultSetIterator;
 
+    using QueryLanguage = CBLQueryLanguage;
+
     /** A database query. */
     class Query : private RefCounted {
     public:
@@ -174,7 +176,7 @@ namespace cbl {
         CBL_REFCOUNTED_BOILERPLATE(ResultSet, RefCounted, CBLResultSet)
     };
 
-    /** Forward iterator over a \ref ResultSet, yielding each \ref Result in turn.
+    /** Single-pass iterator over a \ref ResultSet, yielding each \ref Result in turn.
         Obtained via \ref ResultSet::begin and \ref ResultSet::end. */
     class ResultSetIterator {
     public:

--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -51,7 +51,7 @@ namespace cbl {
         Query(const Database& db, CBLQueryLanguage language, slice queryString) {
             CBLError error;
             auto q = CBLDatabase_CreateQuery(db.ref(), language, queryString, nullptr, &error);
-            Base::check(q, error);
+            internal::check(q, error);
             _ref = (CBLRefCounted*)q;
         }
 
@@ -216,7 +216,7 @@ namespace cbl {
     inline ResultSet Query::execute() {
         CBLError error;
         auto rs = CBLQuery_Execute(ref(), &error);
-        Base::check(rs, error);
+        internal::check(rs, error);
         return ResultSet::adopt(rs);
     }
 
@@ -245,7 +245,7 @@ namespace cbl {
         static ResultSet getResults(Query query, CBLListenerToken* token) {
             CBLError error;
             auto rs = CBLQuery_CopyCurrentResults(query.ref(), token, &error);
-            Base::check(rs, error);
+            internal::check(rs, error);
             return ResultSet::adopt(rs);
         }
 

--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -21,6 +21,7 @@
 #include "cbl/CBLQuery.h"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 // VOLATILE API: Couchbase Lite C++ API is not finalized, and may change in
@@ -48,9 +49,9 @@ namespace cbl {
             @param language  The query language
             @param queryString  The query string.
          */
-        Query(const Database& db, CBLQueryLanguage language, slice queryString) {
+        Query(const Database& db, CBLQueryLanguage language, std::string_view queryString) {
             CBLError error;
-            auto q = CBLDatabase_CreateQuery(db.ref(), language, queryString, nullptr, &error);
+            auto q = CBLDatabase_CreateQuery(db.ref(), language, slice(queryString), nullptr, &error);
             internal::check(q, error);
             _ref = (CBLRefCounted*)q;
         }
@@ -135,15 +136,15 @@ namespace cbl {
             This may return a NULL Value, indicating `MISSING`, if the value doesn't exist, e.g. if
             the column is a property that doesn't exist in the document. (Or, of course, if the key
             is not a column name in this query.) */
-        fleece::Value valueForKey(slice key) const {
-            return CBLResultSet_ValueForKey(_ref, key);
+        fleece::Value valueForKey(std::string_view key) const {
+            return CBLResultSet_ValueForKey(_ref, slice(key));
         }
 
         /** A subscript operator that returns value of a column of the current result, given its (zero-based) numeric index.  */
         fleece::Value operator[](int i) const                           {return valueAtIndex(i);}
         
         /** A subscript operator that returns the value of a column of the current result, given its column name.  */
-        fleece::Value operator[](slice key) const                       {return valueForKey(key);}
+        fleece::Value operator[](std::string_view key) const            {return valueForKey(key);}
 
     protected:
         explicit Result(CBLResultSet* _cbl_nullable ref)                :_ref(ref) { }
@@ -299,7 +300,7 @@ namespace cbl {
 
     // Query
     
-    Query Database::createQuery(CBLQueryLanguage language, slice queryString) {
+    Query Database::createQuery(CBLQueryLanguage language, std::string_view queryString) {
         return Query(*this, language, queryString);
     }
 }

--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -34,8 +34,6 @@ namespace cbl {
     class ResultSet;
     class ResultSetIterator;
 
-    using QueryLanguage = CBLQueryLanguage;
-
     /** A database query. */
     class Query : private RefCounted {
     public:

--- a/include/cbl++/QueryIndex.hh
+++ b/include/cbl++/QueryIndex.hh
@@ -37,7 +37,7 @@ namespace cbl {
         // Accessors:
         
         /** The index's name. */
-        std::string name() const                        {return Base::asString(CBLQueryIndex_Name(ref()));}
+        std::string name() const                        {return internal::asString(CBLQueryIndex_Name(ref()));}
         
         /** A index's collection. */
         Collection collection() const                   {return Collection(CBLQueryIndex_Collection(ref()));}
@@ -61,7 +61,7 @@ namespace cbl {
         
         static QueryIndex adopt(const CBLQueryIndex* _cbl_nullable i, CBLError *error) {
             if (!i && error->code != 0)
-                Base::check(false, *error);
+                internal::check(false, *error);
             QueryIndex index;
             index._ref = (CBLRefCounted*)i;
             return index;
@@ -96,7 +96,7 @@ namespace cbl {
             @param dimension  The dimension of `vector`. Must be equal to the dimension value set in the vector index config. */
         void setVector(unsigned index, const float* _cbl_nullable vector, size_t dimension) {
             CBLError error;
-            Base::check(CBLIndexUpdater_SetVector(ref(), index, vector, dimension, &error), error);
+            internal::check(CBLIndexUpdater_SetVector(ref(), index, vector, dimension, &error), error);
         }
         
         /** Skip setting the vector for the value corresponding to the index.
@@ -112,12 +112,12 @@ namespace cbl {
             @warning The index updater cannot be used after calling \ref IndexUpdater::finish. */
         void finish() {
             CBLError error;
-            Base::check(CBLIndexUpdater_Finish(ref(), &error), error);
+            internal::check(CBLIndexUpdater_Finish(ref(), &error), error);
         }
         
     protected:
         static IndexUpdater adopt(const CBLIndexUpdater* _cbl_nullable i, CBLError *error) {
-            Base::check(i != nullptr || error->code == 0, *error);
+            internal::check(i != nullptr || error->code == 0, *error);
             IndexUpdater updater;
             updater._ref = (CBLRefCounted*)i;
             return updater;

--- a/include/cbl++/QueryIndex.hh
+++ b/include/cbl++/QueryIndex.hh
@@ -134,9 +134,9 @@ namespace cbl {
     }
 #endif
 
-    QueryIndex Collection::getIndex(slice name) {
+    QueryIndex Collection::getIndex(std::string_view name) {
         CBLError error {};
-        return QueryIndex::adopt(CBLCollection_GetIndex(ref(), name, &error), &error);
+        return QueryIndex::adopt(CBLCollection_GetIndex(ref(), slice(name), &error), &error);
     }
 }
 

--- a/include/cbl++/QueryIndex.hh
+++ b/include/cbl++/QueryIndex.hh
@@ -37,7 +37,7 @@ namespace cbl {
         // Accessors:
         
         /** The index's name. */
-        std::string name() const                        {return asString(CBLQueryIndex_Name(ref()));}
+        std::string name() const                        {return Base::asString(CBLQueryIndex_Name(ref()));}
         
         /** A index's collection. */
         Collection collection() const                   {return Collection(CBLQueryIndex_Collection(ref()));}
@@ -61,7 +61,7 @@ namespace cbl {
         
         static QueryIndex adopt(const CBLQueryIndex* _cbl_nullable i, CBLError *error) {
             if (!i && error->code != 0)
-                throw *error;
+                Base::check(false, *error);
             QueryIndex index;
             index._ref = (CBLRefCounted*)i;
             return index;
@@ -96,7 +96,7 @@ namespace cbl {
             @param dimension  The dimension of `vector`. Must be equal to the dimension value set in the vector index config. */
         void setVector(unsigned index, const float* _cbl_nullable vector, size_t dimension) {
             CBLError error;
-            check(CBLIndexUpdater_SetVector(ref(), index, vector, dimension, &error), error);
+            Base::check(CBLIndexUpdater_SetVector(ref(), index, vector, dimension, &error), error);
         }
         
         /** Skip setting the vector for the value corresponding to the index.
@@ -112,13 +112,12 @@ namespace cbl {
             @warning The index updater cannot be used after calling \ref IndexUpdater::finish. */
         void finish() {
             CBLError error;
-            check(CBLIndexUpdater_Finish(ref(), &error), error);
+            Base::check(CBLIndexUpdater_Finish(ref(), &error), error);
         }
         
     protected:
         static IndexUpdater adopt(const CBLIndexUpdater* _cbl_nullable i, CBLError *error) {
-            if (!i && error->code != 0)
-                throw *error;
+            Base::check(i != nullptr || error->code == 0, *error);
             IndexUpdater updater;
             updater._ref = (CBLRefCounted*)i;
             return updater;

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -87,7 +87,7 @@ namespace cbl {
             and optionally a cookie name. */
         static Authenticator sessionAuthenticator(std::string_view sessionId, std::optional<std::string_view> cookieName =std::nullopt) {
             slice cname;
-            if ( cookieName ) cname = slice(*cookieName);
+            if ( cookieName ) cname = *cookieName;
             return Authenticator(CBLAuth_CreateSession(slice(sessionId), cname));
         }
 

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -82,15 +82,13 @@ namespace cbl {
         }
 
         /** Creates a sesssion authenticator using a Couchbase Sync Gateway login session identifier,
-            and optionally a cookie name (pass NULL for the default.) */
-        static Authenticator sessionAuthenticator(std::string_view sessionId) {
-            return Authenticator(CBLAuth_CreateSession(slice(sessionId), fleece::nullslice));
+            and optionally a cookie name. */
+        static Authenticator sessionAuthenticator(std::string_view sessionId, std::optional<std::string_view> cookieName =std::nullopt) {
+            slice cname;
+            if ( cookieName ) cname = slice(*cookieName);
+            return Authenticator(CBLAuth_CreateSession(slice(sessionId), cname));
         }
-        static Authenticator sessionAuthenticator(std::string_view sessionId, std::nullptr_t) = delete;
-        static Authenticator sessionAuthenticator(std::string_view sessionId, std::string_view cookieName) {
-            return Authenticator(CBLAuth_CreateSession(slice(sessionId), slice(cookieName)));
-        }
-        
+
     protected:
         friend class ReplicatorConfiguration;
         

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -42,9 +42,9 @@ namespace cbl {
             The port can be omitted; it defaults to 80 for `ws` and 443 for `wss`.
             For example: `wss://example.org/dbname`.
             @param url  The url. */
-        static Endpoint urlEndpoint(slice url) {
+        static Endpoint urlEndpoint(std::string_view url) {
             CBLError error {};
-            auto endpoint = CBLEndpoint_CreateWithURL(url, &error);
+            auto endpoint = CBLEndpoint_CreateWithURL(slice(url), &error);
             internal::check(endpoint, error);
             return Endpoint(endpoint);
         }
@@ -77,14 +77,18 @@ namespace cbl {
     class Authenticator {
     public:
         /** Creates a basic authenticator authenticator using username/password credentials. */
-        static Authenticator basicAuthenticator(slice username, slice password) {
-            return Authenticator(CBLAuth_CreatePassword(username, password));
+        static Authenticator basicAuthenticator(std::string_view username, std::string_view password) {
+            return Authenticator(CBLAuth_CreatePassword(slice(username), slice(password)));
         }
 
         /** Creates a sesssion authenticator using a Couchbase Sync Gateway login session identifier,
             and optionally a cookie name (pass NULL for the default.) */
-        static Authenticator sessionAuthenticator(slice sessionId, slice cookieName) {
-            return Authenticator(CBLAuth_CreateSession(sessionId, cookieName));
+        static Authenticator sessionAuthenticator(std::string_view sessionId) {
+            return Authenticator(CBLAuth_CreateSession(slice(sessionId), fleece::nullslice));
+        }
+        static Authenticator sessionAuthenticator(std::string_view sessionId, std::nullptr_t) = delete;
+        static Authenticator sessionAuthenticator(std::string_view sessionId, std::string_view cookieName) {
+            return Authenticator(CBLAuth_CreateSession(slice(sessionId), slice(cookieName)));
         }
         
     protected:
@@ -108,7 +112,7 @@ namespace cbl {
     using ReplicationFilter = std::function<bool(Document, CBLDocumentFlags flags)>;
 
     /** Replication Conflict Resolver Function Callback. */
-    using ConflictResolver = std::function<Document(slice docID,
+    using ConflictResolver = std::function<Document(std::string_view docID,
                                                     const Document localDoc,
                                                     const Document remoteDoc)>;
 
@@ -327,7 +331,7 @@ namespace cbl {
                         
                         auto map = (CollectionToReplCollectionMap*)context;
                         auto resolved = map->find(collection)->second.
-                            conflictResolver(slice(docID), localDoc, remoteDoc);
+                            conflictResolver((std::string_view)slice(docID), localDoc, remoteDoc);
                         
                         auto ref = resolved.ref();
                         if (ref && ref != cLocalDoc && ref != cRemoteDoc) {
@@ -408,9 +412,9 @@ namespace cbl {
             @note A `false` result means the document is not pending, _or_ there was an error.
                   To tell the difference, compare the error code to zero.
             @warning If the given collection is not part of the replication, an error will be thrown. */
-        bool isDocumentPending(slice docID, Collection& collection) const {
+        bool isDocumentPending(std::string_view docID, Collection& collection) const {
             CBLError error;
-            bool pending = CBLReplicator_IsDocumentPending(ref(), docID, collection.ref(), &error);
+            bool pending = CBLReplicator_IsDocumentPending(ref(), slice(docID), collection.ref(), &error);
             internal::check(pending || error.code == 0, error);
             return pending;
         }

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -408,7 +408,7 @@ namespace cbl {
             @note A `false` result means the document is not pending, _or_ there was an error.
                   To tell the difference, compare the error code to zero.
             @warning If the given collection is not part of the replication, an error will be thrown. */
-        bool isDocumentPending(fleece::slice docID, Collection& collection) const {
+        bool isDocumentPending(slice docID, Collection& collection) const {
             CBLError error;
             bool pending = CBLReplicator_IsDocumentPending(ref(), docID, collection.ref(), &error);
             internal::check(pending || error.code == 0, error);

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -45,7 +45,7 @@ namespace cbl {
         static Endpoint urlEndpoint(slice url) {
             CBLError error {};
             auto endpoint = CBLEndpoint_CreateWithURL(url, &error);
-            Base::check(endpoint, error);
+            internal::check(endpoint, error);
             return Endpoint(endpoint);
         }
         
@@ -346,7 +346,7 @@ namespace cbl {
             
             CBLError error {};
             _ref = (CBLRefCounted*) CBLReplicator_Create(&c_config, &error);
-            Base::check(_ref, error);
+            internal::check(_ref, error);
         }
 
         /** Starts a replicator, asynchronously. Does nothing if it's already started.
@@ -383,7 +383,7 @@ namespace cbl {
         /** Returns the ID used to correlate the replication session with the remote endpoint.
             This value is intended for logging and diagnostics, and is an empty string until the
             replicator receives a correlation ID from the remote endpoint. */
-        std::string correlationID() const  {return Base::asString(CBLReplicator_CorrelationID(ref()));}
+        std::string correlationID() const  {return internal::asString(CBLReplicator_CorrelationID(ref()));}
 
         /** Indicates which documents in the given collection have local changes that have not yet been
             pushed to the server by this replicator. This is of course a snapshot, that will go out of date
@@ -396,7 +396,7 @@ namespace cbl {
         fleece::Dict pendingDocumentIDs(Collection& collection) const {
             CBLError error;
             fleece::Dict result = CBLReplicator_PendingDocumentIDs(ref(), collection.ref(), &error);
-            Base::check(result != nullptr, error);
+            internal::check(result != nullptr, error);
             return result;
         }
         
@@ -411,7 +411,7 @@ namespace cbl {
         bool isDocumentPending(fleece::slice docID, Collection& collection) const {
             CBLError error;
             bool pending = CBLReplicator_IsDocumentPending(ref(), docID, collection.ref(), &error);
-            Base::check(pending || error.code == 0, error);
+            internal::check(pending || error.code == 0, error);
             return pending;
         }
         

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -45,8 +45,7 @@ namespace cbl {
         static Endpoint urlEndpoint(slice url) {
             CBLError error {};
             auto endpoint = CBLEndpoint_CreateWithURL(url, &error);
-            if (!endpoint)
-                throw error;
+            Base::check(endpoint, error);
             return Endpoint(endpoint);
         }
         
@@ -347,7 +346,7 @@ namespace cbl {
             
             CBLError error {};
             _ref = (CBLRefCounted*) CBLReplicator_Create(&c_config, &error);
-            check(_ref, error);
+            Base::check(_ref, error);
         }
 
         /** Starts a replicator, asynchronously. Does nothing if it's already started.
@@ -384,7 +383,7 @@ namespace cbl {
         /** Returns the ID used to correlate the replication session with the remote endpoint.
             This value is intended for logging and diagnostics, and is an empty string until the
             replicator receives a correlation ID from the remote endpoint. */
-        std::string correlationID() const  {return asString(CBLReplicator_CorrelationID(ref()));}
+        std::string correlationID() const  {return Base::asString(CBLReplicator_CorrelationID(ref()));}
 
         /** Indicates which documents in the given collection have local changes that have not yet been
             pushed to the server by this replicator. This is of course a snapshot, that will go out of date
@@ -397,7 +396,7 @@ namespace cbl {
         fleece::Dict pendingDocumentIDs(Collection& collection) const {
             CBLError error;
             fleece::Dict result = CBLReplicator_PendingDocumentIDs(ref(), collection.ref(), &error);
-            check(result != nullptr, error);
+            Base::check(result != nullptr, error);
             return result;
         }
         
@@ -412,7 +411,7 @@ namespace cbl {
         bool isDocumentPending(fleece::slice docID, Collection& collection) const {
             CBLError error;
             bool pending = CBLReplicator_IsDocumentPending(ref(), docID, collection.ref(), &error);
-            check(pending || error.code == 0, error);
+            Base::check(pending || error.code == 0, error);
             return pending;
         }
         

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -494,6 +494,8 @@ namespace cbl {
             return *this;
         }
         
+        /** Releases the underlying C \ref CBLReplicator and drops the C++ collection-configuration
+            map. After this call the object is empty (\ref operator bool returns false). */
         void clear() {
             RefCounted::clear();
             _collectionMap.reset();

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -21,7 +21,9 @@
 #include "cbl/CBLReplicator.h"
 #include "cbl/CBLDefaults.h"
 #include <functional>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <unordered_map>
 

--- a/include/cbl++/VectorIndex.hh
+++ b/include/cbl++/VectorIndex.hh
@@ -110,13 +110,13 @@ namespace cbl {
         QueryLanguage expressionLanguage() const         {return _exprLang;}
         
         /** The expression. */
-        slice expression() const                            {return _expr;}
+        slice expression() const                         {return _expr;}
         
         /** The number of vector dimensions. */
-        unsigned dimensions() const                         {return _dimensions;}
+        unsigned dimensions() const                      {return _dimensions;}
         
         /** The number of centroids. */
-        unsigned centroids() const                          {return _centroids;}
+        unsigned centroids() const                       {return _centroids;}
         
         /** The boolean flag indicating that index is lazy or not. The default value is false.
          
@@ -160,22 +160,26 @@ namespace cbl {
             The default value is zero, meaning that the numProbes will be determined based on
             the number of centroids. */
         unsigned numProbes = 0;
-        
+
+        /** Builds a transient CBLVectorIndexConfiguration referencing this object's data
+            and passes it to `f`. The C config is only valid while `f` is executing. */
+        template <typename F>
+        decltype(auto) withCConfig(F&& f) const {
+            CBLVectorIndexConfiguration cConfig {
+                _exprLang, slice(_expr), _dimensions, _centroids
+            };
+            cConfig.isLazy   = isLazy;
+            cConfig.encoding = encoding.ref();
+            cConfig.metric   = metric;
+            cConfig.minTrainingSize = minTrainingSize;
+            cConfig.maxTrainingSize = maxTrainingSize;
+            cConfig.numProbes = numProbes;
+            return std::forward<F>(f)(cConfig);
+        }
+
     protected:
         friend Collection;
-        
-        /** To  CBLVectorIndexConfiguration */
-        operator CBLVectorIndexConfiguration() const {
-            CBLVectorIndexConfiguration config { _exprLang, slice(_expr), _dimensions, _centroids };
-            config.isLazy = isLazy;
-            config.encoding = encoding.ref();
-            config.metric = metric;
-            config.minTrainingSize = minTrainingSize;
-            config.maxTrainingSize = maxTrainingSize;
-            config.numProbes = numProbes;
-            return config;
-        }
-            
+
     private:
         QueryLanguage _exprLang;
         std::string   _expr;
@@ -183,9 +187,13 @@ namespace cbl {
         unsigned      _centroids;
     };
 
-    void Collection::createVectorIndex(std::string_view name, const VectorIndexConfiguration &config) {
-        CBLError error {};
-        internal::check(CBLCollection_CreateVectorIndex(ref(), slice(name), config, &error), error);
+    void Collection::createVectorIndex(std::string_view name, VectorIndexConfiguration config) {
+        config.withCConfig([this, name](const CBLVectorIndexConfiguration& cConfig) {
+            CBLError error;
+            internal::check(
+                CBLCollection_CreateVectorIndex(ref(), slice(name), cConfig, &error),
+                error);
+        });
     }
 }
 

--- a/include/cbl++/VectorIndex.hh
+++ b/include/cbl++/VectorIndex.hh
@@ -161,6 +161,10 @@ namespace cbl {
             the number of centroids. */
         unsigned numProbes = 0;
 
+    protected:
+        friend Collection;
+
+    private:
         /** Builds a transient CBLVectorIndexConfiguration referencing this object's data
             and passes it to `f`. The C config is only valid while `f` is executing. */
         template <typename F>
@@ -177,10 +181,6 @@ namespace cbl {
             return std::forward<F>(f)(cConfig);
         }
 
-    protected:
-        friend Collection;
-
-    private:
         QueryLanguage _exprLang;
         std::string   _expr;
         unsigned      _dimensions;

--- a/include/cbl++/VectorIndex.hh
+++ b/include/cbl++/VectorIndex.hh
@@ -180,7 +180,7 @@ namespace cbl {
 
     void Collection::createVectorIndex(slice name, const VectorIndexConfiguration &config) {
         CBLError error {};
-        check(CBLCollection_CreateVectorIndex(ref(), name, config, &error), error);
+        Base::check(CBLCollection_CreateVectorIndex(ref(), name, config, &error), error);
     }
 }
 

--- a/include/cbl++/VectorIndex.hh
+++ b/include/cbl++/VectorIndex.hh
@@ -91,10 +91,10 @@ namespace cbl {
             @param centroids    The number of centroids which is the number buckets to partition the vectors in the index.
                               @note The recommended number of centroids is the square root of the number of vectors to be indexed,
                               and the maximum number of centroids supported is 64,000. */
-        VectorIndexConfiguration(CBLQueryLanguage expressionLanguage, slice expression,
+        VectorIndexConfiguration(CBLQueryLanguage expressionLanguage, std::string_view expression,
                                  unsigned dimensions, unsigned centroids)
         :_exprLang(expressionLanguage)
-        ,_expr(expression)
+        ,_expr(slice(expression))
         ,_dimensions(dimensions)
         ,_centroids(centroids)
         { }
@@ -178,9 +178,9 @@ namespace cbl {
         unsigned _centroids;
     };
 
-    void Collection::createVectorIndex(slice name, const VectorIndexConfiguration &config) {
+    void Collection::createVectorIndex(std::string_view name, const VectorIndexConfiguration &config) {
         CBLError error {};
-        internal::check(CBLCollection_CreateVectorIndex(ref(), name, config, &error), error);
+        internal::check(CBLCollection_CreateVectorIndex(ref(), slice(name), config, &error), error);
     }
 }
 

--- a/include/cbl++/VectorIndex.hh
+++ b/include/cbl++/VectorIndex.hh
@@ -32,6 +32,9 @@ namespace cbl {
     /** ENTERPRISE EDITION ONLY
      
         Vector Encoding  Type*/
+
+    using DistanceMetric = CBLDistanceMetric;
+
     class VectorEncoding {
     public:
         /** Creates a no-encoding type to use in VectorIndexConfiguration; 4 bytes per dimension, no data loss.
@@ -104,7 +107,7 @@ namespace cbl {
         //-- Accessors:
         
         /** The language used in the expressions.  */
-        CBLQueryLanguage expressionLanguage() const         {return _exprLang;}
+        QueryLanguage expressionLanguage() const         {return _exprLang;}
         
         /** The expression. */
         slice expression() const                            {return _expr;}
@@ -131,7 +134,7 @@ namespace cbl {
         VectorEncoding encoding = VectorEncoding::scalarQuantizer(kCBLSQ8);
         
         /** Distance Metric type. The default value is squared euclidean distance.  */
-        CBLDistanceMetric metric = kCBLDistanceMetricEuclideanSquared;
+        DistanceMetric metric = kCBLDistanceMetricEuclideanSquared;
         
         /** The minimum number of vectors for training the index.
             The default value is zero, meaning that minTrainingSize will be determined based on
@@ -163,7 +166,7 @@ namespace cbl {
         
         /** To  CBLVectorIndexConfiguration */
         operator CBLVectorIndexConfiguration() const {
-            CBLVectorIndexConfiguration config { _exprLang, _expr, _dimensions, _centroids };
+            CBLVectorIndexConfiguration config { _exprLang, slice(_expr), _dimensions, _centroids };
             config.isLazy = isLazy;
             config.encoding = encoding.ref();
             config.metric = metric;
@@ -174,10 +177,10 @@ namespace cbl {
         }
             
     private:
-        CBLQueryLanguage _exprLang;
-        slice _expr;
-        unsigned _dimensions;
-        unsigned _centroids;
+        QueryLanguage _exprLang;
+        std::string   _expr;
+        unsigned      _dimensions;
+        unsigned      _centroids;
     };
 
     void Collection::createVectorIndex(std::string_view name, const VectorIndexConfiguration &config) {

--- a/include/cbl++/VectorIndex.hh
+++ b/include/cbl++/VectorIndex.hh
@@ -180,7 +180,7 @@ namespace cbl {
 
     void Collection::createVectorIndex(slice name, const VectorIndexConfiguration &config) {
         CBLError error {};
-        Base::check(CBLCollection_CreateVectorIndex(ref(), name, config, &error), error);
+        internal::check(CBLCollection_CreateVectorIndex(ref(), name, config, &error), error);
     }
 }
 

--- a/include/cbl++/VectorIndex.hh
+++ b/include/cbl++/VectorIndex.hh
@@ -55,6 +55,8 @@ namespace cbl {
             return VectorEncoding(CBLVectorEncoding_CreateProductQuantizer(subquantizers, bits));
         }
         
+        /** Deleted: a VectorEncoding must be constructed via one of the named factories
+            (\ref none, \ref scalarQuantizer, \ref productQuantizer). */
         VectorEncoding() = delete;
         
     protected:

--- a/test/BlobTest_Cpp.cc
+++ b/test/BlobTest_Cpp.cc
@@ -49,13 +49,13 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob", "[Blob]") {
 
         Blob blob;
         SECTION("Create with data") {
-            blob = Blob(kBlobContents, kBlobContentType);
+            blob = Blob(kBlobContentType, kBlobContents);
         }
         SECTION("Create with stream") {
             BlobWriteStream writer(db);
             writer.write("This is the content "_sl);
             writer.write("of the blob."_sl);
-            blob = Blob(writer, kBlobContentType);
+            blob = Blob(kBlobContentType, writer);
         }
         CHECK(blob.digest() == kBlobDigest);
         CHECK(blob.contentType() == kBlobContentType);
@@ -131,7 +131,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob in mutable doc", "[Blob]") {
     {
         MutableDocument doc("blobbo");
         Blob blob;
-        blob = Blob(kBlobContents, kBlobContentType);
+        blob = Blob(kBlobContentType, kBlobContents);
         Dict props = blob.properties();
         doc["picture"] = props;
         defaultCollection.saveDocument(doc);
@@ -152,11 +152,11 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blobs in arrays/dicts", "[Blob]") {
         MutableDocument doc("blobbo");
         MutableArray array = MutableArray::newArray();
         array.insertNulls(0, 1);
-        Blob blob1(kBlobContents, kBlobContentType);
+        Blob blob1(kBlobContentType, kBlobContents);
         array[0] = blob1;
 
         MutableDict dict = MutableDict::newDict();
-        dict["b"] = Blob(kBlobContents,kBlobContentType);
+        dict["b"] = Blob(kBlobContentType, kBlobContents);
 
         doc["array"] = array;
         doc["dict"] = dict;
@@ -177,7 +177,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blobs in ResultSet", "[Blob]") {
         char docID[kDocIDBufferSize];
         snprintf(docID, kDocIDBufferSize, "doc-%d", i);
         MutableDocument doc(docID);
-        Blob blob(kBlobContents, kBlobContentType);
+        Blob blob(kBlobContentType, kBlobContents);
         doc["picture"] = blob.properties();
         defaultCollection.saveDocument(doc);
     }
@@ -201,14 +201,14 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob blobEquals", "[Blob]") {
     slice content1 = "This is the content of the blob 1.";
     slice content2 = "This is the content of the blob 2.";
 
-    Blob blob1(content1, kBlobContentType);
-    Blob blob2(content1, kBlobContentType);
+    Blob blob1(kBlobContentType, content1);
+    Blob blob2(kBlobContentType, content1);
 
     BlobWriteStream writer(db);
     writer.write(content1);
-    Blob blob3(writer, kBlobContentType);
+    Blob blob3(kBlobContentType, writer);
 
-    Blob blob4(content2, kBlobContentType);
+    Blob blob4(kBlobContentType, content2);
 
     CHECK(blob1.digest() == blob2.digest());
     CHECK(blob1.blobEquals(blob2));
@@ -220,7 +220,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob blobEquals", "[Blob]") {
 
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob createJSON", "[Blob]") {
-    Blob blob(kBlobContents, kBlobContentType);
+    Blob blob(kBlobContentType, kBlobContents);
     string json = blob.createJSON();
     string expected = string("{\"@type\":\"blob\",\"content_type\":\"") + kBlobContentType
                     + "\",\"digest\":\"" + kBlobDigest
@@ -231,7 +231,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob createJSON", "[Blob]") {
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream position", "[Blob]") {
     slice content = "This is the content of the blob 1.";
-    Blob blob(content, kBlobContentType);
+    Blob blob(kBlobContentType, content);
     db.saveBlob(blob);
 
     unique_ptr<BlobReadStream> in(blob.openContentStream());
@@ -251,7 +251,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream position", "[Blob]") {
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream seek", "[Blob]") {
     slice content = "This is the content of the blob 1.";
-    Blob blob(content, kBlobContentType);
+    Blob blob(kBlobContentType, content);
     db.saveBlob(blob);
 
     unique_ptr<BlobReadStream> in(blob.openContentStream());
@@ -280,7 +280,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream seek", "[Blob]") {
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream seek to negative position throws", "[Blob][!throws]") {
     slice content = "This is the content of the blob 1.";
-    Blob blob(content, kBlobContentType);
+    Blob blob(kBlobContentType, content);
     db.saveBlob(blob);
 
     unique_ptr<BlobReadStream> in(blob.openContentStream());

--- a/test/BlobTest_Cpp.cc
+++ b/test/BlobTest_Cpp.cc
@@ -195,3 +195,109 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blobs in ResultSet", "[Blob]") {
     }
     CHECK(rowCount == 10);
 }
+
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob blobEquals", "[Blob]") {
+    slice content1 = "This is the content of the blob 1.";
+    slice content2 = "This is the content of the blob 2.";
+
+    Blob blob1(kBlobContentType, content1);
+    Blob blob2(kBlobContentType, content1);
+
+    BlobWriteStream writer(db);
+    writer.write(content1);
+    Blob blob3(kBlobContentType, writer);
+
+    Blob blob4(kBlobContentType, content2);
+
+    CHECK(blob1.digest() == blob2.digest());
+    CHECK(blob1.blobEquals(blob2));
+    CHECK(blob1.blobEquals(blob3));
+
+    CHECK(blob1.digest() != blob4.digest());
+    CHECK(!blob1.blobEquals(blob4));
+}
+
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob createJSON", "[Blob]") {
+    Blob blob(kBlobContentType, kBlobContents);
+    string json = blob.createJSON();
+    string expected = string("{\"@type\":\"blob\",\"content_type\":\"") + kBlobContentType
+                    + "\",\"digest\":\"" + kBlobDigest
+                    + "\",\"length\":" + to_string(kBlobContents.size) + "}";
+    CHECK(json == expected);
+}
+
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream position", "[Blob]") {
+    slice content = "This is the content of the blob 1.";
+    Blob blob(kBlobContentType, content);
+    db.saveBlob(blob);
+
+    unique_ptr<BlobReadStream> in(blob.openContentStream());
+    CHECK(in->position() == 0);
+
+    char buf[20];
+    CHECK(in->read(buf, 20) == 20);
+    CHECK(in->position() == 20);
+
+    CHECK(in->read(buf, 20) == 14);
+    CHECK(in->position() == content.size);
+
+    CHECK(in->read(buf, 20) == 0);
+    CHECK(in->position() == content.size);
+}
+
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream seek", "[Blob]") {
+    slice content = "This is the content of the blob 1.";
+    Blob blob(kBlobContentType, content);
+    db.saveBlob(blob);
+
+    unique_ptr<BlobReadStream> in(blob.openContentStream());
+    char buf[20];
+
+    // Seek from start, then read:
+    CHECK(in->seek(12, kCBLSeekModeFromStart) == 12);
+    CHECK(in->position() == 12);
+    CHECK(in->read(buf, 7) == 7);
+    CHECK(memcmp(buf, &content[12], 7) == 0);
+    CHECK(in->position() == 12 + 7);
+
+    // Seek relative to current position:
+    CHECK(in->seek(1, kCBLSeekModeRelative) == 20);
+    CHECK(in->position() == 20);
+
+    // Seek from end:
+    CHECK(in->seek(-5, kCBLSeekModeFromEnd) == int64_t(content.size) - 5);
+    CHECK(in->position() == content.size - 5);
+
+    // Seek past EOF: pinned to EOF, not an error:
+    CHECK(in->seek(9999, kCBLSeekModeFromStart) == int64_t(content.size));
+    CHECK(in->position() == content.size);
+}
+
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream seek to negative position throws", "[Blob][!throws]") {
+    slice content = "This is the content of the blob 1.";
+    Blob blob(kBlobContentType, content);
+    db.saveBlob(blob);
+
+    unique_ptr<BlobReadStream> in(blob.openContentStream());
+
+    ExpectingExceptions x;
+    CBLError thrown {};
+    bool threw = false;
+    try {
+        in->seek(-999, kCBLSeekModeFromEnd);
+    } catch (const cbl::Error& e) {
+        threw = true;
+        thrown = asCBLError(e);
+    }
+    CHECK(threw);
+    CHECK(thrown.domain == kCBLDomain);
+    CHECK(thrown.code == kCBLErrorInvalidParameter);
+
+    // Position is unchanged if error occurs.
+    CHECK(in->position() == 0);
+}

--- a/test/BlobTest_Cpp.cc
+++ b/test/BlobTest_Cpp.cc
@@ -49,13 +49,13 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob", "[Blob]") {
 
         Blob blob;
         SECTION("Create with data") {
-            blob = Blob(kBlobContentType, kBlobContents);
+            blob = Blob(kBlobContents, kBlobContentType);
         }
         SECTION("Create with stream") {
             BlobWriteStream writer(db);
             writer.write("This is the content "_sl);
             writer.write("of the blob."_sl);
-            blob = Blob(kBlobContentType, writer);
+            blob = Blob(writer, kBlobContentType);
         }
         CHECK(blob.digest() == kBlobDigest);
         CHECK(blob.contentType() == kBlobContentType);
@@ -131,7 +131,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob in mutable doc", "[Blob]") {
     {
         MutableDocument doc("blobbo");
         Blob blob;
-        blob = Blob(kBlobContentType, kBlobContents);
+        blob = Blob(kBlobContents, kBlobContentType);
         Dict props = blob.properties();
         doc["picture"] = props;
         defaultCollection.saveDocument(doc);
@@ -152,11 +152,11 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blobs in arrays/dicts", "[Blob]") {
         MutableDocument doc("blobbo");
         MutableArray array = MutableArray::newArray();
         array.insertNulls(0, 1);
-        Blob blob1(kBlobContentType, kBlobContents);
+        Blob blob1(kBlobContents, kBlobContentType);
         array[0] = blob1;
 
         MutableDict dict = MutableDict::newDict();
-        dict["b"] = Blob(kBlobContentType, kBlobContents);
+        dict["b"] = Blob(kBlobContents,kBlobContentType);
 
         doc["array"] = array;
         doc["dict"] = dict;
@@ -177,7 +177,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blobs in ResultSet", "[Blob]") {
         char docID[kDocIDBufferSize];
         snprintf(docID, kDocIDBufferSize, "doc-%d", i);
         MutableDocument doc(docID);
-        Blob blob(kBlobContentType, kBlobContents);
+        Blob blob(kBlobContents, kBlobContentType);
         doc["picture"] = blob.properties();
         defaultCollection.saveDocument(doc);
     }
@@ -201,14 +201,14 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob blobEquals", "[Blob]") {
     slice content1 = "This is the content of the blob 1.";
     slice content2 = "This is the content of the blob 2.";
 
-    Blob blob1(kBlobContentType, content1);
-    Blob blob2(kBlobContentType, content1);
+    Blob blob1(content1, kBlobContentType);
+    Blob blob2(content1, kBlobContentType);
 
     BlobWriteStream writer(db);
     writer.write(content1);
-    Blob blob3(kBlobContentType, writer);
+    Blob blob3(writer, kBlobContentType);
 
-    Blob blob4(kBlobContentType, content2);
+    Blob blob4(content2, kBlobContentType);
 
     CHECK(blob1.digest() == blob2.digest());
     CHECK(blob1.blobEquals(blob2));
@@ -220,7 +220,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob blobEquals", "[Blob]") {
 
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob createJSON", "[Blob]") {
-    Blob blob(kBlobContentType, kBlobContents);
+    Blob blob(kBlobContents, kBlobContentType);
     string json = blob.createJSON();
     string expected = string("{\"@type\":\"blob\",\"content_type\":\"") + kBlobContentType
                     + "\",\"digest\":\"" + kBlobDigest
@@ -231,7 +231,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob createJSON", "[Blob]") {
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream position", "[Blob]") {
     slice content = "This is the content of the blob 1.";
-    Blob blob(kBlobContentType, content);
+    Blob blob(content, kBlobContentType);
     db.saveBlob(blob);
 
     unique_ptr<BlobReadStream> in(blob.openContentStream());
@@ -251,7 +251,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream position", "[Blob]") {
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream seek", "[Blob]") {
     slice content = "This is the content of the blob 1.";
-    Blob blob(kBlobContentType, content);
+    Blob blob(content, kBlobContentType);
     db.saveBlob(blob);
 
     unique_ptr<BlobReadStream> in(blob.openContentStream());
@@ -280,7 +280,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream seek", "[Blob]") {
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Blob read stream seek to negative position throws", "[Blob][!throws]") {
     slice content = "This is the content of the blob 1.";
-    Blob blob(kBlobContentType, content);
+    Blob blob(content, kBlobContentType);
     db.saveBlob(blob);
 
     unique_ptr<BlobReadStream> in(blob.openContentStream());

--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -227,7 +227,7 @@ void CBLTest_Cpp::resetDatabase(bool deleteDatabase) {
 cbl::Database CBLTest_Cpp::openDatabaseNamed(slice name, bool createEmpty){
     auto config = CBLTest::databaseConfig();
     if (createEmpty == true){
-        cbl::Database::deleteDatabase(name, config.directory);
+        cbl::Database::deleteDatabase(name, (slice)config.directory);
     }
     cbl::Database database = cbl::Database(name, config);
     REQUIRE(database);

--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -227,7 +227,7 @@ void CBLTest_Cpp::resetDatabase(bool deleteDatabase) {
 cbl::Database CBLTest_Cpp::openDatabaseNamed(slice name, bool createEmpty){
     auto config = CBLTest::databaseConfig();
     if (createEmpty == true){
-        cbl::Database::deleteDatabase(name, (slice)config.directory);
+        cbl::Database::deleteDatabase(name, config.directory);
     }
     cbl::Database database = cbl::Database(name, config);
     REQUIRE(database);

--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -227,7 +227,7 @@ void CBLTest_Cpp::resetDatabase(bool deleteDatabase) {
 cbl::Database CBLTest_Cpp::openDatabaseNamed(slice name, bool createEmpty){
     auto config = CBLTest::databaseConfig();
     if (createEmpty == true){
-        cbl::Database::deleteDatabase(name, config.directory);
+        cbl::Database::deleteDatabase(name, slice(config.directory));
     }
     cbl::Database database = cbl::Database(name, config);
     REQUIRE(database);

--- a/test/CBLTest.hh
+++ b/test/CBLTest.hh
@@ -18,6 +18,7 @@
 
 #pragma once
 #include "cbl/CouchbaseLite.h"
+#include "cbl++/Base.hh"
 #include "CBLPrivate.h"
 #include "fleece/slice.hh"
 #include <functional>

--- a/test/CBLTest_Cpp.hh
+++ b/test/CBLTest_Cpp.hh
@@ -58,3 +58,24 @@ public:
 void createDocWithJSON(cbl::Collection& collection, std::string docID, std::string jsonContent);
 
 void createNumberedDocsWithPrefix(cbl::Collection& collection, unsigned n, const std::string& idprefix, unsigned start = 1);
+
+/** Runs `fn` and returns true if it completes without throwing, or false if it throws a
+    cbl::Error. Lets a void, throw-on-error C++ API call be asserted in a Catch CHECK/REQUIRE,
+    e.g. `REQUIRE(succeeds([&]{ db.saveBlob(blob); }));`.
+    @note Only cbl::Error is treated as failure; other exceptions propagate. */
+template <typename Fn>
+static inline bool succeeds(Fn&& fn) {
+    try {
+        std::forward<Fn>(fn)();
+        return true;
+    } catch (const cbl::Error&) {
+        return false;
+    }
+}
+
+/** Converts a thrown cbl::Error back to the C CBLError struct, for tests that compare against
+    expected domain/code (e.g. via CheckError). Usage:
+    `catch (const cbl::Error& e) { error = asCBLError(e); }`. */
+static inline CBLError asCBLError(const cbl::Error& e) {
+    return {e.domain, e.code};
+}

--- a/test/CollectionTest_Cpp.cc
+++ b/test/CollectionTest_Cpp.cc
@@ -44,60 +44,60 @@ public:
         // Document Functions:
         CBLError error {};
         MutableDocument doc("doc1");
-        try { col.saveDocument(doc); } catch (CBLError e) { error = e; }
+        try { col.saveDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
         auto conflictHandler = [](MutableDocument d1, Document d2) -> bool { return true; };
-        try { (void) col.saveDocument(doc, conflictHandler); } catch (CBLError e) { error = e; }
+        try { (void) col.saveDocument(doc, conflictHandler); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { (void) !col.saveDocument(doc, kCBLConcurrencyControlLastWriteWins); } catch (CBLError e) { error = e; }
+        try { (void) !col.saveDocument(doc, kCBLConcurrencyControlLastWriteWins); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { col.getDocument("doc1"); } catch (CBLError e) { error = e; }
+        try { col.getDocument("doc1"); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { col.getMutableDocument("doc1"); } catch (CBLError e) { error = e; }
+        try { col.getMutableDocument("doc1"); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { col.deleteDocument(doc); } catch (CBLError e) { error = e; }
+        try { col.deleteDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { (void) !col.deleteDocument(doc, kCBLConcurrencyControlLastWriteWins); } catch (CBLError e) { error = e; }
+        try { (void) !col.deleteDocument(doc, kCBLConcurrencyControlLastWriteWins); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { col.purgeDocument(doc); } catch (CBLError e) { error = e; }
+        try { col.purgeDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { col.purgeDocument("doc1"); } catch (CBLError e) { error = e; }
+        try { col.purgeDocument("doc1"); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { col.getDocumentExpiration("doc1"); } catch (CBLError e) { error = e; }
+        try { col.getDocumentExpiration("doc1"); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { col.setDocumentExpiration("doc1", CBL_Now()); } catch (CBLError e) { error = e; }
+        try { col.setDocumentExpiration("doc1", CBL_Now()); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { col.createValueIndex("Value", {}); } catch (CBLError e) { error = e; }
+        try { col.createValueIndex("Value", {}); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { col.createFullTextIndex("FTS", {}); } catch (CBLError e) { error = e; }
+        try { col.createFullTextIndex("FTS", {}); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         error = {};
-        try { col.getIndexNames(); } catch (CBLError e) { error = e; }
+        try { col.getIndexNames(); } catch (const cbl::Error& e) { error = asCBLError(e); }
         CheckNotOpenError(error);
         
         auto listener = [](const CollectionChange* change) { };
@@ -136,8 +136,8 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Delete Default Collection", "[Collecti
     CBLError error {};
     try {
         db.createCollection(kCBLDefaultCollectionName);
-    } catch (CBLError e) {
-        error = e;
+    } catch (const cbl::Error& e) {
+        error = asCBLError(e);
     }
     CHECK(error.domain == kCBLDomain);
     CHECK(error.code == kCBLErrorInvalidParameter);
@@ -166,7 +166,7 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Collection Cannot Be Deleted",
     // Try delete the default collection - should fail and catch error:
     try {
         db.deleteCollection(kCBLDefaultCollectionName);
-    } catch (CBLError e){
+    } catch (const cbl::Error& e){
         CHECK((e.domain == kCBLDomain && e.code == kCBLErrorInvalidParameter ));
     }
 }

--- a/test/CollectionTest_Cpp.cc
+++ b/test/CollectionTest_Cpp.cc
@@ -165,7 +165,7 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Collection Cannot Be Deleted",
 
     // Try delete the default collection - should fail and catch error:
     try {
-        db.deleteCollection(kCBLDefaultCollectionName);
+        db.deleteCollection((slice)kCBLDefaultCollectionName);
     } catch (const cbl::Error& e){
         CHECK((e.domain == kCBLDomain && e.code == kCBLErrorInvalidParameter ));
     }
@@ -174,11 +174,11 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Collection Cannot Be Deleted",
 #endif
 
 TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Create And Get Collection In Default Scope", "[Collection]") {
-    Collection col = db.getCollection("colA", kCBLDefaultScopeName);
+    Collection col = db.getCollection("colA", (slice)kCBLDefaultScopeName);
     REQUIRE(!col);
     
     SECTION("Specify scope name") {
-        col = db.createCollection("colA", kCBLDefaultScopeName);
+        col = db.createCollection("colA", (slice)kCBLDefaultScopeName);
     }
     
     SECTION("Not specify scope name") {

--- a/test/CollectionTest_Cpp.cc
+++ b/test/CollectionTest_Cpp.cc
@@ -165,7 +165,7 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Collection Cannot Be Deleted",
 
     // Try delete the default collection - should fail and catch error:
     try {
-        db.deleteCollection((slice)kCBLDefaultCollectionName);
+        db.deleteCollection(kCBLDefaultCollectionName);
     } catch (const cbl::Error& e){
         CHECK((e.domain == kCBLDomain && e.code == kCBLErrorInvalidParameter ));
     }
@@ -174,11 +174,11 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Collection Cannot Be Deleted",
 #endif
 
 TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Create And Get Collection In Default Scope", "[Collection]") {
-    Collection col = db.getCollection("colA", (slice)kCBLDefaultScopeName);
+    Collection col = db.getCollection("colA", kCBLDefaultScopeName);
     REQUIRE(!col);
     
     SECTION("Specify scope name") {
-        col = db.createCollection("colA", (slice)kCBLDefaultScopeName);
+        col = db.createCollection("colA", kCBLDefaultScopeName);
     }
     
     SECTION("Not specify scope name") {

--- a/test/CollectionTest_Cpp.cc
+++ b/test/CollectionTest_Cpp.cc
@@ -165,7 +165,7 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Collection Cannot Be Deleted",
 
     // Try delete the default collection - should fail and catch error:
     try {
-        db.deleteCollection(kCBLDefaultCollectionName);
+        db.deleteCollection(slice(kCBLDefaultCollectionName));
     } catch (const cbl::Error& e){
         CHECK((e.domain == kCBLDomain && e.code == kCBLErrorInvalidParameter ));
     }
@@ -174,17 +174,17 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Default Collection Cannot Be Deleted",
 #endif
 
 TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Create And Get Collection In Default Scope", "[Collection]") {
-    Collection col = db.getCollection("colA", kCBLDefaultScopeName);
+    Collection col = db.getCollection("colA", slice(kCBLDefaultScopeName));
     REQUIRE(!col);
-    
+
     SECTION("Specify scope name") {
-        col = db.createCollection("colA", kCBLDefaultScopeName);
+        col = db.createCollection("colA", slice(kCBLDefaultScopeName));
     }
-    
+
     SECTION("Not specify scope name") {
         col = db.createCollection("colA");
     }
-    
+
     REQUIRE(col);
     CHECK(col.name() == "colA");
     CHECK(col.scopeName() == "_default");

--- a/test/CollectionTest_Cpp.cc
+++ b/test/CollectionTest_Cpp.cc
@@ -351,13 +351,13 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Create, Get and Delete Index", "[Colle
     REQUIRE(names);
     REQUIRE(names.count() == 0);
     
-    CBLValueIndexConfiguration index1 = {kCBLN1QLLanguage, "id"_sl};
+    ValueIndexConfiguration index1 = {kCBLN1QLLanguage, "id"};
     defaultCollection.createValueIndex("index1", index1);
     
-    CBLValueIndexConfiguration index2 = {kCBLN1QLLanguage, "firstname, lastname"_sl};
+    ValueIndexConfiguration index2 = {kCBLN1QLLanguage, "firstname, lastname"};
     defaultCollection.createValueIndex("index2", index2);
     
-    CBLFullTextIndexConfiguration index3 = {kCBLN1QLLanguage, "product.description"_sl, true};
+    FullTextIndexConfiguration index3 = {kCBLN1QLLanguage, "product.description", true};
     defaultCollection.createFullTextIndex("index3", index3);
     
     names = defaultCollection.getIndexNames();
@@ -380,10 +380,10 @@ TEST_CASE_METHOD(CollectionTest_Cpp, "C++ Delete Indexes", "[Collection]") {
     Collection col = db.createCollection("colA", "scopeA");
     REQUIRE(col);
     
-    CBLValueIndexConfiguration index1 = {kCBLN1QLLanguage, "id"_sl};
+    ValueIndexConfiguration index1 = {kCBLN1QLLanguage, "id"};
     col.createValueIndex("index1", index1);
     
-    CBLValueIndexConfiguration index2 = {kCBLN1QLLanguage, "firstname, lastname"_sl};
+    ValueIndexConfiguration index2 = {kCBLN1QLLanguage, "firstname, lastname"};
     col.createValueIndex("index2", index2);
     
     RetainedArray names = col.getIndexNames();

--- a/test/DatabaseTest_Cpp.cc
+++ b/test/DatabaseTest_Cpp.cc
@@ -252,7 +252,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database returns its config") {
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database saveBlob and getBlob round-trip", "[Blob]") {
     slice content = "I'm Blob.";
-    Blob blob("text/plain", content);
+    Blob blob(content, "text/plain");
     REQUIRE(succeeds([&]{ db.saveBlob(blob); }));
 
     Blob fetched = db.getBlob(blob.properties());
@@ -266,7 +266,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database saveBlob and getBlob round-trip", "[
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database saveBlob then read via document", "[Blob]") {
     slice content = "I'm Blob.";
-    Blob blob("text/plain", content);
+    Blob blob(content, "text/plain");
     REQUIRE(succeeds([&]{ db.saveBlob(blob); }));
 
     MutableDocument doc("doc1");

--- a/test/DatabaseTest_Cpp.cc
+++ b/test/DatabaseTest_Cpp.cc
@@ -252,7 +252,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database returns its config") {
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database saveBlob and getBlob round-trip", "[Blob]") {
     slice content = "I'm Blob.";
-    Blob blob(content, "text/plain");
+    Blob blob("text/plain", content);
     REQUIRE(succeeds([&]{ db.saveBlob(blob); }));
 
     Blob fetched = db.getBlob(blob.properties());
@@ -266,7 +266,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database saveBlob and getBlob round-trip", "[
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database saveBlob then read via document", "[Blob]") {
     slice content = "I'm Blob.";
-    Blob blob(content, "text/plain");
+    Blob blob("text/plain", content);
     REQUIRE(succeeds([&]{ db.saveBlob(blob); }));
 
     MutableDocument doc("doc1");

--- a/test/DatabaseTest_Cpp.cc
+++ b/test/DatabaseTest_Cpp.cc
@@ -36,7 +36,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database") {
 }
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database Exist") {
-    CHECK(!Database::exists(kDatabaseName, nullptr));
+    CHECK(!Database::exists(kDatabaseName));
     CHECK(Database::exists(kDatabaseName, CBLTest::databaseDir()));
 }
 

--- a/test/DatabaseTest_Cpp.cc
+++ b/test/DatabaseTest_Cpp.cc
@@ -19,6 +19,7 @@
 #include "CBLTest_Cpp.hh"
 #include "fleece/Fleece.hh"
 #include "fleece/Mutable.hh"
+#include <cstring>
 #include <string>
 #include <thread>
 
@@ -209,28 +210,31 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ DatabaseConfiguration default") {
     CHECK(cfg.encryptionKey.algorithm == kCBLEncryptionNone);
 #endif
 }
-#if 0
+
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ DatabaseConfiguration round-trip with CBL config") {
     string dir = string(slice(CBLTest::databaseDir()));
     DatabaseConfiguration cfg = DatabaseConfiguration::defaultConfiguration();
     cfg.directory = dir;
     cfg.fullSync = true;
 
-    CBLDatabaseConfiguration ccfg = cfg;
-    CHECK(slice(ccfg.directory) == slice(dir));
-    CHECK(ccfg.fullSync == true);
+    CBLDatabaseConfiguration ccfg{
+        slice(cfg.directory),
 #ifdef COUCHBASE_ENTERPRISE
-    CHECK(ccfg.encryptionKey.algorithm == kCBLEncryptionNone);
+        cfg.encryptionKey,
 #endif
+        cfg.fullSync
+    };
 
     DatabaseConfiguration cfg2 = ccfg;
-    CHECK(slice(cfg2.directory) == slice(dir));
-    CHECK(cfg2.fullSync == true);
+    CHECK(cfg2.directory == cfg.directory);
+    CHECK(cfg2.fullSync == cfg.fullSync);
 #ifdef COUCHBASE_ENTERPRISE
-    CHECK(cfg2.encryptionKey.algorithm == kCBLEncryptionNone);
+    CHECK([](EncryptionKey& key1, EncryptionKey& key2) -> bool {
+        return key1.algorithm == key2.algorithm &&
+        std::memcmp(key1.bytes, key2.bytes, sizeof(key1.bytes)) == 0;
+    }(cfg2.encryptionKey, cfg.encryptionKey));
 #endif
 }
-#endif
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database returns its config") {
     DatabaseConfiguration cfg = db.config();

--- a/test/DatabaseTest_Cpp.cc
+++ b/test/DatabaseTest_Cpp.cc
@@ -209,7 +209,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ DatabaseConfiguration default") {
     CHECK(cfg.encryptionKey.algorithm == kCBLEncryptionNone);
 #endif
 }
-
+#if 0
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ DatabaseConfiguration round-trip with CBL config") {
     string dir = string(slice(CBLTest::databaseDir()));
     DatabaseConfiguration cfg = DatabaseConfiguration::defaultConfiguration();
@@ -230,6 +230,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ DatabaseConfiguration round-trip with CBL con
     CHECK(cfg2.encryptionKey.algorithm == kCBLEncryptionNone);
 #endif
 }
+#endif
 
 TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database returns its config") {
     DatabaseConfiguration cfg = db.config();
@@ -309,7 +310,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database getBlob non-existing returns falsy",
     props[kCBLBlobDigestProperty] = "sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=";
 
     // Legitimate "not found": no throw, falsy Blob.
-    Blob got = db.getBlob(props);
+    const Blob got = db.getBlob(props);
     CHECK(!got);
 }
 

--- a/test/DatabaseTest_Cpp.cc
+++ b/test/DatabaseTest_Cpp.cc
@@ -198,3 +198,276 @@ TEST_CASE_METHOD(CBLTest_Cpp, "Empty Listener Token") {
     CHECK(!listenerToken.token());
     listenerToken.remove(); // Noops
 }
+
+
+#pragma mark - DatabaseConfiguration:
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ DatabaseConfiguration default") {
+    auto cfg = DatabaseConfiguration::defaultConfiguration();
+    CHECK(!cfg.fullSync);
+#ifdef COUCHBASE_ENTERPRISE
+    CHECK(cfg.encryptionKey.algorithm == kCBLEncryptionNone);
+#endif
+}
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ DatabaseConfiguration round-trip with CBL config") {
+    string dir = string(slice(CBLTest::databaseDir()));
+    DatabaseConfiguration cfg = DatabaseConfiguration::defaultConfiguration();
+    cfg.directory = dir;
+    cfg.fullSync = true;
+
+    CBLDatabaseConfiguration ccfg = cfg;
+    CHECK(slice(ccfg.directory) == slice(dir));
+    CHECK(ccfg.fullSync == true);
+#ifdef COUCHBASE_ENTERPRISE
+    CHECK(ccfg.encryptionKey.algorithm == kCBLEncryptionNone);
+#endif
+
+    DatabaseConfiguration cfg2 = ccfg;
+    CHECK(slice(cfg2.directory) == slice(dir));
+    CHECK(cfg2.fullSync == true);
+#ifdef COUCHBASE_ENTERPRISE
+    CHECK(cfg2.encryptionKey.algorithm == kCBLEncryptionNone);
+#endif
+}
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database returns its config") {
+    DatabaseConfiguration cfg = db.config();
+
+    // cfg.directory contains the trailing directory separator, '/' or '\\' 
+    CHECK(cfg.directory.substr(0, cfg.directory.length() - 1) == CBLTest::databaseDir().asString());
+    CHECK(!cfg.fullSync);
+#ifdef COUCHBASE_ENTERPRISE
+    CHECK(cfg.encryptionKey.algorithm == kCBLEncryptionNone);
+#endif
+}
+
+
+#pragma mark - Save / Get Blob:
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database saveBlob and getBlob round-trip", "[Blob]") {
+    slice content = "I'm Blob.";
+    Blob blob("text/plain", content);
+    REQUIRE(succeeds([&]{ db.saveBlob(blob); }));
+
+    Blob fetched = db.getBlob(blob.properties());
+    REQUIRE(fetched);
+    CHECK(fetched.length() == content.size);
+    CHECK(fetched.contentType() == "text/plain");
+    CHECK(fetched.digest() == blob.digest());
+    CHECK(fetched.loadContent() == content);
+    CHECK(fetched.blobEquals(blob));
+}
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database saveBlob then read via document", "[Blob]") {
+    slice content = "I'm Blob.";
+    Blob blob("text/plain", content);
+    REQUIRE(succeeds([&]{ db.saveBlob(blob); }));
+
+    MutableDocument doc("doc1");
+    doc["blob"] = blob.properties();
+    defaultCollection.saveDocument(doc);
+
+    Document doc2 = defaultCollection.getDocument("doc1");
+    REQUIRE(doc2);
+    Blob fromDoc(doc2["blob"].asDict());
+    REQUIRE(fromDoc);
+    CHECK(fromDoc.loadContent() == content);
+}
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database saveBlob of already-stored blob throws",
+                 "[Blob][!throws]") {
+    slice content = "I'm Blob.";
+    Blob blob("text/plain", content);
+    REQUIRE(succeeds([&]{ db.saveBlob(blob); }));
+
+    MutableDocument doc("doc1");
+    doc["blob"] = blob.properties();
+    defaultCollection.saveDocument(doc);
+
+    Document doc2 = defaultCollection.getDocument("doc1");
+    Blob fromDoc(doc2["blob"].asDict());
+    REQUIRE(fromDoc);
+
+    ExpectingExceptions x;
+    CBLError thrown {};
+    bool threw = false;
+    try {
+        db.saveBlob(fromDoc);
+    } catch (const cbl::Error& e) {
+        threw = true;
+        thrown = asCBLError(e);
+    }
+    CHECK(threw);
+    CHECK(thrown.domain == kCBLDomain);
+    CHECK(thrown.code == kCBLErrorUnsupported);
+}
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database getBlob non-existing returns falsy", "[Blob]") {
+    auto props = MutableDict::newDict();
+    props[kCBLTypeProperty] = kCBLBlobType;
+    props[kCBLBlobDigestProperty] = "sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=";
+
+    // Legitimate "not found": no throw, falsy Blob.
+    Blob got = db.getBlob(props);
+    CHECK(!got);
+}
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database getBlob with invalid props throws",
+                 "[Blob][!throws]") {
+    auto props = MutableDict::newDict();
+    props[kCBLTypeProperty] = kCBLBlobType;   // missing digest -> kCBLErrorInvalidParameter
+
+    ExpectingExceptions x;
+    CBLError thrown {};
+    bool threw = false;
+    try {
+        db.getBlob(props);
+    } catch (const cbl::Error& e) {
+        threw = true;
+        thrown = asCBLError(e);
+    }
+    CHECK(threw);
+    CHECK(thrown.domain == kCBLDomain);
+    CHECK(thrown.code == kCBLErrorInvalidParameter);
+}
+
+
+#ifdef COUCHBASE_ENTERPRISE
+
+#pragma mark - Encryption:
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ EncryptionKey from password") {
+    EncryptionKey defaultKey;
+    CHECK(defaultKey.algorithm == kCBLEncryptionNone);
+
+    EncryptionKey k("sekrit"_sl);
+    CHECK(k.algorithm == kCBLEncryptionAES256);
+
+    EncryptionKey kOld("sekrit"_sl, true);
+    CHECK(kOld.algorithm == kCBLEncryptionAES256);
+
+    // The two derivation algorithms should yield different bytes for the same password:
+    CHECK(memcmp(k.bytes, kOld.bytes, sizeof(k.bytes)) != 0);
+
+    // Same password + algorithm yields the same key bytes:
+    EncryptionKey k2("sekrit"_sl);
+    CHECK(memcmp(k.bytes, k2.bytes, sizeof(k.bytes)) == 0);
+}
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Open encrypted database via DatabaseConfiguration") {
+    slice encDbName = "encdb_cpp";
+    auto dbDir = CBLTest::databaseDir();
+    cbl::Database::deleteDatabase(encDbName, dbDir);
+    REQUIRE(!cbl::Database::exists(encDbName, dbDir));
+
+    string dir = string(dbDir);
+    DatabaseConfiguration cfg = DatabaseConfiguration::defaultConfiguration();
+    cfg.directory = dir;
+    cfg.encryptionKey = EncryptionKey("sekrit"_sl);
+
+    {
+        cbl::Database encdb(encDbName, cfg);
+        REQUIRE(encdb);
+        DatabaseConfiguration roundTrip = encdb.config();
+        CHECK(roundTrip.encryptionKey.algorithm == kCBLEncryptionAES256);
+        CHECK(memcmp(roundTrip.encryptionKey.bytes, cfg.encryptionKey.bytes,
+                     sizeof(cfg.encryptionKey.bytes)) == 0);
+
+        // A document so we know the database is real:
+        MutableDocument mdoc("doc1");
+        mdoc["greeting"] = "Howdy!";
+        encdb.getDefaultCollection().saveDocument(mdoc);
+        encdb.close();
+    }
+
+    // Reopening with the wrong key fails:
+    {
+        DatabaseConfiguration wrong = DatabaseConfiguration::defaultConfiguration();
+        wrong.directory = dir;
+        wrong.encryptionKey = EncryptionKey("wrongpassword"_sl);
+        ExpectingExceptions x;
+        CBLError thrown {};
+        bool threw = false;
+        try {
+            cbl::Database bad(encDbName, wrong);
+        } catch (const cbl::Error& e) {
+            threw = true;
+            thrown = asCBLError(e);
+        }
+        CHECK(threw);
+        CHECK(thrown.domain == kCBLDomain);
+        CHECK(thrown.code == kCBLErrorNotADatabaseFile);
+    }
+
+    // Reopening with the correct key succeeds:
+    {
+        cbl::Database encdb(encDbName, cfg);
+        REQUIRE(encdb);
+        Document doc = encdb.getDefaultCollection().getDocument("doc1");
+        REQUIRE(doc);
+        CHECK(doc["greeting"].asString() == "Howdy!");
+        encdb.deleteDatabase();
+    }
+}
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Database changeEncryptionKey") {
+    slice encDbName = "encdb_cpp_change";
+    auto dbDir = CBLTest::databaseDir();
+    cbl::Database::deleteDatabase(encDbName, dbDir);
+
+    string dir = string(dbDir);
+    DatabaseConfiguration cfg = DatabaseConfiguration::defaultConfiguration();
+    cfg.directory = dir;
+
+    // 1) Create an unencrypted DB and add a doc:
+    {
+        cbl::Database d(encDbName, cfg);
+        MutableDocument mdoc("doc1");
+        mdoc["greeting"] = "Howdy!";
+        d.getDefaultCollection().saveDocument(mdoc);
+
+        // Encrypt the DB:
+        EncryptionKey newKey("sekrit"_sl);
+        CHECK(succeeds([&]{ d.changeEncryptionKey(&newKey); }));
+        d.close();
+    }
+
+    // 2) Verify it now requires the key:
+    {
+        ExpectingExceptions x;
+        bool threw = false;
+        try {
+            cbl::Database unencrypted(encDbName, cfg);
+        } catch (const cbl::Error&) {
+            threw = true;
+        }
+        CHECK(threw);
+    }
+
+    // 3) Open with the key, then remove the key:
+    {
+        DatabaseConfiguration encCfg = cfg;
+        encCfg.encryptionKey = EncryptionKey("sekrit"_sl);
+        cbl::Database d(encDbName, encCfg);
+
+        Document doc = d.getDefaultCollection().getDocument("doc1");
+        REQUIRE(doc);
+        CHECK(doc["greeting"].asString() == "Howdy!");
+
+        // Remove encryption by passing nullptr:
+        CHECK(succeeds([&]{ d.changeEncryptionKey(nullptr); }));
+        d.close();
+    }
+
+    // 4) Should now open without a key:
+    {
+        cbl::Database d(encDbName, cfg);
+        Document doc = d.getDefaultCollection().getDocument("doc1");
+        REQUIRE(doc);
+        CHECK(doc["greeting"].asString() == "Howdy!");
+        d.deleteDatabase();
+    }
+}
+
+#endif // COUCHBASE_ENTERPRISE

--- a/test/DocumentTest_Cpp.cc
+++ b/test/DocumentTest_Cpp.cc
@@ -497,7 +497,7 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Document Expiration", "[Document][Expiry
 #pragma mark - Blobs:
 
 TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Blob with Collection", "[Document][Blob]") {
-    Blob blob = Blob("text/plain", "I'm Blob.");
+    Blob blob = Blob("I'm Blob.", "text/plain");
     CHECK(blob.digest() == "sha1-FKiFNQZgW201amCeRJLKJOChjAo=");
     CHECK(blob.contentType() == "text/plain");
     CHECK(blob.length() == 9);

--- a/test/DocumentTest_Cpp.cc
+++ b/test/DocumentTest_Cpp.cc
@@ -298,7 +298,7 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Save Document into Different Collection"
     
     ExpectingExceptions ex;
     CBLError error {};
-    try { otherCol.saveDocument(doc); } catch (CBLError e) { error = e; }
+    try { otherCol.saveDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
     CheckError(error, kCBLErrorInvalidParameter);
 }
 
@@ -347,7 +347,7 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Delete Non Existing Doc", "[Document]") 
     
     ExpectingExceptions x;
     CBLError error {};
-    try { defaultCollection.deleteDocument(doc); } catch (CBLError e) { error = e; }
+    try { defaultCollection.deleteDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
     CheckError(error, kCBLErrorNotFound);
 }
 
@@ -415,7 +415,7 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Delete Document into Different Collectio
     
     ExpectingExceptions ex;
     CBLError error {};
-    try { otherCol.deleteDocument(doc); } catch (CBLError e) { error = e; }
+    try { otherCol.deleteDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
     CheckError(error, kCBLErrorInvalidParameter);
 }
 
@@ -427,11 +427,11 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Purge Non Existing Doc", "[Document]") {
     ExpectingExceptions x;
     
     CBLError error {};
-    try { defaultCollection.purgeDocument(doc); } catch (CBLError e) { error = e; }
+    try { defaultCollection.purgeDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
     CheckError(error, kCBLErrorNotFound);
     
     error = {};
-    try { defaultCollection.purgeDocument("foo"); } catch (CBLError e) { error = e; }
+    try { defaultCollection.purgeDocument("foo"); } catch (const cbl::Error& e) { error = asCBLError(e); }
     CheckError(error, kCBLErrorNotFound);
 }
 
@@ -465,7 +465,7 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Purge Already Purged Document", "[Docume
     
     ExpectingExceptions ex;
     CBLError error {};
-    try { defaultCollection.purgeDocument("foo"); } catch (CBLError e) { error = e; }
+    try { defaultCollection.purgeDocument("foo"); } catch (const cbl::Error& e) { error = asCBLError(e); }
     CheckError(error, kCBLErrorNotFound);
 }
 
@@ -477,7 +477,7 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Purge Doc from Different Collection", "[
     
     ExpectingExceptions ex;
     CBLError error {};
-    try { otherCol.purgeDocument(doc); } catch (CBLError e) { error = e; }
+    try { otherCol.purgeDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
     CheckError(error, kCBLErrorInvalidParameter);
 }
 

--- a/test/DocumentTest_Cpp.cc
+++ b/test/DocumentTest_Cpp.cc
@@ -426,9 +426,9 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Purge Non Existing Doc", "[Document]") {
 
     ExpectingExceptions x;
 
-    cbl::Error error{};
-    try { defaultCollection.purgeDocument(doc); } catch (const cbl::Error& e) { error = e; }
-    CHECK(error.code == kCBLErrorNotFound);
+    CBLError error{};
+    try { defaultCollection.purgeDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
+    CheckError(error, kCBLErrorNotFound);
 
     CHECK(!defaultCollection.purgeDocument("foo"));
 }

--- a/test/DocumentTest_Cpp.cc
+++ b/test/DocumentTest_Cpp.cc
@@ -426,7 +426,10 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Purge Non Existing Doc", "[Document]") {
 
     ExpectingExceptions x;
 
-    CHECK(!defaultCollection.purgeDocument(doc));
+    cbl::Error error{};
+    try { defaultCollection.purgeDocument(doc); } catch (const cbl::Error& e) { error = e; }
+    CHECK(error.code == kCBLErrorNotFound);
+
     CHECK(!defaultCollection.purgeDocument("foo"));
 }
 

--- a/test/DocumentTest_Cpp.cc
+++ b/test/DocumentTest_Cpp.cc
@@ -412,7 +412,7 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Delete Doc with FailOnConflict", "[Docum
 
 TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Delete Document into Different Collection", "[Document]") {
     MutableDocument doc = createDocument(defaultCollection, "foo", "greeting", "Howdy");
-    
+
     ExpectingExceptions ex;
     CBLError error {};
     try { otherCol.deleteDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
@@ -423,16 +423,11 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Delete Document into Different Collectio
 
 TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Purge Non Existing Doc", "[Document]") {
     MutableDocument doc("foo");
-    
+
     ExpectingExceptions x;
-    
-    CBLError error {};
-    try { defaultCollection.purgeDocument(doc); } catch (const cbl::Error& e) { error = asCBLError(e); }
-    CheckError(error, kCBLErrorNotFound);
-    
-    error = {};
-    try { defaultCollection.purgeDocument("foo"); } catch (const cbl::Error& e) { error = asCBLError(e); }
-    CheckError(error, kCBLErrorNotFound);
+
+    CHECK(!defaultCollection.purgeDocument(doc));
+    CHECK(!defaultCollection.purgeDocument("foo"));
 }
 
 TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Purge Doc", "[Document]") {
@@ -455,18 +450,15 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Purge Doc", "[Document]") {
 
 TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Purge Already Purged Document", "[Document]") {
     createDocument(defaultCollection, "foo", "greeting", "Howdy");
-    
+
     Document doc = defaultCollection.getDocument("foo");
     REQUIRE(doc);
-    
+
     defaultCollection.purgeDocument(doc);
     doc = defaultCollection.getDocument("foo");
     CHECK(!doc);
-    
     ExpectingExceptions ex;
-    CBLError error {};
-    try { defaultCollection.purgeDocument("foo"); } catch (const cbl::Error& e) { error = asCBLError(e); }
-    CheckError(error, kCBLErrorNotFound);
+    CHECK(!defaultCollection.purgeDocument("foo"));
 }
 
 TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Purge Doc from Different Collection", "[Document]") {

--- a/test/DocumentTest_Cpp.cc
+++ b/test/DocumentTest_Cpp.cc
@@ -497,7 +497,7 @@ TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Document Expiration", "[Document][Expiry
 #pragma mark - Blobs:
 
 TEST_CASE_METHOD(DocumentTest_Cpp, "C++ Blob with Collection", "[Document][Blob]") {
-    Blob blob = Blob("I'm Blob.", "text/plain");
+    Blob blob = Blob("text/plain", "I'm Blob.");
     CHECK(blob.digest() == "sha1-FKiFNQZgW201amCeRJLKJOChjAo=");
     CHECK(blob.contentType() == "text/plain");
     CHECK(blob.length() == 9);

--- a/test/EncryptableTest_Cpp.cc
+++ b/test/EncryptableTest_Cpp.cc
@@ -1,0 +1,141 @@
+//
+// EncryptableTest_Cpp.cc
+//
+// Copyright (c) 2026 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "CBLTest_Cpp.hh"
+#include "fleece/Fleece.hh"
+#include "fleece/Mutable.hh"
+#include <string>
+
+#include "cbl++/CouchbaseLite.hh"
+
+#ifdef COUCHBASE_ENTERPRISE
+
+using namespace std;
+using namespace fleece;
+using namespace cbl;
+
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Encryptable factories", "[Encryptable]") {
+    string expectedJSON;
+    Encryptable enc = Encryptable::createWithNull();   // placeholder; overwritten in sections
+
+    SECTION("Null") {
+        enc = Encryptable::createWithNull();
+        CHECK(enc.value().type() == kFLNull);
+        expectedJSON = "{\"@type\":\"encryptable\",\"value\":null}";
+    }
+    SECTION("Bool") {
+        enc = Encryptable::createWithBool(true);
+        CHECK(enc.value().asBool() == true);
+        expectedJSON = "{\"@type\":\"encryptable\",\"value\":true}";
+    }
+    SECTION("Int") {
+        enc = Encryptable::createWithInt(256);
+        CHECK(enc.value().asInt() == 256);
+        expectedJSON = "{\"@type\":\"encryptable\",\"value\":256}";
+    }
+    SECTION("UInt") {
+        enc = Encryptable::createWithUInt(1024);
+        CHECK(enc.value().asUnsigned() == 1024);
+        expectedJSON = "{\"@type\":\"encryptable\",\"value\":1024}";
+    }
+    SECTION("Float") {
+        enc = Encryptable::createWithFloat(35.57f);
+        CHECK(enc.value().asFloat() == 35.57f);
+        expectedJSON = "{\"@type\":\"encryptable\",\"value\":35.57}";
+    }
+    SECTION("Double") {
+        enc = Encryptable::createWithDouble(35.61);
+        CHECK(enc.value().asDouble() == 35.61);
+        expectedJSON = "{\"@type\":\"encryptable\",\"value\":35.61}";
+    }
+    SECTION("String via constructor (string_view)") {
+        enc = Encryptable{"hello world"};
+        CHECK(enc.value().asString() == "hello world"_sl);
+        expectedJSON = "{\"@type\":\"encryptable\",\"value\":\"hello world\"}";
+    }
+    SECTION("Dict via Value constructor") {
+        auto d = MutableDict::newDict();
+        d["greeting"] = "hello";
+        enc = Encryptable{Value(d)};
+        CHECK(enc.value().asDict().toJSONString() == "{\"greeting\":\"hello\"}");
+        expectedJSON = "{\"@type\":\"encryptable\",\"value\":{\"greeting\":\"hello\"}}";
+    }
+
+    CHECK(enc.properties().toJSON(false, true).asString() == expectedJSON);
+    CHECK(Encryptable::isEncryptableValue(enc.properties()));
+}
+
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Encryptable isEncryptableValue rejects plain dict", "[Encryptable]") {
+    auto plain = MutableDict::newDict();
+    plain["foo"] = "bar";
+    CHECK(!Encryptable::isEncryptableValue(plain));
+    CHECK(!Encryptable::isEncryptableValue(Dict()));
+}
+
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Encryptable getEncryptableValue round-trip", "[Encryptable]") {
+    // Save a document containing an encryptable.
+    {
+        MutableDocument doc("enc-doc");
+        Encryptable enc{"secret-value"};
+        FLMutableDict_SetEncryptableValue(doc.properties(), "secret"_sl, enc.ref());
+        defaultCollection.saveDocument(doc);
+    }
+
+    // Read it back; extract the encryptable; let the wrapper go out of scope
+    // BEFORE the document. A refcount imbalance in getEncryptableValue would
+    // surface as a leak or use-after-free that ~CBLTest_Cpp's
+    // CBL_InstanceCount() == 0 check would flag.
+    Document doc = defaultCollection.getDocument("enc-doc");
+    REQUIRE(doc);
+    Value v = doc["secret"];
+    REQUIRE(FLValue_IsEncryptableValue(v));
+    {
+        Encryptable got = Encryptable::getEncryptableValue(v);
+        REQUIRE(got);
+        CHECK(got.value().asString() == "secret-value"_sl);
+    }
+    // `got` destroyed here; `doc` destroyed at end of test.
+}
+
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Encryptable getEncryptableValue on non-encryptable",
+                 "[Encryptable]") {
+    // FLValue_GetEncryptableValue returns null for a plain (non-encryptable) dict,
+    // and the wrapper should turn that into a falsy Encryptable without crashing.
+    auto plain = MutableDict::newDict();
+    plain["foo"] = "bar";
+    Encryptable got = Encryptable::getEncryptableValue(Value(plain));
+    CHECK(!got);
+}
+
+
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Encryptable embedded in mutable dict", "[Encryptable]") {
+    Encryptable enc{"secret-value"};
+
+    auto dict = MutableDict::newDict();
+    FLSlot_SetEncryptableValue(FLMutableDict_Set(dict, "encryptable"_sl), enc.ref());
+
+    Value v = dict["encryptable"];
+    CHECK(FLValue_IsEncryptableValue(v));
+    CHECK(FLValue_AsDict(v) == (FLDict)enc.properties());
+}
+
+#endif // COUCHBASE_ENTERPRISE

--- a/test/LogTest_Cpp.cc
+++ b/test/LogTest_Cpp.cc
@@ -29,12 +29,12 @@ public:
     }
     
     ~LogTest_Cpp() {
-        LogSinks::setFile({ kCBLLogNone, kFLSliceNull });
-        LogSinks::setCustom({ kCBLLogNone });
+        LogSinks::setFile({ LogLevel(kCBLLogNone) });
+        LogSinks::setCustom({});
         LogSinks::setConsole(_backupConsoleLogSink);
     }
 private:
-    CBLConsoleLogSink _backupConsoleLogSink;
+    ConsoleLogSink _backupConsoleLogSink;
 };
 
 TEST_CASE_METHOD(LogTest_Cpp, "Default Log Sink Cpp", "[Log]") {
@@ -47,13 +47,13 @@ TEST_CASE_METHOD(LogTest_Cpp, "Default Log Sink Cpp", "[Log]") {
     CHECK(custom.domains == 0);
     CHECK(custom.callback == nullptr);
     
-    CBLFileLogSink logSink = LogSinks::file();
-    CHECK(logSink.level == kCBLLogNone);
-    CHECK(logSink.directory == kFLSliceNull);
+    FileLogSink logSink = LogSinks::file();
+    CHECK(logSink.level == LogLevel::None);
+    CHECK(logSink.directory.empty());
 }
 
 TEST_CASE_METHOD(LogTest_Cpp, "Console Log Sink Cpp: Set and Get", "[Log]") {
-    LogSinks::setConsole({ kCBLLogVerbose, kCBLLogDomainMaskAll });
+    LogSinks::setConsole({LogLevel::Verbose, kCBLLogDomainMaskAll});
     CBLConsoleLogSink logSink = LogSinks::console();
     CHECK(logSink.level == kCBLLogVerbose);
     CHECK(logSink.domains == kCBLLogDomainMaskAll);
@@ -61,7 +61,7 @@ TEST_CASE_METHOD(LogTest_Cpp, "Console Log Sink Cpp: Set and Get", "[Log]") {
 
 TEST_CASE_METHOD(LogTest_Cpp, "Custom Log Sink Cpp: Set and Get", "[Log]") {
     CBLLogSinkCallback callback = [](CBLLogDomain domain, CBLLogLevel level, FLString msg) { };
-    LogSinks::setCustom({ kCBLLogVerbose, callback, kCBLLogDomainMaskAll});
+    LogSinks::setCustom({ LogLevel::Verbose, callback, kCBLLogDomainMaskAll});
     CBLCustomLogSink logSink = LogSinks::custom();
     CHECK(logSink.level == kCBLLogVerbose);
     CHECK(logSink.domains == kCBLLogDomainMaskAll);

--- a/test/LogTest_Cpp.cc
+++ b/test/LogTest_Cpp.cc
@@ -29,7 +29,7 @@ public:
     }
     
     ~LogTest_Cpp() {
-        LogSinks::setFile({ LogLevel(kCBLLogNone) });
+        LogSinks::setFile({});
         LogSinks::setCustom({});
         LogSinks::setConsole(_backupConsoleLogSink);
     }
@@ -48,12 +48,12 @@ TEST_CASE_METHOD(LogTest_Cpp, "Default Log Sink Cpp", "[Log]") {
     CHECK(custom.callback == nullptr);
     
     FileLogSink logSink = LogSinks::file();
-    CHECK(logSink.level == LogLevel::None);
+    CHECK(logSink.level == kCBLLogNone);
     CHECK(logSink.directory.empty());
 }
 
 TEST_CASE_METHOD(LogTest_Cpp, "Console Log Sink Cpp: Set and Get", "[Log]") {
-    LogSinks::setConsole({LogLevel::Verbose, kCBLLogDomainMaskAll});
+    LogSinks::setConsole({kCBLLogVerbose, kCBLLogDomainMaskAll});
     CBLConsoleLogSink logSink = LogSinks::console();
     CHECK(logSink.level == kCBLLogVerbose);
     CHECK(logSink.domains == kCBLLogDomainMaskAll);
@@ -61,7 +61,7 @@ TEST_CASE_METHOD(LogTest_Cpp, "Console Log Sink Cpp: Set and Get", "[Log]") {
 
 TEST_CASE_METHOD(LogTest_Cpp, "Custom Log Sink Cpp: Set and Get", "[Log]") {
     CBLLogSinkCallback callback = [](CBLLogDomain domain, CBLLogLevel level, FLString msg) { };
-    LogSinks::setCustom({ LogLevel::Verbose, callback, kCBLLogDomainMaskAll});
+    LogSinks::setCustom({ kCBLLogVerbose, callback, kCBLLogDomainMaskAll});
     CBLCustomLogSink logSink = LogSinks::custom();
     CHECK(logSink.level == kCBLLogVerbose);
     CHECK(logSink.domains == kCBLLogDomainMaskAll);

--- a/test/ReplicatorCollectionTest_Cpp.cc
+++ b/test/ReplicatorCollectionTest_Cpp.cc
@@ -195,7 +195,7 @@ TEST_CASE_METHOD(ReplicatorCollectionTest_Cpp, "C++ Create Replicator with zero 
     
     ExpectingExceptions x;
     CBLError error {};
-    try { auto r = Replicator(config); } catch (CBLError e) { error = e; }
+    try { auto r = Replicator(config); } catch (const cbl::Error& e) { error = asCBLError(e); }
     CheckError(error, kCBLErrorInvalidParameter);
 }
 

--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -367,7 +367,7 @@ public:
             defaultCollection.deleteDocument(doc);
         } else {
             doc["expletive"] = "Shazbatt!";
-            auto blob = Blob("text/plain"_sl, "Blob!"_sl);
+            auto blob = Blob("Blob!"_sl, "text/plain"_sl);
             doc["signature"] = blob.properties();
             defaultCollection.saveDocument(doc);
             expectedLocalRevID = doc.revisionID();
@@ -380,7 +380,7 @@ public:
             otherDBDefaultCol.deleteDocument(doc);
         } else {
             doc["expletive"] = "Frak!";
-            auto blob = Blob("text/plain"_sl, "Pop!"_sl);
+            auto blob = Blob("Pop!"_sl, "text/plain"_sl);
             doc["signature"] = blob.properties();
             otherDBDefaultCol.saveDocument(doc);
             expectedRemoteRevID = CBLDocument_CanonicalRevisionID(doc.ref());

--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -367,7 +367,7 @@ public:
             defaultCollection.deleteDocument(doc);
         } else {
             doc["expletive"] = "Shazbatt!";
-            auto blob = Blob("Blob!"_sl, "text/plain"_sl);
+            auto blob = Blob("text/plain"_sl, "Blob!"_sl);
             doc["signature"] = blob.properties();
             defaultCollection.saveDocument(doc);
             expectedLocalRevID = doc.revisionID();
@@ -380,7 +380,7 @@ public:
             otherDBDefaultCol.deleteDocument(doc);
         } else {
             doc["expletive"] = "Frak!";
-            auto blob = Blob("Pop!"_sl, "text/plain"_sl);
+            auto blob = Blob("text/plain"_sl, "Pop!"_sl);
             doc["signature"] = blob.properties();
             otherDBDefaultCol.saveDocument(doc);
             expectedRemoteRevID = CBLDocument_CanonicalRevisionID(doc.ref());

--- a/test/VectorSearchTest_Cpp.cc
+++ b/test/VectorSearchTest_Cpp.cc
@@ -43,12 +43,12 @@ public:
     
     Database _wordDB;
     Collection _wordsColl;
-    
-    class WordPredictiveModel : public PredictiveModel {
+
+    class WordPredictiveModel {
     public:
         WordPredictiveModel(VectorSearchTest* test) : _test(test) { }
-        
-        fleece::MutableDict prediction(fleece::Dict input) noexcept {
+
+        fleece::MutableDict operator()(fleece::Dict input) noexcept {
             auto word = input["word"].asString();
             if (!word) return MutableDict(nullptr);
             
@@ -62,11 +62,11 @@ public:
     private:
         VectorSearchTest* _test {};
     };
-    
+
     void registerPredictiveModel() {
-        Prediction::registerModel(kPredictiveModelCppName, make_unique<WordPredictiveModel>(this));
+        Prediction::registerModel(kPredictiveModelCppName, WordPredictiveModel(this));
     }
-    
+
     void unregisterPredictiveModel() {
         Prediction::unregisterModel(kPredictiveModelCppName);
     }

--- a/test/cmake/test_source_files.cmake
+++ b/test/cmake/test_source_files.cmake
@@ -24,6 +24,7 @@ function(set_test_source_files)
         ${T_DIR}/DatabaseTest_Cpp.cc
         ${T_DIR}/DocumentTest.cc
         ${T_DIR}/DocumentTest_Cpp.cc
+        ${T_DIR}/EncryptableTest_Cpp.cc
         ${T_DIR}/LogTest.cc
         ${T_DIR}/LogTest_Cpp.cc
         ${T_DIR}/PerfTest.cc


### PR DESCRIPTION
CBL-8263: Unit tests of class Encryptable in the C++ API suite
CBL-8328: Error handling in Lite-C/C++ APIs

1. Add new Encryptable class to the C++ API.
2. Fill in methods missing from Blob and Database relative to the C API,
3. Report errors by throwing exceptions instead of via out-parameters, matching idiomatic C++ usage.
4. Complete the unit tests for the above.