### PR TITLE
CBL-8426 : Improve C++ API Doc

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -866,7 +866,6 @@ WARN_NO_PARAMDOC       = NO
 # The default value is: NO.
 
 WARN_AS_ERROR          = YES
-
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
 # will be replaced by the file and line number from which the warning originated
@@ -1287,15 +1286,6 @@ HTML_COLORSTYLE_SAT    = 100
 
 HTML_COLORSTYLE_GAMMA  = 80
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to YES can help to show when doxygen was last run and thus if the
-# documentation is up to date.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_TIMESTAMP         = NO
-
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
 # are dynamically created via JavaScript. If disabled, the navigation index will
@@ -1619,17 +1609,6 @@ HTML_FORMULA_FORMAT    = png
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 FORMULA_FONTSIZE       = 10
-
-# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
-# generated for formulas are transparent PNGs. Transparent PNGs are not
-# supported properly for IE 6.0, but are supported on all modern browsers.
-#
-# Note that when changing this option you need to delete any form_*.png files in
-# the HTML output directory before the changes have effect.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-FORMULA_TRANSPARENT    = YES
 
 # The FORMULA_MACROFILE can contain LaTeX \newcommand and \renewcommand commands
 # to create new LaTeX commands to be used in formulas as building blocks. See
@@ -1967,14 +1946,6 @@ LATEX_HIDE_INDICES     = NO
 
 LATEX_BIB_STYLE        = plain
 
-# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_TIMESTAMP        = NO
-
 # The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
 # path from which the emoji images will be read. If a relative path is entered,
 # it will be relative to the LATEX_OUTPUT directory. If left blank the
@@ -2295,7 +2266,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = docs/C/cbl_c.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be
@@ -2353,23 +2324,6 @@ HAVE_DOT               = NO
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_NUM_THREADS        = 0
-
-# When you want a differently looking font in the dot files that doxygen
-# generates you can specify the font name using DOT_FONTNAME. You need to make
-# sure dot is able to find the font, which can be done by putting it in a
-# standard location or by setting the DOTFONTPATH environment variable or by
-# setting DOT_FONTPATH to the directory containing the font.
-# The default value is: Helvetica.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTNAME           = Helvetica
-
-# The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
-# dot graphs.
-# Minimum value: 4, maximum value: 24, default value: 10.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTSIZE           = 10
 
 # By default doxygen will tell dot to use the default font as specified with
 # DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
@@ -2615,18 +2569,6 @@ DOT_GRAPH_MAX_NODES    = 50
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 MAX_DOT_GRAPH_DEPTH    = 0
-
-# Set the DOT_TRANSPARENT tag to YES to generate images with a transparent
-# background. This is disabled by default, because dot on Windows does not seem
-# to support this out of the box.
-#
-# Warning: Depending on the platform used, enabling this option may lead to
-# badly anti-aliased labels on the edges of a graph (i.e. they become hard to
-# read).
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This

--- a/Doxyfile_C++
+++ b/Doxyfile_C++
@@ -16,6 +16,8 @@ OUTPUT_DIRECTORY       = docs/C++/
 INPUT                  = include/cbl++
 FILE_PATTERNS          = *.hh
 
+BUILTIN_STL_SUPPORT = YES
+
 # C++ output: turn off the C-tailored mode so classes/namespaces render properly.
 OPTIMIZE_OUTPUT_FOR_C  = NO
 
@@ -41,3 +43,14 @@ PREDEFINED            += _cbl_nullable=_Nullable \
                          CBL_ASSUME_NONNULL_BEGIN= \
                          CBL_ASSUME_NONNULL_END= \
                          _cbl_warn_unused=
+
+# Don't generate a tag file from the C++ build; the parent Doxyfile's
+# GENERATE_TAGFILE=docs/C/cbl_c.tag is inherited via @INCLUDE and would
+# otherwise overwrite the C tag file when this Doxyfile is run after it.
+GENERATE_TAGFILE       =
+
+# Cross-link to the C docs. The parent Doxyfile emits docs/C/cbl_c.tag; with
+# OUTPUT_DIRECTORY=docs/C/ and HTML_OUTPUT=html for the C build, and the C++
+# pages landing in docs/C++/html/, the relative path from a C++ page to a C
+# page is ../../C/html.
+TAGFILES               = docs/C/cbl_c.tag=../../C/html

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>CouchbaseLite For C Documentation</title>
+        <title>CouchbaseLite For C / C++ Documentation</title>
     </head>
     <body>
