### PR TITLE
CBL-8573: Add replicator's document property encryption to the C++ API

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		1BDEBBF32FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */; };
 		1BDEBBF42FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */; };
 		1BDEBBF52FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */; };
+		1BDEBC5A2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBC592FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc */; };
+		1BDEBC5B2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBC592FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc */; };
+		1BDEBC5C2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBC592FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc */; };
+		1BDEBC5D2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BDEBC592FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc */; };
 		1BF219BA2D7F87E2009534EC /* CBLTLSIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BF219B92D7F87E2009534EC /* CBLTLSIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1BF219BB2D7F87E2009534EC /* CBLTLSIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BF219B92D7F87E2009534EC /* CBLTLSIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1BF219C02D7F930F009534EC /* CBLTLSIdentity_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BF219BF2D7F930F009534EC /* CBLTLSIdentity_CAPI.cc */; };
@@ -567,6 +571,7 @@
 		1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLURLEndpointListener.h; sourceTree = "<group>"; };
 		1BC5D9652D6E4DA60080153E /* CBLURLEndpointListener_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLURLEndpointListener_CAPI.cc; sourceTree = "<group>"; };
 		1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EncryptableTest_Cpp.cc; sourceTree = "<group>"; };
+		1BDEBC592FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReplicatorPropEncTest_Cpp.cc; sourceTree = "<group>"; };
 		1BF219B92D7F87E2009534EC /* CBLTLSIdentity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLTLSIdentity.h; sourceTree = "<group>"; };
 		1BF219BF2D7F930F009534EC /* CBLTLSIdentity_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLTLSIdentity_CAPI.cc; sourceTree = "<group>"; };
 		1BF21A3C2D84E419009534EC /* TLSIdentityTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TLSIdentityTest.cc; sourceTree = "<group>"; };
@@ -1097,6 +1102,7 @@
 				FC82CE0428C6E2BD001FA083 /* ReplicatorCollectionTest_Cpp.cc */,
 				2736A633242E5A74002B9D65 /* ReplicatorEETest.cc */,
 				93C70D1626CB334D0093E927 /* ReplicatorPropEncTest.cc */,
+				1BDEBC592FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc */,
 				1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */,
 				1BF21A3C2D84E419009534EC /* TLSIdentityTest.cc */,
 				1B7694AA2DA07261006EEEAB /* TLSIdentityTest.hh */,
@@ -2187,6 +2193,7 @@
 				FC09077C28A5F3EF00201B07 /* CollectionTest_Cpp.cc in Sources */,
 				FCC063F3285BA641000C5BD7 /* DocumentTest.cc in Sources */,
 				275B358923481D0C00FE9CF0 /* CBLTest.cc in Sources */,
+				1BDEBC5A2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */,
 				275B358A23481D0C00FE9CF0 /* DatabaseTest.cc in Sources */,
 				93C70D1726CB334D0093E927 /* ReplicatorPropEncTest.cc in Sources */,
 				275B358B23481D0C00FE9CF0 /* DatabaseTest_Cpp.cc in Sources */,
@@ -2232,6 +2239,7 @@
 				1B21A7DA2D711B29000CA0D5 /* URLEndpointListenerTest.cc in Sources */,
 				93C70D3426D01B5A0093E927 /* BlobTest.cc in Sources */,
 				1B7694AD2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */,
+				1BDEBC5C2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */,
 				27B61DB921D6ECA70027CCDB /* DatabaseTest.cc in Sources */,
 				1BF21A3F2D84E419009534EC /* TLSIdentityTest.cc in Sources */,
 				1BDEBBF42FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */,
@@ -2277,6 +2285,7 @@
 				40B32EED2E53EAF600D48F37 /* URLEndpointListenerTest.cc in Sources */,
 				40B32EEE2E53EAF600D48F37 /* BlobTest.cc in Sources */,
 				40B32EEF2E53EAF600D48F37 /* TLSIdentityTest+Apple.mm in Sources */,
+				1BDEBC5B2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */,
 				40B32EF02E53EAF600D48F37 /* DatabaseTest.cc in Sources */,
 				40B32EF12E53EAF600D48F37 /* TLSIdentityTest.cc in Sources */,
 				1BDEBBF22FBB98A10063786B /* EncryptableTest_Cpp.cc in Sources */,
@@ -2346,6 +2355,7 @@
 				40E32F442D2F45A3000CED57 /* LogTest_Cpp.cc in Sources */,
 				FC645E1629085C6B007D5536 /* DocumentTest_Cpp.cc in Sources */,
 				FC645E1829085C71007D5536 /* QueryTest.cc in Sources */,
+				1BDEBC5D2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */,
 				FC645E0F29085C0A007D5536 /* CBLTest.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/include/cbl++/Encryptable.hh
+++ b/include/cbl++/Encryptable.hh
@@ -93,6 +93,16 @@ namespace cbl {
     /** Returns the Encryptable's underlying dictionary representation (its persistent form). */
     fleece::Dict properties() const {return CBLEncryptable_Properties(ref());}
 
+    /** Sets this encryptable value into @p dict under @p key.
+        Equivalent to the C API `FLMutableDict_SetEncryptableValue`. */
+    void setInto(fleece::MutableDict dict, fleece::slice key) const {
+        fleece::Dict props = properties();
+        fleece::MutableDict mProps = props.asMutable();
+        if (!mProps)
+            mProps = props.mutableCopy();
+        dict[key] = mProps;
+    }
+
     /** Returns true if the given dictionary is the persistent form of an Encryptable.
         @param dict  The dictionary to test. */
     static bool isEncryptableValue(fleece::Dict dict) {

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -102,7 +102,7 @@ namespace cbl {
                 CBLAuth_Free(r);
             });
         }
-        
+
         std::shared_ptr<CBLAuthenticator> _ref;
     };
 
