### PR TITLE
Remove kCBLDefaultDatabaseMmapDisabled

### DIFF
--- a/include/cbl/CBLDefaults.h
+++ b/include/cbl/CBLDefaults.h
@@ -41,9 +41,6 @@ CBL_CAPI_BEGIN
 /** [false] Full sync is off by default because the performance hit is seldom worth the benefit */
 CBL_PUBLIC extern const bool kCBLDefaultDatabaseFullSync;
 
-/** [false] Memory mapped database files are enabled by default */
-CBL_PUBLIC extern const bool kCBLDefaultDatabaseMmapDisabled;
-
 /** @} */
 
 /** \name CBLLogFileConfiguration

--- a/src/CBLDefaults_CAPI.cc
+++ b/src/CBLDefaults_CAPI.cc
@@ -27,7 +27,6 @@
 #pragma mark - CBLDatabaseConfiguration
 
 CBL_PUBLIC const bool kCBLDefaultDatabaseFullSync = false;
-CBL_PUBLIC const bool kCBLDefaultDatabaseMmapDisabled = false;
 
 #pragma mark - CBLLogFileConfiguration
 

--- a/src/exports/CBLDefaults_Exports.txt
+++ b/src/exports/CBLDefaults_Exports.txt
@@ -23,7 +23,6 @@
 ### CBLDatabaseConfiguration
 
 kCBLDefaultDatabaseFullSync
-kCBLDefaultDatabaseMmapDisabled
 
 ### CBLLogFileConfiguration
 

--- a/src/exports/generated/CBL.def
+++ b/src/exports/generated/CBL.def
@@ -166,7 +166,6 @@ CBLLog_Reset
 CBLLog_LogWithC4Log
 CBL_DeleteDirectoryRecursive
 kCBLDefaultDatabaseFullSync
-kCBLDefaultDatabaseMmapDisabled
 kCBLDefaultLogFileUsePlaintext
 kCBLDefaultLogFileMaxSize
 kCBLDefaultLogFileMaxRotateCount

--- a/src/exports/generated/CBL.exp
+++ b/src/exports/generated/CBL.exp
@@ -174,7 +174,6 @@ _CBLLog_Reset
 _CBLLog_LogWithC4Log
 _CBL_DeleteDirectoryRecursive
 _kCBLDefaultDatabaseFullSync
-_kCBLDefaultDatabaseMmapDisabled
 _kCBLDefaultLogFileUsePlaintext
 _kCBLDefaultLogFileMaxSize
 _kCBLDefaultLogFileMaxRotateCount

--- a/src/exports/generated/CBL.gnu
+++ b/src/exports/generated/CBL.gnu
@@ -164,7 +164,6 @@ CBL_C {
 		CBLLog_LogWithC4Log;
 		CBL_DeleteDirectoryRecursive;
 		kCBLDefaultDatabaseFullSync;
-		kCBLDefaultDatabaseMmapDisabled;
 		kCBLDefaultLogFileUsePlaintext;
 		kCBLDefaultLogFileMaxSize;
 		kCBLDefaultLogFileMaxRotateCount;

--- a/src/exports/generated/CBL_Android.gnu
+++ b/src/exports/generated/CBL_Android.gnu
@@ -165,7 +165,6 @@ CBL_C {
 		CBLLog_LogWithC4Log;
 		CBL_DeleteDirectoryRecursive;
 		kCBLDefaultDatabaseFullSync;
-		kCBLDefaultDatabaseMmapDisabled;
 		kCBLDefaultLogFileUsePlaintext;
 		kCBLDefaultLogFileMaxSize;
 		kCBLDefaultLogFileMaxRotateCount;

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -260,7 +260,6 @@ CBLLog_Reset
 CBLLog_LogWithC4Log
 CBL_DeleteDirectoryRecursive
 kCBLDefaultDatabaseFullSync
-kCBLDefaultDatabaseMmapDisabled
 kCBLDefaultLogFileUsePlaintext
 kCBLDefaultLogFileMaxSize
 kCBLDefaultLogFileMaxRotateCount

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -269,7 +269,6 @@ _CBLLog_Reset
 _CBLLog_LogWithC4Log
 _CBL_DeleteDirectoryRecursive
 _kCBLDefaultDatabaseFullSync
-_kCBLDefaultDatabaseMmapDisabled
 _kCBLDefaultLogFileUsePlaintext
 _kCBLDefaultLogFileMaxSize
 _kCBLDefaultLogFileMaxRotateCount

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -255,7 +255,6 @@ CBL_C {
 		CBLLog_LogWithC4Log;
 		CBL_DeleteDirectoryRecursive;
 		kCBLDefaultDatabaseFullSync;
-		kCBLDefaultDatabaseMmapDisabled;
 		kCBLDefaultLogFileUsePlaintext;
 		kCBLDefaultLogFileMaxSize;
 		kCBLDefaultLogFileMaxRotateCount;

--- a/src/exports/generated/CBL_EE_Android.gnu
+++ b/src/exports/generated/CBL_EE_Android.gnu
@@ -256,7 +256,6 @@ CBL_C {
 		CBLLog_LogWithC4Log;
 		CBL_DeleteDirectoryRecursive;
 		kCBLDefaultDatabaseFullSync;
-		kCBLDefaultDatabaseMmapDisabled;
 		kCBLDefaultLogFileUsePlaintext;
 		kCBLDefaultLogFileMaxSize;
 		kCBLDefaultLogFileMaxRotateCount;


### PR DESCRIPTION
* Ported from 4.1 branch.
* We have removed the API for disabling the mmap in 4.0 but the constant variable is left over.