-        <h1>Couchbase Lite For C Documentation</h1>
+        <h1>Couchbase Lite For C / C++ Documentation</h1>
         <ul>
             <li><a href="C/html/modules.html">C API</a></li>
+            <li><a href="C++/html/annotated.html">C++ API</a></li>
         </ul>
-        <p><a href="https://github.com/couchbaselabs/couchbase-lite-C">GitHub project page</a></p>
     </body>
 </html>

--- a/include/cbl++/Base.hh
+++ b/include/cbl++/Base.hh
@@ -45,9 +45,9 @@ inline bool operator== (const CBLError &e1, const CBLError &e2) {
 
 namespace cbl {
 
-    /** Convenience alias for \ref fleece::slice, a non-owning view of a byte range. */
+    /** Convenience alias for `fleece::slice`, a non-owning view of a byte range. */
     using slice = fleece::slice;
-    /** Convenience alias for \ref fleece::alloc_slice, an owning byte buffer. */
+    /** Convenience alias for `fleece::alloc_slice`, an owning byte buffer. */
     using alloc_slice = fleece::alloc_slice;
 
     using QueryLanguage = CBLQueryLanguage;
@@ -170,7 +170,7 @@ public: \
     CLASS& operator=(CLASS &&other) noexcept      {SUPER::operator=((SUPER&&)other); return *this;}
 
     /** A token representing a registered listener; instances are returned from the various
-        methods that register listeners, such as \ref Database::addListener.
+        methods that register listeners, such as \ref Collection::addChangeListener.
         When this object goes out of scope, the listener will be unregistered.
         @note ListenerToken is not allowed to copy. */
     template <class... Args>

--- a/include/cbl++/Blob.hh
+++ b/include/cbl++/Blob.hh
@@ -118,7 +118,7 @@ namespace cbl {
         struct adopt_t {};
         inline static constexpr adopt_t adopt{};
 
-        Blob(CBLBlob* cObj, adopt_t) { _ref = (CBLRefCounted*)cObj; }
+        Blob(CBLBlob* _cbl_nullable cObj, adopt_t) { _ref = (CBLRefCounted*)cObj; }
     };
 
     /** A stream for reading a blob's content from the database. */

--- a/include/cbl++/Collection.hh
+++ b/include/cbl++/Collection.hh
@@ -163,7 +163,7 @@ namespace cbl {
         inline Document getDocument(std::string_view docID) const;
         
         /** Reads a document from the collection in mutable form that can be updated and saved.
-            (This function is otherwise identical to \ref Collection::getDocument(slice docID).)
+            (This function is otherwise identical to \ref Collection::getDocument.)
             @param docID  The ID of the document.
             @return A new \ref Document instance, or a falsy Document if the doc doesn't exist.
             @throws cbl::Error  On a database error. Note a non-existent document is not an
@@ -211,7 +211,7 @@ namespace cbl {
         /** Purges a document from the collection. This removes all traces of the document.
             Purges are _not_ replicated. If the document is changed on a server, it will be re-created
             when pulled.
-            @note If you don't have the document in memory already, \ref purgeDocument(slice docID) is a simpler shortcut.
+            @note If you don't have the document in memory already, \ref purgeDocument(std::string_view docID) is a simpler shortcut.
             @param doc  The document to purge. */
         inline void purgeDocument(Document &doc);
 
@@ -227,7 +227,7 @@ namespace cbl {
         }
         
         /** Returns the time, if any, at which a given document in the collection will expire and be purged.
-            Documents don't normally expire; you have to call \ref Collection::setDocumentExpiration(slice docID, time_t expiration)
+            Documents don't normally expire; you have to call \ref Collection::setDocumentExpiration(std::string_view docID, time_t expiration)
             to set a document's expiration time.
             @param docID  The ID of the document.
             @return The expiration time as a CBLTimestamp (milliseconds since Unix epoch),

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -443,22 +443,33 @@ namespace cbl {
         std::shared_ptr<NotificationsReadyCallbackAccess> _notificationReadyCallbackAccess;
         
     public:
+        /** Copy constructor. Both `*this` and `other` refer to the same underlying
+            \ref CBLDatabase handle (its refcount is incremented) and share the
+            buffered-notification callback state. */
         Database(const Database &other) noexcept
         :RefCounted(other)
         ,_notificationReadyCallbackAccess(other._notificationReadyCallbackAccess)
         { }
-        
+
+        /** Move constructor. Takes over `other`'s \ref CBLDatabase handle and
+            buffered-notification callback state, leaving `other` empty. */
         Database(Database &&other) noexcept
         :RefCounted((RefCounted&&)other)
         ,_notificationReadyCallbackAccess(std::move(other._notificationReadyCallbackAccess))
         { }
-        
+
+        /** Copy assignment. Releases the currently-referenced handle (if any), then
+            makes `*this` refer to the same \ref CBLDatabase as `other` (refcount
+            incremented) and share its buffered-notification callback state. */
         Database& operator=(const Database &other) noexcept {
             RefCounted::operator=(other);
             _notificationReadyCallbackAccess = other._notificationReadyCallbackAccess;
             return *this;
         }
-        
+
+        /** Move assignment. Releases the currently-referenced handle (if any), then
+            takes over `other`'s \ref CBLDatabase handle and buffered-notification
+            callback state; `other` is left empty. */
         Database& operator=(Database &&other) noexcept {
             RefCounted::operator=((RefCounted&&)other);
             _notificationReadyCallbackAccess = std::move(other._notificationReadyCallbackAccess);
@@ -466,7 +477,7 @@ namespace cbl {
         }
         
         /** Releases the underlying C \ref CBLDatabase handle and drops the buffered-notification
-            callback. After this call the object is empty (\ref operator bool returns false).
+            callback. After this call the object is empty (its `operator bool` returns false).
             @note Other \ref Database references to the same database file remain valid. */
         void clear() {
             // Reset _notificationReadyCallbackAccess the releasing the _ref to

--- a/include/cbl++/Document.hh
+++ b/include/cbl++/Document.hh
@@ -117,7 +117,7 @@ namespace cbl {
         /** Returns a mutable document's properties as a mutable dictionary.
             You may modify this dictionary and then call \ref Collection::saveDocument(MutableDocument &doc) to persist the changes.
             @note  When accessing nested collections inside the properties as a mutable collection
-                   for modification, use \ref MutableDict::getMutableDict() or \ref MutableDict::getMutableArray() */
+                   for modification, use `fleece::MutableDict::getMutableDict()` or `fleece::MutableDict::getMutableArray()` */
         fleece::MutableDict properties()                {return CBLDocument_MutableProperties(ref());}
 
         /** Sets a property key and value.

--- a/include/cbl++/LogSinks.hh
+++ b/include/cbl++/LogSinks.hh
@@ -43,8 +43,8 @@ namespace cbl {
 
     /** Custom log sink configuration for logging to a user-defined callback. */
     struct CustomLogSink {
-        LogLevel level = kCBLLogNone   ;         ///< The minimum level of message to write (Required).
-        LogSinkCallback callback;                ///< Custom log callback (Required).
+        LogLevel level = kCBLLogNone;            ///< The minimum level of message to write (Required).
+        LogSinkCallback _cbl_nullable callback;  ///< Custom log callback.
         LogDomainMask domains;                   ///< Bitmask for enabled log domains. Use zero for all domains.
 
         operator CBLCustomLogSink() const {

--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -40,10 +40,11 @@ namespace cbl {
             \ref Query object around instead of compiling it each time. If you need to run related queries
             with only some values different, create one query with placeholder parameter(s), and substitute
             the desired value(s) with \ref Query::setParameters(fleece::Dict parameters) each time you run the query.
-            @warning <b>Deprecated :</b> Use Database::createQuery(CBLQueryLanguage language, slice queryString) instead.
+            @warning <b>Deprecated :</b> Use \ref Database::createQuery instead.
             @note The JSON query language is a volatile API. Volatile APIs are experimental and may likely be changed.
                   They may also be used to indicate inherently private APIs that may be exposed, but "YMMV"
                   (your mileage may vary) principles apply.
+            @param db  The database the query runs against.
             @param language  The query language
             @param queryString  The query string.
          */
@@ -69,7 +70,7 @@ namespace cbl {
             Parameters are specified in the query source as
             e.g. `$PARAM` (N1QL) or `["$PARAM"]` (JSON). In this example, the `parameters` dictionary
             to this call should have a key `PARAM` that maps to the value of the parameter.
-            @param parameters  The parameters in the form of a Fleece \ref Dict "dictionary" whose
+            @param parameters  The parameters in the form of a Fleece `Dict` (dictionary) whose
                     keys are the parameter names. (It's easiest to construct this by using the fleece::MutableDict) */
         void setParameters(fleece::Dict parameters) {CBLQuery_SetParameters(ref(), parameters);}
         

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -406,7 +406,7 @@ namespace cbl {
         /** Indicates whether the document with the given ID in the given collection has local changes
             that have not yet been pushed to the server by this replicator.
          
-            This is equivalent to, but faster than, calling \ref Replicator::pendingDocumentIDs(Collection& collection) and
+            This is equivalent to, but faster than, calling \ref Replicator::pendingDocumentIDs and
             checking whether the result contains \p docID. See that function's documentation for details.
             @note A `false` result means the document is not pending, _or_ there was an error.
                   To tell the difference, compare the error code to zero.
@@ -473,22 +473,33 @@ namespace cbl {
         CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE(Replicator, RefCounted, CBLReplicator)
         
     public:
+        /** Copy constructor. Both `*this` and `other` refer to the same underlying
+            \ref CBLReplicator handle (its refcount is incremented) and share the
+            collection-configuration map. */
         Replicator(const Replicator &other) noexcept
         :RefCounted(other)
         ,_collectionMap(other._collectionMap)
         { }
-        
+
+        /** Move constructor. Takes over `other`'s \ref CBLReplicator handle and
+            collection-configuration map, leaving `other` empty. */
         Replicator(Replicator &&other) noexcept
         :RefCounted((RefCounted&&)other)
         ,_collectionMap(std::move(other._collectionMap))
         { }
-        
+
+        /** Copy assignment. Releases the currently-referenced handle (if any), then
+            makes `*this` refer to the same \ref CBLReplicator as `other` (refcount
+            incremented) and share its collection-configuration map. */
         Replicator& operator=(const Replicator &other) noexcept {
             RefCounted::operator=(other);
             _collectionMap = other._collectionMap;
             return *this;
         }
-        
+
+        /** Move assignment. Releases the currently-referenced handle (if any), then
+            takes over `other`'s \ref CBLReplicator handle and collection-configuration
+            map; `other` is left empty. */
         Replicator& operator=(Replicator &&other) noexcept {
             RefCounted::operator=((RefCounted&&)other);
             _collectionMap = std::move(other._collectionMap);
@@ -496,7 +507,8 @@ namespace cbl {
         }
         
         /** Releases the underlying C \ref CBLReplicator and drops the C++ collection-configuration
-            map. After this call the object is empty (\ref operator bool returns false). */
+            map. After this call the object is empty (its \ref Replicator::operator bool() const
+            returns false). */
         void clear() {
             RefCounted::clear();
             _collectionMap.reset();

--- a/include/cbl/CBLBase.h
+++ b/include/cbl/CBLBase.h
@@ -153,7 +153,7 @@ typedef struct CBLRefCounted CBLRefCounted;
 
 /** Increments an object's reference-count.
     Usually you'll call one of the type-safe synonyms specific to the object type,
-    like \ref CBLDatabase_Retain` */
+    like \ref CBLDatabase_Retain. */
 CBLRefCounted* CBL_Retain(CBLRefCounted* _cbl_nullable) CBLAPI;
 
 /** Decrements an object's reference-count, freeing the object if the count hits zero.

--- a/include/cbl/CBLEncryptable.h
+++ b/include/cbl/CBLEncryptable.h
@@ -35,9 +35,9 @@ CBL_CAPI_BEGIN
     whose value is the actual value to be encrypted by the push replicator.
  
     The push replicator will automatically detect \ref CBLEncryptable dictionaries inside
-    the document and calls the specified \ref CBLPropertyEncryptor callback to encrypt the
+    the document and call the specified \ref CBLDocumentPropertyEncryptor callback to encrypt the
     actual value. When the value is successfully encrypted, the replicator will transform
-    the property key and the encrypted \ref CBLPropertyEncryptor dictionary value into
+    the property key and the encrypted \ref CBLDocumentPropertyEncryptor dictionary value into
     Couchbase Server SDK's encrypted field format :
  
     * The original key will be prefixed with 'encrypted$'.
@@ -45,28 +45,28 @@ CBL_CAPI_BEGIN
     * The transformed \ref CBLEncryptable dictionary will contain `alg` property indicating
       the encryption algorithm, `ciphertext` property whose value is a base-64 string of the
       encrypted value, and optionally `kid` property indicating the encryption key identifier
-      if specified when returning the result of \ref CBLPropertyEncryptor callback call.
+      if specified when returning the result of \ref CBLDocumentPropertyEncryptor callback call.
     
-    For security reason, a document that contains CBLEncryptable dictionaries will fail
+    For security reasons, a document that contains CBLEncryptable dictionaries will fail
     to push with the \ref kCBLErrorCrypto error if their value cannot be encrypted including
-    when a \ref CBLPropertyEncryptor callback is not specified or when there is an error
+    when a \ref CBLDocumentPropertyEncryptor callback is not specified or when there is an error
     or a null result returned from the callback call.
  
     The pull replicator will automatically detect the encrypted properties that are in the
-    Couchbase Server SDK's encrypted field format and call the specified \ref CBLPropertyDecryptor
+    Couchbase Server SDK's encrypted field format and call the specified \ref CBLDocumentPropertyDecryptor
     callback to decrypt the encrypted value. When the value is successfully decrypted,
     the replicator will transform the property format back to the CBLEncryptable format
     including removing the 'encrypted$' prefix.
  
-    The \ref CBLPropertyDecryptor callback can intentionally skip the decryption by returnning a
+    The \ref CBLDocumentPropertyDecryptor callback can intentionally skip the decryption by returning a
     null result. When a decryption is skipped, the encrypted property in the form of
     Couchbase Server SDK's encrypted field format will be kept as it was received from the remote
     server. If an error is returned from the callback call, the document will be failed to pull with
     the \ref kCBLErrorCrypto error.
  
-    If a \ref CBLPropertyDecryptor callback is not specified, the replicator will not attempt to
+    If a \ref CBLDocumentPropertyDecryptor callback is not specified, the replicator will not attempt to
     detect any encrypted properties. As a result, all encrypted properties in the form of
-    Couchbase Server SDK's encrypted field format will be kept as they was received from the remote
+    Couchbase Server SDK's encrypted field format will be kept as they were received from the remote
     server.
     
     To create a new \ref CBLEncryptable, call CBLEncryptable_CreateWith<Value Type>

--- a/include/cbl/CBLLog.h
+++ b/include/cbl/CBLLog.h
@@ -36,7 +36,7 @@ CBL_CAPI_BEGIN
     Undefined Behavior will result, possibly including crashes or overwriting the stack.
     @param domain  The log domain to associate this message with.
     @param level  The severity of the message. If this is lower than the current minimum level for the domain
-                 (as set by \ref CBLLog_SetConsoleLevel), nothing is logged.
+                 (as set by \ref CBLLogSinks_SetConsole), nothing is logged.
     @param format  A `printf`-style format string. `%` characters in this string introduce parameters,
                  and corresponding arguments must follow.
     @warning  <b>Deprecated :</b> No alternative for this function and this function will be removed in the future release. */
@@ -47,7 +47,7 @@ void CBL_Log(CBLLogDomain domain,
 /** Writes a pre-formatted message to the log, exactly as given.
     @param domain  The log domain to associate this message with.
     @param level  The severity of the message. If this is lower than the current minimum level for the domain
-                 (as set by \ref CBLLog_SetConsoleLevel), nothing is logged.
+                 (as set by \ref CBLLogSinks_SetConsole), nothing is logged.
     @param message  The exact message to write to the log.
     @warning  <b>Deprecated :</b> No alternative for this function and this function will be removed in the future release.*/
 void CBL_LogMessage(CBLLogDomain domain,

--- a/include/cbl/CBLLogSinks.h
+++ b/include/cbl/CBLLogSinks.h
@@ -77,7 +77,7 @@ typedef struct {
 /** Custom log sink configuration for logging to a user-defined callback. */
 typedef struct {
     CBLLogLevel level;                          ///< The minimum level of message to write (Required).
-    CBLLogSinkCallback _cbl_nullable callback;  ///< Custom log callback (Required).
+    CBLLogSinkCallback _cbl_nullable callback;  ///< Custom log callback.
     CBLLogDomainMask domains;                   ///< Bitmask for enabled log domains. Use zero for all domains.
 } CBLCustomLogSink;
 

--- a/include/cbl/CBLTLSIdentity.h
+++ b/include/cbl/CBLTLSIdentity.h
@@ -94,7 +94,7 @@ CBL_REFCOUNTED(CBLKeyPair*, KeyPair);
     @param outError On failure, the error will be written here.
     @return A CBLCert instance on success, or NULL on failure.
     @note PEM data might consist of a series of certificates. If so, the returned CBLCert
-          will represent only the first, and you can iterate over the next by calling \ref CBLCert_NextInChain.
+          will represent only the first, and you can iterate over the next by calling \ref CBLCert_CertNextInChain.
     @note You are responsible for releasing the returned reference. */
 _cbl_warn_unused
 CBLCert* _cbl_nullable CBLCert_CreateWithData(FLSlice certData, CBLError* _cbl_nullable outError) CBLAPI;
@@ -301,8 +301,8 @@ typedef CBL_OPTIONS(uint16_t, CBLKeyUsages) {
     @param outError On failure, the error will be written here.
     @return A CBLTLSIdentity instance on success, or NULL on failure.
     @note A non-NULL label is not supported on Linux or Android platforms. On these platforms, passing `kFLSliceNull` for the label is required.
-    @Note The Common Name (kCBLCertAttrKeyCommonName) attribute is required.
-    @Note You are responsible for releasing the returned reference. */
+    @note The Common Name (kCBLCertAttrKeyCommonName) attribute is required.
+    @note You are responsible for releasing the returned reference. */
 _cbl_warn_unused
 CBLTLSIdentity* _cbl_nullable CBLTLSIdentity_CreateIdentity(CBLKeyUsages keyUsages,
                                                             FLDict attributes,
@@ -317,8 +317,8 @@ CBLTLSIdentity* _cbl_nullable CBLTLSIdentity_CreateIdentity(CBLKeyUsages keyUsag
     @param validityInMilliseconds Certificate validity duration in milliseconds.
     @param outError On failure, the error will be written here.
     @return A CBLTLSIdentity instance on success, or NULL on failure.
-    @Note The Common Name (kCBLCertAttrKeyCommonName) attribute is required.
-    @Note You are responsible for releasig the returned reference. */
+    @note The Common Name (kCBLCertAttrKeyCommonName) attribute is required.
+    @note You are responsible for releasing the returned reference. */
 _cbl_warn_unused
 CBLTLSIdentity* _cbl_nullable CBLTLSIdentity_CreateIdentityWithKeyPair(CBLKeyUsages keyUsages,
                                                                        CBLKeyPair* keypair,
@@ -344,7 +344,7 @@ _cbl_warn_unused
  *  @param outError On failure, the error will be written here.
  *  @return A CBLTLSIdentity instance if the identity is found and successfully retrieved,
  *          or `NULL` if the identity does not exist or an error occurs.
-    @Note The Linux and Android platforms do not support this function.
+    @note The Linux and Android platforms do not support this function.
     @note You are responsible for releasing the returned reference. */
 CBLTLSIdentity* _cbl_nullable CBLTLSIdentity_IdentityWithLabel(FLString label,
                                                                CBLError* _cbl_nullable outError) CBLAPI;
@@ -371,7 +371,7 @@ CBLTLSIdentity* _cbl_nullable CBLTLSIdentity_IdentityWithKeyPairAndCerts(CBLKeyP
  *  @param cert A CBLCert instance representing the certificate chain.
  *  @param outError On failure, the error will be written here.
  *  @return A CBLTLSIdentity instance on success, or `NULL` if an error occurs.
- *  @Note The Linux and Android platforms do not support this function.
+ *  @note The Linux and Android platforms do not support this function.
  *  @note You are responsible for releasing the returned reference. */
 _cbl_warn_unused
 CBLTLSIdentity* _cbl_nullable CBLTLSIdentity_IdentityWithCerts(CBLCert* cert,


### PR DESCRIPTION
* Direct ported from release/4.1 branch.

* Update LiteCore to the latest release/3.4 branch.

-- 

Fix Doxygen configurations and source documentation errors

Resolve configuration and annotation errors preventing Doxygen from
generating essential build artifacts. Specifically, this fixes the
C API Doxygen build so it correctly generates the tag file required
by the C++ API documentation references.

Documentation updates:
- Fix `Doxyfile` (C) and `Doxyfile_C++` configuration files.
- Resolve source code formatting warnings/errors in Fleece and cbl++.
- Update outdated documentation comments across cbl++.

Both Doxygen pipelines now execute to completion with zero warnings
or errors. This is a documentation-only change; no functional code
was modified.