### PR TITLE
CBL-8559: Serialize log outputs to cout/cerr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       shell: bash
       run: |
         pushd build/test
-        ./CBL_C_Tests -r list
+        ./CBL_C_Tests -r quiet
         popd
 
     - name: Test On Windows

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -263,7 +263,7 @@ typedef struct {
     //-- Required fields:
     
     /** The collections to replicate with the target's endpoint (Required).  */
-    CBLCollectionConfiguration* collections;
+    CBLCollectionConfiguration* _cbl_nullable collections;
     
     /** The number of collections (Required).
         Must match the number of items in `collections`. */

--- a/jenkins/ci_build_unix.sh
+++ b/jenkins/ci_build_unix.sh
@@ -78,7 +78,7 @@ fi
 
 if [[ -z ${SKIP_TESTS} ]] && [[ ${EDITION} == 'enterprise' ]]; then
     cd ${WORKSPACE}/build_release/${project_dir}/test
-    ./CBL_C_Tests || exit 1
+    ./CBL_C_Tests -r quiet || exit 1
 fi
 
 cd ${WORKSPACE}

--- a/jenkins/jenkins_unix.sh
+++ b/jenkins/jenkins_unix.sh
@@ -53,7 +53,7 @@ make -j `expr $core_count + 1`
 
 # Run Tests
 pushd test > /dev/null
-./CBL_C_Tests -r list
+./CBL_C_Tests -r quiet
 popd > /dev/null
 
 popd > /dev/null

--- a/src/CBLLogSinks.cc
+++ b/src/CBLLogSinks.cc
@@ -43,6 +43,7 @@ CBLFileLogSink CBLLogSinks::_sFileSink { kCBLLogNone, kFLSliceNull };
 alloc_slice CBLLogSinks::_sLogFileDir;
 
 std::shared_mutex CBLLogSinks::_sMutex;
+std::mutex        CBLLogSinks::_sStreamOutputMutex;
 
 static const char* kC4LogDomains[] = { "DB", "Query", "Sync", "WS", "Listener", "SyncBusy",
                                        "Changes", "BLIPMessages", "TLS", "Zip" };
@@ -229,9 +230,12 @@ void CBLLogSinks::logToConsoleLogSink(CBLConsoleLogSink& consoleSink,
     __android_log_write(androidLevels[(int) level], tag.c_str(), msg);
 #else
     ostream& os = level < kCBLLogWarning ? cout : cerr;
-    LogDecoder::writeTimestamp(LogDecoder::now(), os);
-    LogDecoder::writeHeader(levelName, domainName.c_str(), os);
-    os << msg << '\n';
+    {
+        std::scoped_lock lock(_sStreamOutputMutex);
+        LogDecoder::writeTimestamp(LogDecoder::now(), os);
+        LogDecoder::writeHeader(levelName, domainName.c_str(), os);
+        os << msg << '\n';
+    }
 #endif
 }
 

--- a/src/CBLLogSinks_Internal.hh
+++ b/src/CBLLogSinks_Internal.hh
@@ -59,6 +59,16 @@ private:
     static fleece::alloc_slice _sLogFileDir;
     
     static std::shared_mutex _sMutex;
+
+    // Serializes all writes to std::cout/std::cerr across threads.
+    // Two distinct benefits:
+    // 1. Production: a log entry spans multiple << writes (timestamp, header, message);
+    //    without a lock, concurrent threads interleave these into garbled output.
+    // 2. Testing (Catch2): some reporters replace cout/cerr's rdbuf with a non-thread-safe
+    //    std::ostringstream to capture output; concurrent writes without a lock cause
+    //    heap corruption (e.g. ASan heap-use-after-free during buffer reallocation).
+    // Note: Android logging uses __android_log_write (a syscall) and does not need this lock.
+    static std::mutex _sStreamOutputMutex;
     
     static const std::vector<C4LogDomain>& c4LogDomains();
     static C4LogDomain toC4LogDomain(CBLLogDomain);


### PR DESCRIPTION
The main reason is to avoid ASan error when running tests with Catch2's quiet mode. Incidentally, it fixes the unpleasant interleavings of timestampts and messages when logged concurrently in different threads.

Changed Catch2 report mode to "quiet" for unix builds. For Windows, Catch2 will hang with quiet mode.

Also, mark CBLReplicatorConfiguration::collections as nullable for cases when collectionCount == 0.