### PR TITLE
CBL-8348: Add C++ Doxyfile and improve C/C++ main and topic pages

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -192,7 +192,8 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = include
+STRIP_FROM_INC_PATH    = include \
+                         vendor/couchbase-lite-core/vendor/fleece/API
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't

--- a/Doxyfile_C++
+++ b/Doxyfile_C++
@@ -1,0 +1,43 @@
+# Doxyfile for the Couchbase Lite C++ API (include/cbl++).
+#
+# Inherits all settings from the C Doxyfile via @INCLUDE, then overrides only what
+# the header-only C++ wrapper needs. Run from the repo root, AFTER `doxygen`:
+#
+#     doxygen              # C   API -> docs/C/html
+#     doxygen Doxyfile_C++ # C++ API -> docs/C++/html
+
+@INCLUDE = Doxyfile
+
+PROJECT_NAME           = "Couchbase Lite C++"
+PROJECT_BRIEF          = "Couchbase Lite C++ API"
+OUTPUT_DIRECTORY       = docs/C++/
+
+# Document only the inline C++ wrapper headers.
+INPUT                  = include/cbl++
+FILE_PATTERNS          = *.hh
+
+# C++ output: turn off the C-tailored mode so classes/namespaces render properly.
+OPTIMIZE_OUTPUT_FOR_C  = NO
+
+# Expand the ref-counting boilerplate macros so the generated members
+# (constructors, ref(), operator bool, ==) appear in the docs.
+EXPAND_AS_DEFINED     += CBL_REFCOUNTED_BOILERPLATE \
+                         CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE
+
+# Required for EXPAND_AS_DEFINED above to take effect: the cbl++ headers include
+# the macros' definitions as "cbl++/Base.hh", a path the preprocessor can only
+# resolve relative to include/. Without this, the macros silently never expand.
+INCLUDE_PATH           = include
+
+# Implementation details that are not part of the public API.
+EXCLUDE_SYMBOLS        = cbl::RefCounted \
+                         cbl::internal
+
+# The cbl++ headers pull these annotation macros from cbl/ (not in INPUT here);
+# left undefined, they leak verbatim into rendered signatures. _cbl_nullable is
+# rendered as clang's _Nullable so the docs convey nullability; the rest are
+# blanked out.
+PREDEFINED            += _cbl_nullable=_Nullable \
+                         CBL_ASSUME_NONNULL_BEGIN= \
+                         CBL_ASSUME_NONNULL_END= \
+                         _cbl_warn_unused=

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -52,7 +52,9 @@ namespace cbl {
 
     using QueryLanguage = CBLQueryLanguage;
 
-    // Artificial base class of the C++ wrapper classes; just manages ref-counting.
+    // Internal base class of the C++ wrapper classes; it holds the reference to the
+    // underlying ref-counted C object and manages retain/release for it.
+    // Not part of the public API, and excluded from the API docs.
     class RefCounted {
     protected:
         RefCounted() noexcept                            :_ref(nullptr) { }
@@ -133,25 +135,38 @@ namespace cbl {
         }
     }
 
-// Internal use only: Copy/move ctors and assignment ops that have to be declared in subclasses
+// For use by the cbl++ headers only: generates the public boilerplate members (ctors,
+// assignment ops, comparisons, ref()) that each wrapper class must declare itself.
 #define CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE(CLASS, SUPER, C_TYPE) \
 public: \
+    /** Constructs a null reference (one that points to no object). */ \
     CLASS() noexcept                              :SUPER() { } \
+    /** Releases the underlying object and resets this to a null reference. */ \
     CLASS& operator=(std::nullptr_t)              {clear(); return *this;} \
+    /** Returns true if this references an object, or false if it is a null reference. */ \
     bool valid() const                            {return RefCounted::valid();} \
+    /** Returns true if this references an object (same as \ref valid). */ \
     explicit operator bool() const                {return valid();} \
+    /** Returns true if both sides reference the same object, or are both null references. */ \
     bool operator==(const CLASS &other) const     {return _ref == other._ref;} \
+    /** Returns true if the two sides reference different objects. */ \
     bool operator!=(const CLASS &other) const     {return _ref != other._ref;} \
+    /** Returns a pointer to the underlying C object (C_TYPE), or NULL if this is a null reference. */ \
     C_TYPE* _cbl_nullable ref() const             {return (C_TYPE*)_ref;}\
 protected: \
+    /** (Internal) Constructs a reference wrapping, and retaining, a C object pointer. */ \
     explicit CLASS(C_TYPE* _cbl_nullable ref)     :SUPER((CBLRefCounted*)ref) { }
 
 #define CBL_REFCOUNTED_BOILERPLATE(CLASS, SUPER, C_TYPE) \
 CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE(CLASS, SUPER, C_TYPE) \
 public: \
+    /** Copy constructor: creates another reference to the same object as \p other. */ \
     CLASS(const CLASS &other) noexcept            :SUPER(other) { } \
+    /** Move constructor: takes over the reference from \p other, leaving it a null reference. */ \
     CLASS(CLASS &&other) noexcept                 :SUPER((SUPER&&)other) { } \
+    /** Copy assignment: replaces this reference with a reference to \p other's object. */ \
     CLASS& operator=(const CLASS &other) noexcept {SUPER::operator=(other); return *this;} \
+    /** Move assignment: replaces this reference with \p other's, leaving \p other a null reference. */ \
     CLASS& operator=(CLASS &&other) noexcept      {SUPER::operator=((SUPER&&)other); return *this;}
 
     /** A token representing a registered listener; instances are returned from the various

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -121,7 +121,7 @@ namespace cbl {
         Blob(CBLBlob* cObj, adopt_t) { _ref = (CBLRefCounted*)cObj; }
     };
 
-    /** A stream for writing a new blob to the database. */
+    /** A stream for reading a blob's content from the database. */
     class BlobReadStream {
     public:
         /** Alias for the C \ref CBLSeekBase enum describing the reference point used by \ref seek. */

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -40,7 +40,8 @@ namespace cbl {
     /** Conflict handler used when saving a document. */
     using CollectionConflictHandler  = std::function<bool(MutableDocument documentBeingSaved,
                                                           Document conflictingDocument)>;
-    /** Value Index Configuration. */
+    /** Configuration for creating a value index, which indexes the values of one or more
+        document properties. */
     struct ValueIndexConfiguration {
         /** The language used in the expressions (Required). */
         QueryLanguage expressionLanguage;
@@ -56,7 +57,7 @@ namespace cbl {
         std::string where;
     };
 
-    /** Full-Text Index Configuration. */
+    /** Configuration for creating a full-text index, which enables full-text search in queries. */
     struct FullTextIndexConfiguration {
         /** The language used in the expressions (Required). */
         QueryLanguage expressionLanguage;
@@ -111,7 +112,7 @@ namespace cbl {
     };
 
     /**
-     A Collection class represent a collection which is a container for documents.
+     A Collection is a container for documents within a database.
      A collection can be thought as a table in the relational database. Each collection belongs to
      a scope which is simply a namespce, and has a name which is unique within its scope.
      
@@ -297,11 +298,10 @@ namespace cbl {
         }
 
 #ifdef COUCHBASE_ENTERPRISE
-        /** ENTERPRISE EDITION ONLY
-         
-            Creatres a vector index in the collection.
+        /** Creates a vector index in the collection.
             If an identical index with that name already exists, nothing happens (and no error is returned.)
             If a non-identical index with that name already exists, it is deleted and re-created.
+            \note ENTERPRISE EDITION ONLY
             @param name  The index name.
             @param config  The vector index config. */
         inline void createVectorIndex(std::string_view name, VectorIndexConfiguration config);

--- a/include/cbl++/CouchbaseLite.hh
+++ b/include/cbl++/CouchbaseLite.hh
@@ -17,10 +17,66 @@
 //
 
 
-/** \defgroup cbl_cpp Couchbase Lite C++ API
-    @{
+/** \mainpage Couchbase Lite C++ API
 
-    \section error_handling Error handling
+    A header-only C++ wrapper API around the Couchbase Lite C API, providing ref-counted
+    C++ classes for the Couchbase Lite objects with automatic memory management, and
+    exceptions for error handling.
+
+    \section getting_started Getting Started
+
+    Include `cbl++/CouchbaseLite.hh` (or the individual `cbl++` headers). All classes
+    live in the \ref cbl namespace and are listed in the
+    <a href="annotated.html">class list</a>; the main ones are \ref cbl::Database,
+    \ref cbl::Collection, \ref cbl::MutableDocument, \ref cbl::Query, and
+    \ref cbl::Replicator.
+
+    \code{.cpp}
+    #include "cbl++/CouchbaseLite.hh"
+
+    cbl::Database db("mydb");
+    cbl::Collection collection = db.getDefaultCollection();
+
+    cbl::MutableDocument doc("doc1");
+    doc["greeting"] = "Hello, World!";
+    collection.saveDocument(doc);
+    \endcode
+
+    \section object_model Object Model
+
+    The wrapper classes are thin smart references to the underlying ref-counted
+    Couchbase Lite objects, behaving much like `std::shared_ptr`: copying a
+    wrapper creates another reference to the same object, not a copy of the
+    object, and the object is freed when its last reference goes away.
+
+    A default-constructed wrapper is a null reference that points to no object;
+    test it with `operator bool()` or with `valid()`. This documentation calls such
+    objects *falsy*: functions like \ref cbl::Collection::getDocument return a
+    falsy object instead of throwing when the requested item doesn't exist.
+
+    Use `ref()` to access the underlying C object when mixing in C API calls.
+
+    \section document_data Document Data
+
+    Document properties are stored as Fleece values: \ref cbl::Document::properties
+    returns a `fleece::Dict`, \ref cbl::MutableDocument::properties returns a
+    `fleece::MutableDict`, and individual property values are accessed as
+    `fleece::Value`.
+
+    Strings and binary data are passed as `fleece::slice` and `fleece::alloc_slice`,
+    which are constructible from `std::string`, `std::string_view`, and C strings.
+    The difference between them is ownership: a `slice` is a non-owning view of a
+    byte range and must not outlive the data it points to, while an `alloc_slice`
+    owns a reference-counted buffer that keeps its data alive. To keep string data
+    around, store it as an `alloc_slice` or convert it with `asString()`. The `cbl`
+    namespace declares \ref cbl::slice and \ref cbl::alloc_slice as convenience
+    aliases for these two types.
+
+    The `fleece` classes are declared in the `fleece/Fleece.hh`, `fleece/Mutable.hh`,
+    and `fleece/slice.hh` headers shipped with Couchbase Lite. They are thin wrappers
+    around the Fleece C API, which is documented in the Couchbase Lite C API Reference.
+
+    \section error_handling Error Handling
 
     Functions in the Couchbase Lite C++ API report Couchbase Lite-specific failures by
     throwing \ref cbl::Error, a subclass of `std::runtime_error` that provides the error
@@ -31,8 +87,7 @@
 
     `noexcept` marks functions that are guaranteed not to throw. All other functions
     should be treated as potentially throwing on failure, unless otherwise documented.
-
-    @} */
+*/
 
 #pragma once
 #include "Blob.hh"

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -50,9 +50,8 @@ namespace cbl {
 
     
 #ifdef COUCHBASE_ENTERPRISE
-    /** ENTERPRISE EDITION ONLY
-     
-        Couchbase Lite  Extension. */
+    /** Manages Couchbase Lite extensions, such as the Vector Search extension.
+        \note ENTERPRISE EDITION ONLY */
     class Extension {
     public:
         /** Enables Vector Search extension by specifying the extension path to search for the Vector Search extension library.
@@ -70,10 +69,9 @@ namespace cbl {
     /** Alias for the C \ref CBLEncryptionKeySize enum giving the required key size for an algorithm. */
     using EncryptionKeySize   = CBLEncryptionKeySize;
 
-    /** ENTERPRISE EDITION ONLY
-
-        A database encryption key, used in \ref DatabaseConfiguration to open or create an
-        encrypted database. */
+    /** A database encryption key, used in \ref DatabaseConfiguration to open or create an
+        encrypted database.
+        \note ENTERPRISE EDITION ONLY */
     class EncryptionKey : public CBLEncryptionKey {
     public:
         /** Creates an empty key (algorithm \ref kCBLEncryptionNone, i.e. no encryption). */
@@ -145,7 +143,7 @@ namespace cbl {
         }
     };
 
-    /** Couchbase Lite Database. */
+    /** A Couchbase Lite database, which is a container for collections of documents. */
     class Database : private RefCounted {
     public:
         // Static database-file operations:

--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -29,7 +29,7 @@ CBL_ASSUME_NONNULL_BEGIN
 namespace cbl {
     class MutableDocument;
 
-    /** Immutable Document. */
+    /** An immutable, in-memory copy of a document read from a collection. */
     class Document : protected RefCounted {
     public:
         // Metadata:
@@ -97,7 +97,7 @@ namespace cbl {
     };
 
 
-    /** Mutable Document. */
+    /** A mutable document, whose properties can be modified and saved to a collection. */
     class MutableDocument : public Document {
     public:
         /** Creates a new, empty document in memory, with a randomly-generated unique ID.

--- a/include/cbl++/Encryptable.hh
+++ b/include/cbl++/Encryptable.hh
@@ -34,7 +34,8 @@ namespace cbl {
         An Encryptable wraps a value (null, bool, number, string, array, dict) that should
         be encrypted by the push replicator and decrypted by the pull replicator. Its
         persistent form is a special dictionary in the document properties; construct an
-        Encryptable from such a dictionary via Encryptable::getEncryptableValue. */
+        Encryptable from such a dictionary via Encryptable::getEncryptableValue.
+        \note ENTERPRISE EDITION ONLY */
     class Encryptable : protected RefCounted {
     public:
     /** Creates an Encryptable wrapping an arbitrary Fleece value.

--- a/include/cbl++/Prediction.hh
+++ b/include/cbl++/Prediction.hh
@@ -28,20 +28,17 @@
 CBL_ASSUME_NONNULL_BEGIN
 
 namespace cbl {
-    /** ENTERPRISE EDITION ONLY
-     
-        The PredictiveModel  that allows to integrate machine learning model
-        into queries via invoking query's PREDICTION() function.
-     
-        @note The predictive index feature is not supported by Couchbase Lite for C.
+    /** A predictive model callable that integrates a machine learning model into queries,
+        invoked via the query's PREDICTION() function. Given an input dictionary, return the
+        output dictionary.
+        \note ENTERPRISE EDITION ONLY
+        \note The predictive index feature is not supported by Couchbase Lite for C.
               The Predictive Model is currently for creating vector indexes using the PREDICTION() function,
               which will call the specified predictive model for computing the vectors. */
-
-    /** A predictive model callable, invoked by queries via the PREDICTION() function.
-        Given an input dictionary, return the output dictionary. */
     using PredictiveModel = std::function<fleece::MutableDict(fleece::Dict)>;
 
-    /** Registers/unregisters predictive models by name. */
+    /** Registers/unregisters predictive models by name.
+        \note ENTERPRISE EDITION ONLY */
     class Prediction {
     public:
         /** Registers a predictive model with the given name.

--- a/include/cbl++/QueryIndex.hh
+++ b/include/cbl++/QueryIndex.hh
@@ -29,7 +29,7 @@ namespace cbl {
     class IndexUpdater;
 #endif
 
-    /** QueryIndex object representing an existing index in the collection. */
+    /** Represents an existing index in a collection. */
     class QueryIndex : private RefCounted {
     public:
         // Accessors:
@@ -43,10 +43,9 @@ namespace cbl {
 #ifdef COUCHBASE_ENTERPRISE
         // Index Updater:
         
-        /** ENTERPRISE EDITION ONLY
-         
-            Finds new or updated documents for which vectors need to be (re)computed and returns an \ref IndexUpdater object
+        /** Finds new or updated documents for which vectors need to be (re)computed and returns an \ref IndexUpdater object
             for setting the computed vectors to update the index. If the index is not lazy, an error will be returned.
+            \note ENTERPRISE EDITION ONLY
             @note For updating lazy vector indexes only.
             @param limit The maximum number of vectors to be computed.
             @return An \ref IndexUpdater object for setting the computed vectors to update the index,
@@ -70,10 +69,10 @@ namespace cbl {
 
 #ifdef COUCHBASE_ENTERPRISE
 
-    /** ENTERPRISE EDITION ONLY
-     
-        IndexUpdater is used for updating the index in lazy mode. Currently, the vector index is the only index type
-        that can be updated lazily. */
+    /** Updates a lazy index by setting the computed vectors for the documents returned from
+        \ref QueryIndex::beginUpdate. Currently, the vector index is the only index type that
+        can be updated lazily.
+        \note ENTERPRISE EDITION ONLY */
     class IndexUpdater : private RefCounted {
     public:
         /** The total number of vectors to compute and set for updating the index. */

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -114,7 +114,8 @@ namespace cbl {
                                                     const Document localDoc,
                                                     const Document remoteDoc)>;
 
-    /** The collection and the configuration that can be configured specifically for the replication. */
+    /** A collection to replicate, along with its collection-specific replication settings
+        such as filters and a conflict resolver. */
     class CollectionConfiguration {
     public:
         /** Creates CollectionConfiguration with the collection. */
@@ -264,7 +265,7 @@ namespace cbl {
         std::vector<CollectionConfiguration> _collections;
     };
 
-    /** Replicator for replicating documents in collections in local database and targeted database. */
+    /** A replicator that syncs documents between a local database's collections and a target database. */
     class Replicator : private RefCounted {
     public:
         /** Creates a new replicator using the specified config. */

--- a/include/cbl++/VectorIndex.hh
+++ b/include/cbl++/VectorIndex.hh
@@ -27,12 +27,13 @@
 CBL_ASSUME_NONNULL_BEGIN
 
 namespace cbl {
-    /** ENTERPRISE EDITION ONLY
-     
-        Vector Encoding  Type*/
-
+    /** The distance metric used by a vector index to measure the similarity of vectors.
+        \note ENTERPRISE EDITION ONLY */
     using DistanceMetric = CBLDistanceMetric;
 
+    /** Vector encoding type to use in a \ref VectorIndexConfiguration, for reducing the
+        size of the stored vectors.
+        \note ENTERPRISE EDITION ONLY */
     class VectorEncoding {
     public:
         /** Creates a no-encoding type to use in VectorIndexConfiguration; 4 bytes per dimension, no data loss.
@@ -75,9 +76,9 @@ namespace cbl {
         std::shared_ptr<CBLVectorEncoding> _ref;
     };
 
-    /** ENTERPRISE EDITION ONLY
-     
-        Vector Index Configuration. */
+    /** Configuration for creating a vector index, which enables searching documents
+        by vector similarity.
+        \note ENTERPRISE EDITION ONLY */
     class VectorIndexConfiguration {
     public:
         /** Creates the VectorIndexConfiguration. 

--- a/include/cbl/CBLBase.h
+++ b/include/cbl/CBLBase.h
@@ -117,7 +117,8 @@ FLSliceResult CBLError_Message(const CBLError* _cbl_nullable outError) CBLAPI;
 
 
 /** \defgroup other_types   Other Types
-     @{ */
+     @{
+    Timestamps and other miscellaneous types and functions. */
 
 /** A date/time representation used for document expiration (and in date/time queries.)
     Measured in milliseconds since the Unix epoch (1/1/1970, midnight UTC.) */
@@ -177,25 +178,25 @@ void CBL_DumpInstances(void) CBLAPI;
 
 
 
-/** \defgroup database  Database
+/** \addtogroup database
      @{ */
 /** A connection to an open database. */
 typedef struct CBLDatabase   CBLDatabase;
 /** @} */
 
-/** \defgroup scope  Scope
+/** \addtogroup scope
      @{ */
 /** A  collection's scope. */
 typedef struct CBLScope CBLScope;
 /** @} */
 
-/** \defgroup collection  Collection
+/** \addtogroup collection
      @{ */
 /** A collection, a document container. */
 typedef struct CBLCollection    CBLCollection;
 /** @} */
 
-/** \defgroup documents  Documents
+/** \addtogroup documents
      @{ */
 /** An in-memory copy of a document.
     CBLDocument objects can be mutable or immutable. Immutable objects are referenced by _const_
@@ -204,13 +205,13 @@ typedef struct CBLCollection    CBLCollection;
 typedef struct CBLDocument   CBLDocument;
 /** @} */
 
-/** \defgroup blobs Blobs
+/** \addtogroup blobs
      @{ */
 /** A binary data value associated with a \ref CBLDocument. */
 typedef struct CBLBlob      CBLBlob;
 /** @} */
 
-/** \defgroup query  Query
+/** \addtogroup query
      @{ */
 /** A compiled database query. */
 typedef struct CBLQuery      CBLQuery;
@@ -219,7 +220,7 @@ typedef struct CBLQuery      CBLQuery;
 typedef struct CBLResultSet  CBLResultSet;
 /** @} */
 
-/** \defgroup index  Index
+/** \addtogroup index
      @{ */
 /** A query index. */
 typedef struct CBLQueryIndex      CBLQueryIndex;
@@ -229,7 +230,7 @@ typedef struct CBLIndexUpdater      CBLIndexUpdater;
 #endif
 /** @} */
 
-/** \defgroup replication  Replication
+/** \addtogroup replication
      @{ */
 /** A background task that syncs a \ref CBLDatabase with a remote server or peer. */
 typedef struct CBLReplicator CBLReplicator;
@@ -237,7 +238,7 @@ typedef struct CBLReplicator CBLReplicator;
 
 #ifdef COUCHBASE_ENTERPRISE
 
-/** \defgroup encryptables Encryptables
+/** \addtogroup encryptables
      @{ */
 /** An encryptable value. The encryptable values will be encrypted by a push replicator via the
     specified property encryptor callback when the document is push to the remote server.

--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -351,7 +351,7 @@ CBLListenerToken* CBLDatabase_AddChangeListener(const CBLDatabase* db,
 #ifdef __APPLE__
 #pragma mark - NOTIFICATION SCHEDULING
 #endif
-/** \defgroup listeners   Listeners
+/** \addtogroup listeners
     @{ */
 /** \name  Scheduling notifications
     @{

--- a/include/cbl/CBLPrediction.h
+++ b/include/cbl/CBLPrediction.h
@@ -23,6 +23,12 @@
 
 CBL_CAPI_BEGIN
 
+/** \defgroup prediction   Prediction
+    @{
+    Registering predictive models, which integrate machine learning models into queries
+    via the query PREDICTION() function.
+    \note ENTERPRISE EDITION ONLY */
+
 /** Predictive Model  */
 typedef struct {
     /** A pointer to any external data needed by the `prediction` callback, which will receive this as its first parameter. */
@@ -51,6 +57,8 @@ void CBL_RegisterPredictiveModel(FLString name, CBLPredictiveModel model) CBLAPI
 /** Unregisters the predictive model.
     @param name  The name of the registered predictive model. */
 void CBL_UnregisterPredictiveModel(FLString name) CBLAPI;
+
+/** @} */
 
 CBL_CAPI_END
 

--- a/include/cbl/CBLQueryIndexTypes.h
+++ b/include/cbl/CBLQueryIndexTypes.h
@@ -22,7 +22,7 @@
 
 CBL_CAPI_BEGIN
 
-/** \defgroup index  Index 
+/** \addtogroup index
     @{ */
 
 /** \name Index Configuration

--- a/include/cbl/CBLQueryTypes.h
+++ b/include/cbl/CBLQueryTypes.h
@@ -21,7 +21,7 @@
 
 CBL_CAPI_BEGIN
 
-/** \defgroup queries   Queries
+/** \addtogroup query
     @{ */
 
 /** Query languages */

--- a/include/cbl/CBLURLEndpointListener.h
+++ b/include/cbl/CBLURLEndpointListener.h
@@ -25,6 +25,12 @@
 
 CBL_CAPI_BEGIN
 
+/** \defgroup URLEndpointListener   URLEndpointListener
+    @{
+    URLEndpointListener listens for incoming replicator connections, serving the collections
+    of local databases over the network to enable peer-to-peer sync.
+    \note ENTERPRISE EDITION ONLY */
+
 /** An opaque object representing the listener authenticator. */
 typedef struct CBLListenerAuthenticator CBLListenerAuthenticator;
 
@@ -127,6 +133,8 @@ bool CBLURLEndpointListener_Start(CBLURLEndpointListener*, CBLError* _cbl_nullab
 
 /** Stops the listener. */
 void CBLURLEndpointListener_Stop(CBLURLEndpointListener*) CBLAPI;
+
+/** @} */
 
 CBL_CAPI_END
 

--- a/include/cbl/CouchbaseLite.h
+++ b/include/cbl/CouchbaseLite.h
@@ -16,6 +16,73 @@
 // limitations under the License.
 //
 
+
+/** \mainpage Couchbase Lite C API
+
+    The C API of Couchbase Lite, an embedded NoSQL document database for mobile,
+    desktop, and edge devices.
+
+    \section getting_started Getting Started
+
+    Include `cbl/CouchbaseLite.h` (or the individual `cbl/CBL*.h` headers). The API
+    is organized into the groups listed on the <a href="modules.html">Modules</a> page.
+
+    \code{.c}
+    #include "cbl/CouchbaseLite.h"
+
+    CBLError error;
+    CBLDatabase* db = CBLDatabase_Open(FLSTR("mydb"), NULL, &error);
+    if (!db) {
+        // handle error; see CBLError_Message()
+    }
+
+    CBLCollection* collection = CBLDatabase_DefaultCollection(db, &error);
+
+    CBLDocument* doc = CBLDocument_CreateWithID(FLSTR("doc1"));
+    FLMutableDict props = CBLDocument_MutableProperties(doc);
+    FLMutableDict_SetString(props, FLSTR("greeting"), FLSTR("Hello, World!"));
+
+    if (!CBLCollection_SaveDocument(collection, doc, &error)) {
+        // handle error
+    }
+
+    CBLDocument_Release(doc);
+    CBLCollection_Release(collection);
+    CBLDatabase_Close(db, &error);
+    CBLDatabase_Release(db);
+    \endcode
+
+    \section reference_counting Reference Counting
+
+    Couchbase Lite objects are reference-counted. Functions that create an object
+    (typically named `..._Create()` or `..._New()`) return it with a ref-count of 1;
+    release it with the type-safe `CBLXxx_Release()` function when you are done with
+    it, or it will be leaked. Functions that return an existing object do not change
+    its ref-count: do not release it unless you retained it, and retain it if you
+    need to keep it alive. Each function's documentation states whether you are
+    responsible for releasing the returned object. See
+    \ref refcounting "Reference Counting" for details.
+
+    \section error_handling Error Handling
+
+    Functions that can fail take a `CBLError*` out-parameter and signal failure
+    through their return value, typically by returning `false` or `NULL`. On failure,
+    the error's domain and code are written to the out-parameter, and
+    \ref CBLError_Message returns a human-readable message for it. See
+    \ref errors "Errors".
+
+    \section document_data Document Data
+
+    Document properties are stored as Fleece values: \ref CBLDocument_Properties
+    returns an `FLDict`, and \ref CBLDocument_MutableProperties returns an
+    `FLMutableDict`. Strings and binary data are passed as `FLString`/`FLSlice`,
+    non-owning views of a byte range that must not outlive the data they point to;
+    use `FLSTR()` to make one from a string literal. Functions returning
+    `FLSliceResult`/`FLStringResult` transfer ownership of heap-allocated data:
+    release the result when done. The Fleece API is documented in this reference
+    under the Fleece topic groups.
+*/
+
 #pragma once
 #include "CBLBase.h"
 #include "CBLBlob.h"


### PR DESCRIPTION
C++
* Add Doxyfile_C++ to generate the C++ API reference (docs/C++) from include/cbl++.
* Improve mange page of both C and C++ with intro, getting started w/ compile-checked examples, object model / reference counting, document data, and error handling sections.
* Revise C++ class brief descriptions; move ENTERPRISE EDITION ONLY markers into \note so the short description in the Classes page doesn’t only show ENTERPRISE EDITION ONLY for those classes.

C:
* Fix empty group descriptions on the C Modules page: define each group once (\addtogroup elsewhere), merge orphan Queries group into Query, and add missing Prediction and URLEndpointListener groups.
* Strip the fleece vendor path from #include lines (STRIP_FROM_INC_PATH) so no local paths leak into the docs.