### PR TITLE
Remove fatal exception backtrace initializer and Backtrace.cc test dependency

### DIFF
--- a/src/Internal.cc
+++ b/src/Internal.cc
@@ -31,14 +31,6 @@ using namespace fleece;
 
 namespace cbl_internal {
 
-    // Initializer that is called once when the library (sCBLInitializer) is loaded:
-    struct CBLInitializer {
-    public:
-        CBLInitializer () {
-            c4log_enableFatalExceptionBacktrace();
-        }
-    } sCBLInitializer;
-
     void BridgeException(const char *fnName, CBLError *outError) noexcept {
         C4Error error = C4Error::fromCurrentException();
         if (outError)

--- a/test/cmake/test_source_files.cmake
+++ b/test/cmake/test_source_files.cmake
@@ -40,7 +40,6 @@ function(set_test_source_files)
         ${T_DIR}/VectorSearchTest.cc
         ${T_DIR}/VectorSearchTest_Cpp.cc
         ${T_DIR}/LazyVectorIndexTest.cc
-        ${T_DIR}/../vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/Backtrace.cc
         ${T_DIR}/../vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/LibC++Debug.cc
         ${T_DIR}/../vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/betterassert.cc
         PARENT_SCOPE


### PR DESCRIPTION
* Ported this change from 4.1 branch.

* Removed the static CBLInitializer in Internal.cc that enabled fatal exception backtraces via c4log_enableFatalExceptionBacktrace() as the backtrace is now enabled by default.

* Removed Backtrace.cc link from the test source files as it’s not needed.