@@ -113,6 +113,44 @@ namespace cbl {
     using ConflictResolver = std::function<Document(std::string_view docID,
                                                     const Document localDoc,
                                                     const Document remoteDoc)>;
+
+#ifdef COUCHBASE_ENTERPRISE
+    /** Result returned by a \ref PropertyEncryptor callback. */
+    struct EncryptionResult {
+        fleece::alloc_slice ciphertext;          ///< Encrypted data. Empty = skip (results in a crypto error).
+        std::optional<std::string> algorithm;   ///< Optional algorithm name. Default: "CB_MOBILE_CUSTOM".
+        std::optional<std::string> keyID;       ///< Optional key identifier.
+        CBLError error {};              ///< Optional error. Non-zero aborts replication for this doc.
+    };
+
+    /** Result returned by a \ref PropertyDecryptor callback. */
+    struct DecryptionResult {
+        fleece::alloc_slice plaintext;  ///< Decrypted data. Empty = leave property in encrypted form.
+        CBLError error {};              ///< Optional error. Non-zero aborts replication for this doc.
+    };
+
+    /** Property Encryptor Function Callback. (Enterprise Edition only.)
+        Called by the push replicator for each encryptable property in a document. */
+    using PropertyEncryptor = std::function<EncryptionResult(
+        fleece::slice scope,
+        fleece::slice collection,
+        fleece::slice documentID,
+        fleece::Dict properties,
+        fleece::slice keyPath,
+        fleece::slice input)>;
+
+    /** Property Decryptor Function Callback. (Enterprise Edition only.)
+        Called by the pull replicator for each encrypted property in a document. */
+    using PropertyDecryptor = std::function<DecryptionResult(
+        fleece::slice scope,
+        fleece::slice collection,
+        fleece::slice documentID,
+        fleece::Dict properties,
+        fleece::slice keyPath,
+        fleece::slice input,
+        std::optional<std::string_view> algorithm,
+        std::optional<std::string_view> keyID)>;
+#endif
 
     /** A collection to replicate, along with its collection-specific replication settings
         such as filters and a conflict resolver. */
@@ -222,14 +260,27 @@ namespace cbl {
             This option is disabled by default, which means that the parent-domain cookies are not permitted
             to save by default. */
         bool acceptParentDomainCookies      = kCBLDefaultReplicatorAcceptParentCookies;
-        
+
         //-- TLS settings:
         /** An X.509 cert (PEM or DER) to "pin" for TLS connections. The pinned cert will be evaluated against any certs
             in a cert chain, and the cert chain will be valid only if the cert chain contains the pinned cert. */
         std::string pinnedServerCertificate;
         /** Set of anchor certs (PEM format). */
         std::string trustedRootCertificates;
-        
+#ifdef COUCHBASE_ENTERPRISE
+        /** Accept only self-signed server certificates; any other certificates are rejected.
+            (Enterprise Edition only.) */
+        bool acceptOnlySelfSignedServerCertificate = false;
+#endif
+
+#ifdef COUCHBASE_ENTERPRISE
+        //-- Property Encryption (Enterprise Edition only):
+        /** Optional callback to encrypt encryptable properties during push replication. */
+        PropertyEncryptor documentPropertyEncryptor;
+        /** Optional callback to decrypt encrypted properties during pull replication. */
+        PropertyDecryptor documentPropertyDecryptor;
+#endif
+
     protected:
         friend class Replicator;
         
@@ -257,6 +308,9 @@ namespace cbl {
                 conf.pinnedServerCertificate = slice(pinnedServerCertificate);
             if (!trustedRootCertificates.empty())
                 conf.trustedRootCertificates = slice(trustedRootCertificates);
+#ifdef COUCHBASE_ENTERPRISE
+            conf.acceptOnlySelfSignedServerCertificate = acceptOnlySelfSignedServerCertificate;
+#endif
             return conf;
         }
         
@@ -274,22 +328,23 @@ namespace cbl {
             // Get the current configured collections and populate one for the
             // default collection if the config is configured with the database:
             auto collections = config.collections();
-            
-            // Created a shared collection map. The pointer of the collection map will be
-            // used as a context.
-            _collectionMap = std::shared_ptr<CollectionToReplCollectionMap>(new CollectionToReplCollectionMap());
-            
+
+            // Create a shared context. Its pointer is passed as the C-level context so
+            // that all captureless C callbacks (filters, conflict resolver, encryptor,
+            // decryptor) can reach both the collection map and the crypto functions.
+            _context = std::make_shared<ReplicatorContext>();
+
             // Get base C config:
             CBLReplicatorConfiguration c_config = config;
-            
+
             // Construct C replication collections to set to the c_config:
             std::vector<CBLCollectionConfiguration> colConfigs;
             for (int i = 0; i < collections.size(); i++) {
                 CollectionConfiguration& col = collections[i];
-                
+
                 CBLCollectionConfiguration colConfig {};
                 colConfig.collection = col.collection().ref();
-                
+
                 if (!col.channels.empty()) {
                     colConfig.channels = col.channels;
                 }
@@ -303,21 +358,21 @@ namespace cbl {
                                               CBLDocument* cDoc,
                                               CBLDocumentFlags flags) -> bool {
                         auto doc = Document(cDoc);
-                        auto map = (CollectionToReplCollectionMap*)context;
-                        return map->find(doc.collection())->second.pushFilter(doc, flags);
+                        auto ctx = (ReplicatorContext*)context;
+                        return ctx->collectionMap.find(doc.collection())->second.pushFilter(doc, flags);
                     };
                 }
-                
+
                 if (col.pullFilter) {
                     colConfig.pullFilter = [](void* context,
                                               CBLDocument* cDoc,
                                               CBLDocumentFlags flags) -> bool {
                         auto doc = Document(cDoc);
-                        auto map = (CollectionToReplCollectionMap*)context;
-                        return map->find(doc.collection())->second.pullFilter(doc, flags);
+                        auto ctx = (ReplicatorContext*)context;
+                        return ctx->collectionMap.find(doc.collection())->second.pullFilter(doc, flags);
                     };
                 }
-                
+
                 if (col.conflictResolver) {
                     colConfig.conflictResolver = [](void* context,
                                                     FLString docID,
@@ -327,11 +382,11 @@ namespace cbl {
                         auto localDoc = Document(cLocalDoc);
                         auto remoteDoc = Document(cRemoteDoc);
                         auto collection = localDoc ? localDoc.collection() : remoteDoc.collection();
-                        
-                        auto map = (CollectionToReplCollectionMap*)context;
-                        auto resolved = map->find(collection)->second.
+
+                        auto ctx = (ReplicatorContext*)context;
+                        auto resolved = ctx->collectionMap.find(collection)->second.
                             conflictResolver((std::string_view)slice(docID), localDoc, remoteDoc);
-                        
+
                         auto ref = resolved.ref();
                         if (ref && ref != cLocalDoc && ref != cRemoteDoc) {
                             CBLDocument_Retain(ref);
@@ -340,13 +395,59 @@ namespace cbl {
                     };
                 }
                 colConfigs.push_back(colConfig);
-                _collectionMap->insert({col.collection(), col});
+                _context->collectionMap.insert({col.collection(), col});
             }
-            
+
             c_config.collections = colConfigs.data();
             c_config.collectionCount = colConfigs.size();
-            c_config.context = _collectionMap.get();
-            
+            c_config.context = _context.get();
+
+#ifdef COUCHBASE_ENTERPRISE
+            if (config.documentPropertyEncryptor) {
+                _context->encryptor = config.documentPropertyEncryptor;
+                c_config.documentPropertyEncryptor = [](void* context,
+                                                        FLString scope,
+                                                        FLString collection,
+                                                        FLString documentID,
+                                                        FLDict properties,
+                                                        FLString keyPath,
+                                                        FLSlice input,
+                                                        FLStringResult* algorithm,
+                                                        FLStringResult* keyID,
+                                                        CBLError* error) -> FLSliceResult {
+                    auto ctx = (ReplicatorContext*)context;
+                    auto r = ctx->encryptor(scope, collection, documentID, properties, keyPath, input);
+                    if (error)     *error     = r.error;
+                    if (algorithm) *algorithm = r.algorithm ? FLStringResult(slice(*r.algorithm)) : FLStringResult{};
+                    if (keyID)     *keyID     = r.keyID ? FLStringResult(slice(*r.keyID)) : FLStringResult{};
+                    return FLSliceResult(r.ciphertext);
+                };
+            }
+
+            if (config.documentPropertyDecryptor) {
+                _context->decryptor = config.documentPropertyDecryptor;
+                c_config.documentPropertyDecryptor = [](void* context,
+                                                        FLString scope,
+                                                        FLString collection,
+                                                        FLString documentID,
+                                                        FLDict properties,
+                                                        FLString keyPath,
+                                                        FLSlice input,
+                                                        FLString algorithm,
+                                                        FLString keyID,
+                                                        CBLError* error) -> FLSliceResult {
+                    auto ctx = (ReplicatorContext*)context;
+                    auto toOpt = [](FLString s) -> std::optional<std::string_view> {
+                        return s.buf ? std::optional<std::string_view>{{(const char*)s.buf, s.size}} : std::nullopt;
+                    };
+                    auto r = ctx->decryptor(scope, collection, documentID, properties, keyPath, input,
+                                            toOpt(algorithm), toOpt(keyID));
+                    if (error) *error = r.error;
+                    return FLSliceResult(r.plaintext);
+                };
+            }
+#endif
+
             CBLError error {};
             _ref = (CBLRefCounted*) CBLReplicator_Create(&c_config, &error);
             internal::check(_ref, error);
@@ -468,7 +569,15 @@ namespace cbl {
         }
         
         using CollectionToReplCollectionMap = std::unordered_map<Collection, CollectionConfiguration>;
-        std::shared_ptr<CollectionToReplCollectionMap> _collectionMap;
+
+        struct ReplicatorContext {
+            CollectionToReplCollectionMap collectionMap;
+#ifdef COUCHBASE_ENTERPRISE
+            PropertyEncryptor encryptor;
+            PropertyDecryptor decryptor;
+#endif
+        };
+        std::shared_ptr<ReplicatorContext> _context;
         
         CBL_REFCOUNTED_WITHOUT_COPY_MOVE_BOILERPLATE(Replicator, RefCounted, CBLReplicator)
         
@@ -478,14 +587,14 @@ namespace cbl {
             collection-configuration map. */
         Replicator(const Replicator &other) noexcept
         :RefCounted(other)
-        ,_collectionMap(other._collectionMap)
+        ,_context(other._context)
         { }
 
         /** Move constructor. Takes over `other`'s \ref CBLReplicator handle and
             collection-configuration map, leaving `other` empty. */
         Replicator(Replicator &&other) noexcept
         :RefCounted((RefCounted&&)other)
-        ,_collectionMap(std::move(other._collectionMap))
+        ,_context(std::move(other._context))
         { }
 
         /** Copy assignment. Releases the currently-referenced handle (if any), then
@@ -493,7 +602,7 @@ namespace cbl {
             incremented) and share its collection-configuration map. */
         Replicator& operator=(const Replicator &other) noexcept {
             RefCounted::operator=(other);
-            _collectionMap = other._collectionMap;
+            _context = other._context;
             return *this;
         }
 
@@ -502,7 +611,7 @@ namespace cbl {
             map; `other` is left empty. */
         Replicator& operator=(Replicator &&other) noexcept {
             RefCounted::operator=((RefCounted&&)other);
-            _collectionMap = std::move(other._collectionMap);
+            _context = std::move(other._context);
             return *this;
         }
         
@@ -511,7 +620,7 @@ namespace cbl {
             returns false). */
         void clear() {
             RefCounted::clear();
-            _collectionMap.reset();
+            _context.reset();
         }
     };
 }

--- a/test/ReplicatorPropEncTest.cc
+++ b/test/ReplicatorPropEncTest.cc
@@ -866,7 +866,7 @@ TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest, "Key ID and Algorithm", "[Rep
     }
 }
 
-TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest, "Encrypt and decrypt with multipe collections", "[Replicator][Encryptable]") {
+TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest, "Encrypt and decrypt with multiple collections", "[Replicator][Encryptable]") {
     auto c1x = CreateCollection(db.ref(), "colA", "scopeA");
     auto c2x = CreateCollection(db.ref(), "colB", "scopeA");
     

--- a/test/ReplicatorPropEncTest_Cpp.cc
+++ b/test/ReplicatorPropEncTest_Cpp.cc
@@ -1,0 +1,632 @@
+//
+// ReplicatorPropEncTest_Cpp.cc
+//
+// Copyright © 2026 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "CBLTest_Cpp.hh"
+#include "fleece/Fleece.hh"
+#include "fleece/Mutable.hh"
+#include <atomic>
+#include <string>
+#include <chrono>
+#include <thread>
+#include <unordered_map>
+
+#include "cbl++/CouchbaseLite.hh"
+
+#ifdef COUCHBASE_ENTERPRISE     // Property Encryption is an EE feature.
+
+using namespace std;
+using namespace fleece;
+using namespace cbl;
+
+class ReplicatorPropertyEncryptionTest_Cpp : public CBLTest_Cpp {
+public:
+    Database otherDB;
+    Collection otherDBDefaultCol;
+    Replicator repl;
+
+    struct ReplicatedDoc {
+        CBLDocumentFlags flags {};
+        CBLError error {};
+    };
+    unordered_map<string, ReplicatedDoc> replicatedDocs;
+
+    ReplicatorPropertyEncryptionTest_Cpp()
+    :otherDB(openDatabaseNamed("otherDB", true))
+    ,otherDBDefaultCol(otherDB.getDefaultCollection())
+    {}
+
+    ~ReplicatorPropertyEncryptionTest_Cpp() {
+        otherDB.close();
+        otherDB = nullptr;
+    }
+
+    void replicate(ReplicatorConfiguration& config, bool resetCheckpoint = false) {
+        repl = Replicator(config);
+        doReplicate(resetCheckpoint);
+    }
+
+    // Restart the current repl (must already be set via replicate(config)).
+    void replicate(bool resetCheckpoint) {
+        REQUIRE(repl);
+        doReplicate(resetCheckpoint);
+    }
+
+private:
+    void doReplicate(bool resetCheckpoint) {
+        auto docListener = repl.addDocumentReplicationListener(
+            [this](Replicator, bool, const vector<CBLReplicatedDocument>& docs) {
+                for (auto& doc : docs) {
+                    string scopeStr = slice(doc.scope).asString();
+                    string collStr  = slice(doc.collection).asString();
+                    string docIDStr = slice(doc.ID).asString();
+                    string key = (scopeStr == "_default" && collStr == "_default")
+                                 ? docIDStr
+                                 : scopeStr + "." + collStr + "." + docIDStr;
+                    ReplicatedDoc rdoc {};
+                    rdoc.flags = doc.flags;
+                    rdoc.error = doc.error;
+                    replicatedDocs[key] = rdoc;
+                }
+            });
+        repl.start(resetCheckpoint);
+        using clock = chrono::high_resolution_clock;
+        using seconds = chrono::duration<double, ratio<1,1>>;
+        auto t0 = clock::now();
+        CBLReplicatorStatus status {};
+        while (chrono::duration_cast<seconds>(clock::now() - t0).count() < 30.0) {
+            status = repl.status();
+            if (status.activity == kCBLReplicatorIdle)
+                repl.stop();
+            else if (status.activity == kCBLReplicatorStopped)
+                break;
+            this_thread::sleep_for(100ms);
+        }
+        CHECK(status.activity == kCBLReplicatorStopped);
+    }
+};
+
+TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest_Cpp, "C++ No encryptor : crypto error",
+                 "[Replicator][Encryptable]") {
+    MutableDocument doc("doc1");
+    Encryptable secret("Secret 1");
+
+    secret.setInto(doc.properties(), "secret1"_sl);
+    defaultCollection.saveDocument(doc);
+
+    auto config = ReplicatorConfiguration(
+        { CollectionConfiguration(defaultCollection) },
+        Endpoint::databaseEndpoint(otherDB));
+    config.replicatorType = kCBLReplicatorTypePushAndPull;
+
+    {
+        ExpectingExceptions x;
+        replicate(config);
+    }
+
+    CHECK(replicatedDocs.size() == 1);
+    CHECK(replicatedDocs["doc1"].error.code == kCBLErrorCrypto);
+    CHECK(replicatedDocs["doc1"].error.domain == kCBLDomain);
+    CHECK(!otherDBDefaultCol.getDocument("doc1"));
+}
+
+TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest_Cpp, "C++ No decryptor : ok",
+                 "[Replicator][Encryptable]") {
+    // --- Phase 1: push with encryptor, no decryptor ---
+    {
+        MutableDocument doc("doc1");
+        Encryptable secret("Secret 1");
+        secret.setInto(doc.properties(), "secret1"_sl);
+        defaultCollection.saveDocument(doc);
+
+        auto config = ReplicatorConfiguration(
+            { CollectionConfiguration(defaultCollection) },
+            Endpoint::databaseEndpoint(otherDB));
+        config.replicatorType = kCBLReplicatorTypePushAndPull;
+        config.documentPropertyEncryptor = [](fleece::slice,
+                                              fleece::slice,
+                                              fleece::slice,
+                                              fleece::Dict,
+                                              fleece::slice,
+                                              fleece::slice input) -> EncryptionResult {
+            alloc_slice ciphertext(input);
+            for (size_t i = 0; i < input.size; ++i)
+                (uint8_t&)ciphertext[i] = ciphertext[i] ^ 'K';
+            return {ciphertext};
+        };
+        replicate(config);
+
+        Document otherDoc = otherDBDefaultCol.getDocument("doc1");
+        REQUIRE(otherDoc);
+        CHECK(otherDoc.properties().toJSON(false, true).asString() ==
+              "{\"encrypted$secret1\":{\"alg\":\"CB_MOBILE_CUSTOM\",\"ciphertext\":\"aRguKDkuP2t6aQ==\"}}");
+    }
+
+    // --- Phase 2: pull with no decryptor — encrypted form arrives as-is ---
+    {
+        replicatedDocs.clear();
+        resetDatabase(true);
+
+        auto config = ReplicatorConfiguration(
+            { CollectionConfiguration(defaultCollection) },
+            Endpoint::databaseEndpoint(otherDB));
+        config.replicatorType = kCBLReplicatorTypePushAndPull;
+        replicate(config);
+
+        Document doc = defaultCollection.getDocument("doc1");
+        REQUIRE(doc);
+        CHECK(doc.properties().toJSON(false, true).asString() ==
+              "{\"encrypted$secret1\":{\"alg\":\"CB_MOBILE_CUSTOM\",\"ciphertext\":\"aRguKDkuP2t6aQ==\"}}");
+    }
+}
+
+TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest_Cpp, "C++ Skip encryption : crypto error",
+                 "[Replicator][Encryptable]") {
+    MutableDocument doc("doc1");
+    Encryptable secret("Secret 1");
+    secret.setInto(doc.properties(), "secret1"_sl);
+    defaultCollection.saveDocument(doc);
+
+    auto config = ReplicatorConfiguration(
+        { CollectionConfiguration(defaultCollection) },
+        Endpoint::databaseEndpoint(otherDB));
+    config.replicatorType = kCBLReplicatorTypePushAndPull;
+    config.documentPropertyEncryptor = [](fleece::slice,
+                                          fleece::slice,
+                                          fleece::slice,
+                                          fleece::Dict,
+                                          fleece::slice,
+                                          fleece::slice) -> EncryptionResult {
+        return {};  // empty ciphertext = skip → crypto error
+    };
+
+    {
+        ExpectingExceptions x;
+        replicate(config);
+    }
+
+    CHECK(replicatedDocs.size() == 1);
+    CHECK(replicatedDocs["doc1"].error.code == kCBLErrorCrypto);
+    CHECK(replicatedDocs["doc1"].error.domain == kCBLDomain);
+    CHECK(!otherDBDefaultCol.getDocument("doc1"));
+}
+
+TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest_Cpp, "C++ Skip decryption : ok",
+                 "[Replicator][Encryptable]") {
+    // --- Phase 1: push with encryptor ---
+    {
+        MutableDocument doc("doc1");
+        Encryptable secret("Secret 1");
+        secret.setInto(doc.properties(), "secret1"_sl);
+        defaultCollection.saveDocument(doc);
+
+        auto config = ReplicatorConfiguration(
+            { CollectionConfiguration(defaultCollection) },
+            Endpoint::databaseEndpoint(otherDB));
+        config.replicatorType = kCBLReplicatorTypePushAndPull;
+        config.documentPropertyEncryptor = [](fleece::slice, fleece::slice, fleece::slice,
+                                              fleece::Dict, fleece::slice,
+                                              fleece::slice input) -> EncryptionResult {
+            alloc_slice ciphertext(input);
+            for (size_t i = 0; i < input.size; ++i)
+                (uint8_t&)ciphertext[i] = ciphertext[i] ^ 'K';
+            return {ciphertext};
+        };
+        replicate(config);
+
+        Document otherDoc = otherDBDefaultCol.getDocument("doc1");
+        REQUIRE(otherDoc);
+        CHECK(otherDoc.properties().toJSON(false, true).asString() ==
+              "{\"encrypted$secret1\":{\"alg\":\"CB_MOBILE_CUSTOM\",\"ciphertext\":\"aRguKDkuP2t6aQ==\"}}");
+    }
+
+    // --- Phase 2: pull with decryptor that skips — encrypted form arrives as-is ---
+    {
+        replicatedDocs.clear();
+        resetDatabase(true);
+
+        auto config = ReplicatorConfiguration(
+            { CollectionConfiguration(defaultCollection) },
+            Endpoint::databaseEndpoint(otherDB));
+        config.replicatorType = kCBLReplicatorTypePushAndPull;
+        config.documentPropertyDecryptor = [](fleece::slice, fleece::slice, fleece::slice,
+                                              fleece::Dict, fleece::slice, fleece::slice,
+                                              std::optional<std::string_view>, std::optional<std::string_view>) -> DecryptionResult {
+            return {};  // empty plaintext = skip → leave encrypted as-is
+        };
+        replicate(config);
+
+        Document doc = defaultCollection.getDocument("doc1");
+        REQUIRE(doc);
+        CHECK(doc.properties().toJSON(false, true).asString() ==
+              "{\"encrypted$secret1\":{\"alg\":\"CB_MOBILE_CUSTOM\",\"ciphertext\":\"aRguKDkuP2t6aQ==\"}}");
+    }
+}
+
+TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest_Cpp, "C++ Encryption error",
+                 "[Replicator][Encryptable]") {
+    MutableDocument doc("doc1");
+    Encryptable secret("Secret 1");
+    secret.setInto(doc.properties(), "secret1"_sl);
+    defaultCollection.saveDocument(doc);
+
+    CBLError encryptionError {};
+    CBLError expectedDocError {};
+    bool willRetryToSyncAgain = false;
+
+    SECTION("503 Error") {
+        encryptionError = {kCBLWebSocketDomain, 503};
+        expectedDocError = encryptionError;
+        willRetryToSyncAgain = true;
+    }
+    SECTION("Crypto Error") {
+        encryptionError = {kCBLDomain, kCBLErrorCrypto};
+        expectedDocError = encryptionError;
+    }
+    SECTION("Other Error") {
+        encryptionError = {kCBLDomain, kCBLErrorUnexpectedError};
+        expectedDocError = encryptionError;
+    }
+
+    // --- First replication: encryptor returns an error ---
+    {
+        auto config = ReplicatorConfiguration(
+            { CollectionConfiguration(defaultCollection) },
+            Endpoint::databaseEndpoint(otherDB));
+        config.replicatorType = kCBLReplicatorTypePush;
+        config.documentPropertyEncryptor = [encryptionError](fleece::slice, fleece::slice,
+                                                              fleece::slice, fleece::Dict,
+                                                              fleece::slice,
+                                                              fleece::slice) -> EncryptionResult {
+            EncryptionResult r;
+            r.error = encryptionError;
+            return r;
+        };
+        ExpectingExceptions x;
+        replicate(config);
+    }
+
+    CHECK(replicatedDocs.size() == 1);
+    CHECK(replicatedDocs["doc1"].error.domain == expectedDocError.domain);
+    CHECK(replicatedDocs["doc1"].error.code == expectedDocError.code);
+    CHECK(!otherDBDefaultCol.getDocument("doc1"));
+
+    // --- Second replication: no error ---
+    replicatedDocs.clear();
+    {
+        auto config = ReplicatorConfiguration(
+            { CollectionConfiguration(defaultCollection) },
+            Endpoint::databaseEndpoint(otherDB));
+        config.replicatorType = kCBLReplicatorTypePush;
+        config.documentPropertyEncryptor = [](fleece::slice, fleece::slice, fleece::slice,
+                                              fleece::Dict, fleece::slice,
+                                              fleece::slice input) -> EncryptionResult {
+            alloc_slice ciphertext(input);
+            for (size_t i = 0; i < input.size; ++i)
+                (uint8_t&)ciphertext[i] = ciphertext[i] ^ 'K';
+            return {ciphertext};
+        };
+        replicate(config);
+    }
+
+    if (willRetryToSyncAgain) {
+        CHECK(replicatedDocs.size() == 1);
+        CHECK(replicatedDocs["doc1"].error.domain == 0);
+        CHECK(replicatedDocs["doc1"].error.code == 0);
+        CHECK(otherDBDefaultCol.getDocument("doc1"));
+    } else {
+        CHECK(replicatedDocs.size() == 0);
+        CHECK(!otherDBDefaultCol.getDocument("doc1"));
+    }
+}
+
+TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest_Cpp, "C++ Decryption error",
+                 "[Replicator][Encryptable]") {
+    // --- Phase 1: push with encryptor so otherDB has the encrypted doc ---
+    {
+        MutableDocument doc("doc1");
+        Encryptable secret("Secret 1");
+        secret.setInto(doc.properties(), "secret1"_sl);
+        defaultCollection.saveDocument(doc);
+
+        auto config = ReplicatorConfiguration(
+            { CollectionConfiguration(defaultCollection) },
+            Endpoint::databaseEndpoint(otherDB));
+        config.replicatorType = kCBLReplicatorTypePushAndPull;
+        config.documentPropertyEncryptor = [](fleece::slice, fleece::slice, fleece::slice,
+                                              fleece::Dict, fleece::slice,
+                                              fleece::slice input) -> EncryptionResult {
+            alloc_slice ciphertext(input);
+            for (size_t i = 0; i < input.size; ++i)
+                (uint8_t&)ciphertext[i] = ciphertext[i] ^ 'K';
+            return {ciphertext};
+        };
+        config.documentPropertyDecryptor = [](fleece::slice, fleece::slice, fleece::slice,
+                                              fleece::Dict, fleece::slice, fleece::slice input,
+                                              std::optional<std::string_view>, std::optional<std::string_view>) -> DecryptionResult {
+            alloc_slice plaintext(input);
+            for (size_t i = 0; i < input.size; ++i)
+                (uint8_t&)plaintext[i] = plaintext[i] ^ 'K';
+            return {plaintext};
+        };
+        replicate(config);
+
+        CHECK(otherDBDefaultCol.getDocument("doc1"));
+    }
+
+    // --- Phase 2: reset local, pull with decryptor that errors ---
+    {
+        replicatedDocs.clear();
+        resetDatabase(true);
+
+        CBLError decryptionError {};
+        CBLError expectedDocError {};
+        bool willRetryToSyncAgain = false;
+
+        SECTION("503 Error") {
+            decryptionError = {kCBLWebSocketDomain, 503};
+            expectedDocError = decryptionError;
+            willRetryToSyncAgain = true;
+        }
+        SECTION("Crypto Error") {
+            decryptionError = {kCBLDomain, kCBLErrorCrypto};
+            expectedDocError = decryptionError;
+        }
+        SECTION("Other Error") {
+            decryptionError = {kCBLDomain, kCBLErrorUnexpectedError};
+            expectedDocError = decryptionError;
+        }
+
+        CHECK(replicatedDocs.size() == 0);
+        {
+            auto config = ReplicatorConfiguration(
+                { CollectionConfiguration(defaultCollection) },
+                Endpoint::databaseEndpoint(otherDB));
+            config.replicatorType = kCBLReplicatorTypePushAndPull;
+            config.documentPropertyDecryptor = [decryptionError](fleece::slice, fleece::slice,
+                                                                  fleece::slice, fleece::Dict,
+                                                                  fleece::slice, fleece::slice,
+                                                                  std::optional<std::string_view>,
+                                                                  std::optional<std::string_view>) -> DecryptionResult {
+                DecryptionResult r;
+                r.error = decryptionError;
+                return r;
+            };
+            ExpectingExceptions x;
+            replicate(config);
+        }
+
+        CHECK(replicatedDocs.size() == 1);
+        CHECK(replicatedDocs["doc1"].error.domain == expectedDocError.domain);
+        CHECK(replicatedDocs["doc1"].error.code == expectedDocError.code);
+        CHECK(!defaultCollection.getDocument("doc1"));
+
+        // --- Third replication: no error ---
+        replicatedDocs.clear();
+        {
+            auto config = ReplicatorConfiguration(
+                { CollectionConfiguration(defaultCollection) },
+                Endpoint::databaseEndpoint(otherDB));
+            config.replicatorType = kCBLReplicatorTypePushAndPull;
+            config.documentPropertyDecryptor = [](fleece::slice, fleece::slice, fleece::slice,
+                                                  fleece::Dict, fleece::slice, fleece::slice input,
+                                                  std::optional<std::string_view>, std::optional<std::string_view>) -> DecryptionResult {
+                alloc_slice plaintext(input);
+                for (size_t i = 0; i < input.size; ++i)
+                    (uint8_t&)plaintext[i] = plaintext[i] ^ 'K';
+                return {plaintext};
+            };
+            replicate(config);
+        }
+
+        if (willRetryToSyncAgain) {
+            CHECK(replicatedDocs.size() == 1);
+            CHECK(replicatedDocs["doc1"].error.domain == 0);
+            CHECK(replicatedDocs["doc1"].error.code == 0);
+            CHECK(defaultCollection.getDocument("doc1"));
+        } else {
+            CHECK(replicatedDocs.size() == 0);
+            CHECK(!defaultCollection.getDocument("doc1"));
+        }
+    }
+}
+
+TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest_Cpp, "C++ Encrypt already encrypted values",
+                 "[Replicator][Encryptable]") {
+    // Build a doc with a manually-constructed already-encrypted dict so the encryptor should skip it.
+    MutableDocument doc("doc1");
+    fleece::MutableDict secret = fleece::MutableDict::newDict();
+    secret["alg"_sl]        = "CB_MOBILE_CUSTOM"_sl;
+    secret["ciphertext"_sl] = "aRguKDkuP2t6aQ=="_sl;
+    doc.properties()["encrypted$secret"_sl] = secret;
+    defaultCollection.saveDocument(doc);
+
+    int encryptCount = 0;
+    auto config = ReplicatorConfiguration(
+        { CollectionConfiguration(defaultCollection) },
+        Endpoint::databaseEndpoint(otherDB));
+    config.replicatorType = kCBLReplicatorTypePushAndPull;
+    config.documentPropertyEncryptor = [&encryptCount](fleece::slice, fleece::slice, fleece::slice,
+                                                        fleece::Dict, fleece::slice,
+                                                        fleece::slice input) -> EncryptionResult {
+        ++encryptCount;
+        alloc_slice ciphertext(input);
+        for (size_t i = 0; i < input.size; ++i)
+            (uint8_t&)ciphertext[i] = ciphertext[i] ^ 'K';
+        return {ciphertext};
+    };
+    replicate(config);
+
+    CHECK(encryptCount == 0);
+    auto otherDoc = otherDBDefaultCol.getDocument("doc1");
+    REQUIRE(otherDoc);
+    CHECK(otherDoc.properties()["encrypted$secret"_sl].asDict().toJSON(false, true) ==
+          "{\"alg\":\"CB_MOBILE_CUSTOM\",\"ciphertext\":\"aRguKDkuP2t6aQ==\"}");
+}
+
+TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest_Cpp, "C++ Key ID and Algorithm",
+                 "[Replicator][Encryptable]") {
+    // Phase 1: encrypt with custom algorithm and key ID, verify in otherDB
+    {
+        MutableDocument doc("doc1");
+        Encryptable secret("Secret 1");
+        secret.setInto(doc.properties(), "secret1"_sl);
+        defaultCollection.saveDocument(doc);
+
+        int encryptCount = 0;
+        auto config = ReplicatorConfiguration(
+            { CollectionConfiguration(defaultCollection) },
+            Endpoint::databaseEndpoint(otherDB));
+        config.replicatorType = kCBLReplicatorTypePushAndPull;
+        config.documentPropertyEncryptor = [&encryptCount](fleece::slice, fleece::slice, fleece::slice,
+                                                            fleece::Dict, fleece::slice,
+                                                            fleece::slice input) -> EncryptionResult {
+            ++encryptCount;
+            alloc_slice ciphertext(input);
+            for (size_t i = 0; i < input.size; ++i)
+                (uint8_t&)ciphertext[i] = ciphertext[i] ^ 'K';
+            return {ciphertext, "XOR_ALG", "MY_KEY_ID"};
+        };
+        replicate(config);
+
+        CHECK(encryptCount == 1);
+        auto otherDoc = otherDBDefaultCol.getDocument("doc1");
+        REQUIRE(otherDoc);
+        CHECK(otherDoc.properties().toJSON(false, true) ==
+              "{\"encrypted$secret1\":{\"alg\":\"XOR_ALG\",\"ciphertext\":\"aRguKDkuP2t6aQ==\",\"kid\":\"MY_KEY_ID\"}}");
+    }
+
+    // Phase 2: reset local, pull with decryptor that checks algorithm and key ID
+    {
+        replicatedDocs.clear();
+        resetDatabase(true);
+
+        std::atomic<int> decryptCount{0};
+        std::optional<std::string> capturedAlgorithm, capturedKeyID;
+        auto config = ReplicatorConfiguration(
+            { CollectionConfiguration(defaultCollection) },
+            Endpoint::databaseEndpoint(otherDB));
+        config.replicatorType = kCBLReplicatorTypePushAndPull;
+        config.documentPropertyDecryptor = [&decryptCount, &capturedAlgorithm, &capturedKeyID](
+                                               fleece::slice, fleece::slice, fleece::slice,
+                                               fleece::Dict, fleece::slice, fleece::slice input,
+                                               std::optional<std::string_view> algorithm,
+                                               std::optional<std::string_view> keyID) -> DecryptionResult {
+            ++decryptCount;
+            if (algorithm) capturedAlgorithm = std::string(*algorithm);
+            if (keyID)     capturedKeyID     = std::string(*keyID);
+            alloc_slice plaintext(input);
+            for (size_t i = 0; i < input.size; ++i)
+                (uint8_t&)plaintext[i] = plaintext[i] ^ 'K';
+            return {plaintext};
+        };
+        replicate(config);
+
+        CHECK(decryptCount.load() == 1);
+        CHECK(capturedAlgorithm == "XOR_ALG");
+        CHECK(capturedKeyID == "MY_KEY_ID");
+        auto localDoc = defaultCollection.getDocument("doc1");
+        REQUIRE(localDoc);
+        CHECK(localDoc.properties().toJSON(false, true) ==
+              "{\"secret1\":{\"@type\":\"encryptable\",\"value\":\"Secret 1\"}}");
+    }
+}
+
+TEST_CASE_METHOD(ReplicatorPropertyEncryptionTest_Cpp, "C++ Encrypt and decrypt with multiple collections",
+                 "[Replicator][Encryptable]") {
+    auto c1x = db.createCollection("colA", "scopeA");
+    auto c2x = db.createCollection("colB", "scopeA");
+    auto c1y = otherDB.createCollection("colA", "scopeA");
+    auto c2y = otherDB.createCollection("colB", "scopeA");
+
+    auto createEncryptedDoc = [](Collection& col, const char* docID) {
+        MutableDocument doc(docID);
+        Encryptable secret("Secret 1");
+        secret.setInto(doc.properties(), "secret"_sl);
+        col.saveDocument(doc);
+    };
+    createEncryptedDoc(c1x, "doc1");
+    createEncryptedDoc(c2x, "doc2");
+
+    PropertyEncryptor encryptor = [](fleece::slice scope, fleece::slice collection,
+                                     fleece::slice docID, fleece::Dict, fleece::slice,
+                                     fleece::slice input) -> EncryptionResult {
+        CHECK(scope == "scopeA"_sl);
+        if (collection == "colA"_sl)
+            CHECK(docID == "doc1"_sl);
+        else if (collection == "colB"_sl)
+            CHECK(docID == "doc2"_sl);
+        else
+            FAIL("Unexpected collection in encryptor");
+        alloc_slice ciphertext(input);
+        for (size_t i = 0; i < input.size; ++i)
+            (uint8_t&)ciphertext[i] = ciphertext[i] ^ 'K';
+        return {ciphertext};
+    };
+
+    PropertyDecryptor decryptor = [](fleece::slice scope, fleece::slice collection,
+                                     fleece::slice docID, fleece::Dict, fleece::slice,
+                                     fleece::slice input, std::optional<std::string_view>, std::optional<std::string_view>) -> DecryptionResult {
+        CHECK(scope == "scopeA"_sl);
+        if (collection == "colA"_sl)
+            CHECK(docID == "doc1"_sl);
+        else if (collection == "colB"_sl)
+            CHECK(docID == "doc2"_sl);
+        else
+            FAIL("Unexpected collection in decryptor");
+        alloc_slice plaintext(input);
+        for (size_t i = 0; i < input.size; ++i)
+            (uint8_t&)plaintext[i] = plaintext[i] ^ 'K';
+        return {plaintext};
+    };
+
+    auto config = ReplicatorConfiguration(
+        { CollectionConfiguration(c1x), CollectionConfiguration(c2x) },
+        Endpoint::databaseEndpoint(otherDB));
+    config.replicatorType = kCBLReplicatorTypePushAndPull;
+    config.documentPropertyEncryptor = encryptor;
+    config.documentPropertyDecryptor = decryptor;
+
+    replicate(config);
+
+    auto doc1y = c1y.getDocument("doc1");
+    REQUIRE(doc1y);
+    CHECK(doc1y.properties().toJSON(false, true) ==
+          "{\"encrypted$secret\":{\"alg\":\"CB_MOBILE_CUSTOM\",\"ciphertext\":\"aRguKDkuP2t6aQ==\"}}");
+
+    auto doc2y = c2y.getDocument("doc2");
+    REQUIRE(doc2y);
+    CHECK(doc2y.properties().toJSON(false, true) ==
+          "{\"encrypted$secret\":{\"alg\":\"CB_MOBILE_CUSTOM\",\"ciphertext\":\"aRguKDkuP2t6aQ==\"}}");
+
+    // Purge local docs and pull again with reset checkpoint:
+    c1x.purgeDocument("doc1");
+    c2x.purgeDocument("doc2");
+    replicate(true);
+
+    auto doc1x = c1x.getDocument("doc1");
+    REQUIRE(doc1x);
+    CHECK(doc1x.properties().toJSON(false, true) ==
+          "{\"secret\":{\"@type\":\"encryptable\",\"value\":\"Secret 1\"}}");
+
+    auto doc2x = c2x.getDocument("doc2");
+    REQUIRE(doc2x);
+    CHECK(doc2x.properties().toJSON(false, true) ==
+          "{\"secret\":{\"@type\":\"encryptable\",\"value\":\"Secret 1\"}}");
+}
+
+#endif  // COUCHBASE_ENTERPRISE

--- a/test/cmake/test_source_files.cmake
+++ b/test/cmake/test_source_files.cmake
@@ -34,6 +34,7 @@ function(set_test_source_files)
         ${T_DIR}/ReplicatorCollectionTest_Cpp.cc
         ${T_DIR}/ReplicatorEETest.cc
         ${T_DIR}/ReplicatorPropEncTest.cc
+        ${T_DIR}/ReplicatorPropEncTest_Cpp.cc
         ${T_DIR}/ReplicatorTest.cc
         ${T_DIR}/TLSIdentityTest.cc
         ${T_DIR}/URLEndpointListenerTest.cc


### PR DESCRIPTION
Cherry-picked from CBL-8521, Add replicator's document property encryption to the C++ API
                   CBL-8539, Add acceptOnlySelfSignedServerCertificate to ReplicatorConfiguration of the C++ API

Add ReplicatorPropEncTest_Cpp.cc with C++ API equivalents of all property encryption replicator tests: no encryptor, no/skip decryptor, encryption/decryption errors, key ID and algorithm, and multi-collection.

Also tidy up the C++ encryption API in Replicator.hh:
- Types EncryptionResult, DecryptionResult, used to bridge C++ std::function and C function.
- EncryptionResult::algorithm and keyID: std::optional<std::string>
- PropertyDecryptor algorithm and keyID params: fleece::slice → std::optional<std::string_view>
- Add acceptOnlySelfSignedServerCertificate to ReplicatorConfiguration (EE)