### PR TITLE
CBL-8594: Add TLSIdentity to the C++ API

### DIFF
--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -16,8 +16,8 @@
 		1B7694AD2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */; };
 		1B7694AE2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */; };
 		1B7694B12DA49EB9006EEEAB /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 277CC9B122BC4E2E00B245CB /* Security.framework */; };
-		1B8BE8C4300570A500162AC5 /* TLSIdentity.hh in Headers */ = {isa = PBXBuildFile; fileRef = 1B8BE8C3300570A500162AC5 /* TLSIdentity.hh */; };
-		1B8BE8C5300570A500162AC5 /* TLSIdentity.hh in Headers */ = {isa = PBXBuildFile; fileRef = 1B8BE8C3300570A500162AC5 /* TLSIdentity.hh */; };
+		1B8BE8C4300570A500162AC5 /* TLSIdentity.hh in Headers */ = {isa = PBXBuildFile; fileRef = 1B8BE8C3300570A500162AC5 /* TLSIdentity.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B8BE8C5300570A500162AC5 /* TLSIdentity.hh in Headers */ = {isa = PBXBuildFile; fileRef = 1B8BE8C3300570A500162AC5 /* TLSIdentity.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		1B8BE8D930057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B8BE8D830057FB600162AC5 /* TLSIdentityTest_Cpp.cc */; };
 		1B8BE8DA30057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B8BE8D830057FB600162AC5 /* TLSIdentityTest_Cpp.cc */; };
 		1B8BE8DB30057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B8BE8D830057FB600162AC5 /* TLSIdentityTest_Cpp.cc */; };

--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -16,6 +16,12 @@
 		1B7694AD2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */; };
 		1B7694AE2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */; };
 		1B7694B12DA49EB9006EEEAB /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 277CC9B122BC4E2E00B245CB /* Security.framework */; };
+		1B8BE8C4300570A500162AC5 /* TLSIdentity.hh in Headers */ = {isa = PBXBuildFile; fileRef = 1B8BE8C3300570A500162AC5 /* TLSIdentity.hh */; };
+		1B8BE8C5300570A500162AC5 /* TLSIdentity.hh in Headers */ = {isa = PBXBuildFile; fileRef = 1B8BE8C3300570A500162AC5 /* TLSIdentity.hh */; };
+		1B8BE8D930057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B8BE8D830057FB600162AC5 /* TLSIdentityTest_Cpp.cc */; };
+		1B8BE8DA30057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B8BE8D830057FB600162AC5 /* TLSIdentityTest_Cpp.cc */; };
+		1B8BE8DB30057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B8BE8D830057FB600162AC5 /* TLSIdentityTest_Cpp.cc */; };
+		1B8BE8DC30057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B8BE8D830057FB600162AC5 /* TLSIdentityTest_Cpp.cc */; };
 		1BC5D9602D6E3BD10080153E /* CBLURLEndpointListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1BC5D9612D6E3BD10080153E /* CBLURLEndpointListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1BC5D9662D6E4DA60080153E /* CBLURLEndpointListener_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BC5D9652D6E4DA60080153E /* CBLURLEndpointListener_CAPI.cc */; };
@@ -568,6 +574,8 @@
 		1B4D22B42FAE496B005E24FA /* Encryptable.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Encryptable.hh; sourceTree = "<group>"; };
 		1B7694AA2DA07261006EEEAB /* TLSIdentityTest.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TLSIdentityTest.hh; sourceTree = "<group>"; };
 		1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "TLSIdentityTest+Apple.mm"; sourceTree = "<group>"; };
+		1B8BE8C3300570A500162AC5 /* TLSIdentity.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TLSIdentity.hh; sourceTree = "<group>"; };
+		1B8BE8D830057FB600162AC5 /* TLSIdentityTest_Cpp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TLSIdentityTest_Cpp.cc; sourceTree = "<group>"; };
 		1BC5D95F2D6E3BD10080153E /* CBLURLEndpointListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLURLEndpointListener.h; sourceTree = "<group>"; };
 		1BC5D9652D6E4DA60080153E /* CBLURLEndpointListener_CAPI.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CBLURLEndpointListener_CAPI.cc; sourceTree = "<group>"; };
 		1BDEBBF12FBB98A10063786B /* EncryptableTest_Cpp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EncryptableTest_Cpp.cc; sourceTree = "<group>"; };
@@ -1066,6 +1074,7 @@
 				277FEE4F21E6AB1100B60E3C /* Query.hh */,
 				400AB0522C2E66B500DB6223 /* QueryIndex.hh */,
 				27C9B5F121F7D74A0040BC45 /* Replicator.hh */,
+				1B8BE8C3300570A500162AC5 /* TLSIdentity.hh */,
 				400AB0542C2E7AC300DB6223 /* VectorIndex.hh */,
 			);
 			path = "cbl++";
@@ -1105,6 +1114,7 @@
 				1BDEBC592FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc */,
 				1B7694AB2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm */,
 				1BF21A3C2D84E419009534EC /* TLSIdentityTest.cc */,
+				1B8BE8D830057FB600162AC5 /* TLSIdentityTest_Cpp.cc */,
 				1B7694AA2DA07261006EEEAB /* TLSIdentityTest.hh */,
 				1B21A7D82D711B29000CA0D5 /* URLEndpointListenerTest.cc */,
 				1B49DBCF2DAF106F000F382E /* URLEndpointListenerTest.hh */,
@@ -1315,6 +1325,7 @@
 				1B4D22B62FAE496B005E24FA /* Encryptable.hh in Headers */,
 				27DBD0A9246CA667002FD7A7 /* CBLLog.h in Headers */,
 				405D4F8E2C34714F00221516 /* CBLQueryTypes.h in Headers */,
+				1B8BE8C4300570A500162AC5 /* TLSIdentity.hh in Headers */,
 				27984E362249A247000FE777 /* Query.hh in Headers */,
 				27984E372249A247000FE777 /* Replicator.hh in Headers */,
 			);
@@ -1371,6 +1382,7 @@
 				1B4D22B52FAE496B005E24FA /* Encryptable.hh in Headers */,
 				40B32FA12E54034500D48F37 /* CBLLog.h in Headers */,
 				40B32FA22E54034500D48F37 /* CBLQueryTypes.h in Headers */,
+				1B8BE8C5300570A500162AC5 /* TLSIdentity.hh in Headers */,
 				40B32FA32E54034500D48F37 /* Query.hh in Headers */,
 				40B32FA42E54034500D48F37 /* Replicator.hh in Headers */,
 			);
@@ -2191,6 +2203,7 @@
 				93C70D3526D01B5A0093E927 /* BlobTest.cc in Sources */,
 				FC0907E828AD763600201B07 /* DocumentTest_Cpp.cc in Sources */,
 				FC09077C28A5F3EF00201B07 /* CollectionTest_Cpp.cc in Sources */,
+				1B8BE8DA30057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */,
 				FCC063F3285BA641000C5BD7 /* DocumentTest.cc in Sources */,
 				275B358923481D0C00FE9CF0 /* CBLTest.cc in Sources */,
 				1BDEBC5A2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */,
@@ -2237,6 +2250,7 @@
 				FCD8298C283591D4004AA814 /* CollectionTest.cc in Sources */,
 				FC645E2D29088211007D5536 /* Platform_Apple.mm in Sources */,
 				1B21A7DA2D711B29000CA0D5 /* URLEndpointListenerTest.cc in Sources */,
+				1B8BE8D930057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */,
 				93C70D3426D01B5A0093E927 /* BlobTest.cc in Sources */,
 				1B7694AD2DA085F4006EEEAB /* TLSIdentityTest+Apple.mm in Sources */,
 				1BDEBC5C2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */,
@@ -2283,6 +2297,7 @@
 				40B32EEB2E53EAF600D48F37 /* CollectionTest.cc in Sources */,
 				40B32EEC2E53EAF600D48F37 /* Platform_Apple.mm in Sources */,
 				40B32EED2E53EAF600D48F37 /* URLEndpointListenerTest.cc in Sources */,
+				1B8BE8DB30057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */,
 				40B32EEE2E53EAF600D48F37 /* BlobTest.cc in Sources */,
 				40B32EEF2E53EAF600D48F37 /* TLSIdentityTest+Apple.mm in Sources */,
 				1BDEBC5B2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */,
@@ -2357,6 +2372,7 @@
 				FC645E1829085C71007D5536 /* QueryTest.cc in Sources */,
 				1BDEBC5D2FEB5E690063786B /* ReplicatorPropEncTest_Cpp.cc in Sources */,
 				FC645E0F29085C0A007D5536 /* CBLTest.cc in Sources */,
+				1B8BE8DC30057FB600162AC5 /* TLSIdentityTest_Cpp.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/include/cbl++/CouchbaseLite.hh
+++ b/include/cbl++/CouchbaseLite.hh
@@ -100,4 +100,5 @@
 #include "Query.hh"
 #include "QueryIndex.hh"
 #include "Replicator.hh"
+#include "TLSIdentity.hh"
 #include "VectorIndex.hh"

--- a/include/cbl++/TLSIdentity.hh
+++ b/include/cbl++/TLSIdentity.hh
@@ -24,6 +24,7 @@
 #include "cbl/CBLLog.h"
 #include "cbl/CBLTLSIdentity.h"
 #include "fleece/Fleece.hh"
+#include <cstring>
 #include <exception>
 #include <functional>
 #include <memory>

--- a/include/cbl++/TLSIdentity.hh
+++ b/include/cbl++/TLSIdentity.hh
@@ -21,9 +21,9 @@
 #ifdef COUCHBASE_ENTERPRISE
 
 #include "cbl++/Base.hh"
+#include "cbl/CBLLog.h"
 #include "cbl/CBLTLSIdentity.h"
 #include "fleece/Fleece.hh"
-#include <cstring>
 #include <exception>
 #include <functional>
 #include <memory>

--- a/include/cbl++/TLSIdentity.hh
+++ b/include/cbl++/TLSIdentity.hh
@@ -224,12 +224,20 @@ namespace cbl {
 
         // Shared by the publicKeyData/decrypt trampolines in createWithExternalKey: copies
         // result into output (bounded by outputMaxLen) and sets outputLen.
-        static bool copyResult(const std::optional<alloc_slice>& result, void* output, size_t outputMaxLen,
-                               size_t* outputLen) {
-            if ( !result || result->size > outputMaxLen ) return false;
-            memcpy(output, result->buf, result->size);
-            *outputLen = result->size;
-            return true;
+static bool copyResult(const std::optional<alloc_slice>& result, void* output, size_t outputMaxLen,
+                       size_t* outputLen) {
+    if ( !outputLen ) return false;
+    if ( !result ) {
+        *outputLen = 0;
+        return false;
+    }
+
+    *outputLen = result->size;
+    if ( result->size > outputMaxLen || (result->size > 0 && !output) ) return false;
+
+    if ( result->size > 0 ) memcpy(output, result->buf, result->size);
+    return true;
+}
         }
 
         // Invokes fn, catching and logging any exception it throws. Required because the C API

--- a/include/cbl++/TLSIdentity.hh
+++ b/include/cbl++/TLSIdentity.hh
@@ -24,9 +24,12 @@
 #include "cbl/CBLTLSIdentity.h"
 #include "fleece/Fleece.hh"
 #include <cstring>
+#include <exception>
+#include <functional>
+#include <memory>
 #include <optional>
+#include <string>
 #include <string_view>
-
 CBL_ASSUME_NONNULL_BEGIN
 
 namespace cbl {

--- a/include/cbl++/TLSIdentity.hh
+++ b/include/cbl++/TLSIdentity.hh
@@ -1,0 +1,478 @@
+//
+// TLSIdentity.hh
+//
+// Copyright (c) 2026 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#pragma once
+
+#ifdef COUCHBASE_ENTERPRISE
+
+#include "cbl++/Base.hh"
+#include "cbl/CBLTLSIdentity.h"
+#include "fleece/Fleece.hh"
+#include <cstring>
+#include <optional>
+#include <string_view>
+
+CBL_ASSUME_NONNULL_BEGIN
+
+namespace cbl {
+
+    /** An RSA key pair, used with \ref Cert and \ref TLSIdentity.
+        \note ENTERPRISE EDITION ONLY */
+    class KeyPair : protected RefCounted {
+    public:
+        /** Alias for the C \ref CBLSignatureDigestAlgorithm enum, used by \ref ExternalKeyHolder::SignCallback. */
+        using SignatureDigestAlgorithm = CBLSignatureDigestAlgorithm;
+
+        /** The callbacks (and optional opaque handle) needed to wrap an externally managed key
+            pair, used by \ref createWithExternalKey. Move-only: constructing a KeyPair from a
+            holder transfers ownership of it -- and, if \ref customFree is set, of \ref externalKey
+            too -- to the resulting KeyPair, or releases them immediately if creation fails.
+            @note If \ref publicKeyData, \ref decrypt, or \ref sign throws, the exception is
+                  caught and logged, and the corresponding TLS operation simply fails (as if the
+                  callback had returned `std::nullopt`) rather than propagating out of the library. */
+        struct ExternalKeyHolder {
+            /** Returns the public key as an ASN.1 DER-encoded SubjectPublicKeyInfo structure,
+                or `std::nullopt` on failure. */
+            using PublicKeyCallback = std::function<std::optional<alloc_slice>(void* ctx)>;
+
+            /** Decrypts \p input (RSA/PKCS#1 v1.5) and returns the plaintext, or `std::nullopt`
+                on failure. */
+            using DecryptCallback = std::function<std::optional<alloc_slice>(
+                    void* ctx, slice input)>;
+
+            /** Signs the already-hashed \p input and returns the signature, whose length must
+                equal the key size, or `std::nullopt` on failure. */
+            using SignCallback = std::function<std::optional<alloc_slice>(
+                    void* ctx, SignatureDigestAlgorithm digestAlgorithm, slice input)>;
+
+            /** Releases \ref externalKey. Called at most once, when the holder is destroyed --
+                normally when the owning KeyPair is released, but immediately instead if
+                \ref createWithExternalKey fails to create one. Leave `nullptr` (the default)
+                if you want to manage externalKey's lifetime yourself. */
+            using FreeCallback = std::function<void(void* ctx)>;
+
+            /** An opaque pointer passed back to every callback below, including \ref customFree. */
+            void* _cbl_nullable externalKey{nullptr};
+            PublicKeyCallback   publicKeyData;
+            DecryptCallback     decrypt;
+            SignCallback        sign;
+            FreeCallback        customFree{nullptr};
+
+            /** Constructs a holder from the given opaque key handle and callbacks.
+                @param externalKey_  See \ref externalKey.
+                @param publicKeyData_  See \ref publicKeyData.
+                @param decrypt_  See \ref decrypt.
+                @param sign_  See \ref sign.
+                @param customFree_  See \ref customFree. */
+            ExternalKeyHolder(void* externalKey_,
+                               PublicKeyCallback publicKeyData_,
+                               DecryptCallback decrypt_,
+                               SignCallback sign_,
+                               FreeCallback customFree_ =nullptr)
+                :externalKey(externalKey_)
+                ,publicKeyData(std::move(publicKeyData_))
+                ,decrypt(std::move(decrypt_))
+                ,sign(std::move(sign_))
+                ,customFree(std::move(customFree_))
+            { }
+
+            ~ExternalKeyHolder() {
+                // This destructor is implicitly noexcept, so customFree must never let an
+                // exception escape it.
+                if ( !customFree || !externalKey ) return;
+                try {
+                    customFree(externalKey);
+                } catch (const cbl::Error& error) {
+                    CBL_Log(kCBLLogDomainNetwork, kCBLLogError, "ExternalKeyHolder::customFree threw error %d/%d: %s",
+                            error.domain, error.code, error.what());
+                } catch (const std::exception& error) {
+                    CBL_Log(kCBLLogDomainNetwork, kCBLLogError, "ExternalKeyHolder::customFree threw %s", error.what());
+                } catch (...) {
+                    CBL_Log(kCBLLogDomainNetwork, kCBLLogError, "ExternalKeyHolder::customFree threw an unknown exception");
+                }
+            }
+
+            ExternalKeyHolder(ExternalKeyHolder&& other) noexcept
+                :externalKey(other.externalKey)
+                ,publicKeyData(std::move(other.publicKeyData))
+                ,decrypt(std::move(other.decrypt))
+                ,sign(std::move(other.sign))
+                ,customFree(std::move(other.customFree))
+            {
+                // Null these out so the moved-from holder's destructor doesn't also free externalKey.
+                other.externalKey = nullptr;
+                other.customFree = nullptr;
+            }
+
+            ExternalKeyHolder(const ExternalKeyHolder&) = delete;
+            ExternalKeyHolder& operator=(const ExternalKeyHolder&) = delete;
+            ExternalKeyHolder& operator=(ExternalKeyHolder&&) = delete;
+        };
+
+        /** Returns a key pair that wraps an external key pair managed by application code.
+            All private key operations (signing and decryption) are delegated to \p holder's
+            callbacks.
+            @param keySizeInBits  The size of the RSA key in bits (e.g., 2048 or 4096).
+            @param holder  The external key's callbacks and opaque handle. Ownership of the holder,
+                   and of its \ref ExternalKeyHolder::externalKey "externalKey" if it has a
+                   \ref ExternalKeyHolder::customFree "customFree" callback, transfers to the
+                   returned KeyPair -- or is released immediately if this call throws.
+            @throws cbl::Error  If the key pair cannot be created. */
+        static KeyPair createWithExternalKey(size_t keySizeInBits, ExternalKeyHolder&& holder) {
+            // Owned by this local unique_ptr until the CBLKeyPair takes ownership (see below);
+            // if creation fails, its destructor cleans this up instead of leaking it.
+            std::unique_ptr<ExternalKeyContext> context(new ExternalKeyContext{std::move(holder), keySizeInBits});
+
+            CBLExternalKeyCallbacks cCallbacks = {};
+            cCallbacks.publicKeyData = [](void* rawContext, void* output, size_t outputMaxLen,
+                                          size_t* outputLen) -> bool {
+                return invokeSafely("publicKeyData", [&] {
+                    auto& holder = ((ExternalKeyContext*)rawContext)->holder;
+                    return copyResult(holder.publicKeyData(holder.externalKey), output, outputMaxLen, outputLen);
+                });
+            };
+            cCallbacks.decrypt = [](void* rawContext, FLSlice input, void* output, size_t outputMaxLen,
+                                    size_t* outputLen) -> bool {
+                return invokeSafely("decrypt", [&] {
+                    auto& holder = ((ExternalKeyContext*)rawContext)->holder;
+                    return copyResult(holder.decrypt(holder.externalKey, input), output, outputMaxLen, outputLen);
+                });
+            };
+            cCallbacks.sign = [](void* rawContext, CBLSignatureDigestAlgorithm digestAlgorithm,
+                                 FLSlice inputData, void* outSignature) -> bool {
+                return invokeSafely("sign", [&] {
+                    auto* context = (ExternalKeyContext*)rawContext;
+                    auto& holder  = context->holder;
+                    auto  result  = holder.sign(holder.externalKey, digestAlgorithm, inputData);
+                    // The signature buffer is always exactly the key size, with no length to check
+                    // it against, so reject any mismatch rather than risk overrunning it.
+                    if ( !result || result->size != (context->keySizeInBits + 7) / 8 ) return false;
+                    memcpy(outSignature, result->buf, result->size);
+                    return true;
+                });
+            };
+            cCallbacks.free = [](void* rawContext) { delete (ExternalKeyContext*)rawContext; };
+
+            CBLError error{};
+            CBLKeyPair* kp = CBLKeyPair_CreateWithExternalKey(keySizeInBits, context.get(), cCallbacks, &error);
+            internal::check(kp != nullptr, error);
+            context.release();  // The CBLKeyPair now owns it, and will free it via cCallbacks.free.
+            return KeyPair(kp, adopt);
+        }
+
+        /** Creates an RSA key pair from private key data in PEM or DER format.
+            @param privateKeyData  The private key data, in either PEM or DER format.
+            @param passwordOrNull  The password used to decrypt the key, if any.
+            @note Only PKCS#1 format for private keys is supported.
+            @throws cbl::Error  If the key pair cannot be created. */
+        static KeyPair createWithPrivateKeyData(slice privateKeyData,
+                                                 std::optional<std::string_view> passwordOrNull =std::nullopt) {
+            slice password;
+            if ( passwordOrNull ) password = slice(*passwordOrNull);
+            CBLError error{};
+            CBLKeyPair* kp = CBLKeyPair_CreateWithPrivateKeyData(privateKeyData, password, &error);
+            internal::check(kp != nullptr, error);
+            return KeyPair(kp, adopt);
+        }
+
+        /** Returns a hex-encoded digest of the public key, or an empty string if it's not accessible. */
+        std::string publicKeyDigest() const     {return internal::asString(CBLKeyPair_PublicKeyDigest(ref()));}
+
+        /** Returns the public key data, or an empty string if it's not accessible. */
+        std::string publicKeyData() const       {return internal::asString(CBLKeyPair_PublicKeyData(ref()));}
+
+        /** Returns the private key data in DER format, or an empty string if it's not accessible
+            (e.g. for a persistent key in secure storage, or an external key). */
+        std::string privateKeyData() const      {return internal::asString(CBLKeyPair_PrivateKeyData(ref()));}
+
+    protected:
+        CBL_REFCOUNTED_BOILERPLATE(KeyPair, RefCounted, CBLKeyPair)
+
+    private:
+        friend class Cert;
+
+        struct adopt_t {};
+        inline static constexpr adopt_t adopt{};
+
+        KeyPair(CBLKeyPair* _cbl_nullable cObj, adopt_t) {_ref = (CBLRefCounted*)cObj;}
+
+        // The heap-allocated context handed to the C API by createWithExternalKey: owns the
+        // ExternalKeyHolder and remembers the key size so the sign trampoline can bounds-check
+        // against it. Deleted by the CBLExternalKeyCallbacks::free trampoline.
+        struct ExternalKeyContext {
+            ExternalKeyHolder holder;
+            size_t            keySizeInBits;
+        };
+
+        // Shared by the publicKeyData/decrypt trampolines in createWithExternalKey: copies
+        // result into output (bounded by outputMaxLen) and sets outputLen.
+        static bool copyResult(const std::optional<alloc_slice>& result, void* output, size_t outputMaxLen,
+                               size_t* outputLen) {
+            if ( !result || result->size > outputMaxLen ) return false;
+            memcpy(output, result->buf, result->size);
+            *outputLen = result->size;
+            return true;
+        }
+
+        // Invokes fn, catching and logging any exception it throws. Required because the C API
+        // invokes these trampolines from a noexcept path (litecore's
+        // ExternalKeyPair::_decrypt/_sign), where an escaping exception would call
+        // std::terminate() instead of just failing the TLS operation.
+        template <class Fn>
+        static bool invokeSafely(const char* what, Fn&& fn) noexcept {
+            try {
+                return fn();
+            } catch (const cbl::Error& error) {
+                CBL_Log(kCBLLogDomainNetwork, kCBLLogError, "ExternalKeyHolder::%s threw error %d/%d: %s",
+                        what, error.domain, error.code, error.what());
+            } catch (const std::exception& error) {
+                CBL_Log(kCBLLogDomainNetwork, kCBLLogError, "ExternalKeyHolder::%s threw %s", what, error.what());
+            } catch (...) {
+                CBL_Log(kCBLLogDomainNetwork, kCBLLogError, "ExternalKeyHolder::%s threw an unknown exception", what);
+            }
+            return false;
+        }
+    };
+
+    /** An X.509 certificate, or the first link of a certificate chain.
+        \note ENTERPRISE EDITION ONLY */
+    class Cert : protected RefCounted {
+    public:
+        /** Creates a Cert from X.509 certificate data in DER or PEM format.
+            @param certData  The certificate data, in DER or PEM format.
+            @note PEM data might consist of a series of certificates; if so, the returned Cert
+                  represents only the first, and \ref nextInChain accesses the rest.
+            @throws cbl::Error  If the certificate cannot be parsed. */
+        static Cert createWithData(slice certData) {
+            CBLError error{};
+            CBLCert* cert = CBLCert_CreateWithData(certData, &error);
+            internal::check(cert != nullptr, error);
+            return Cert(cert, adopt);
+        }
+
+        /** Returns the next certificate in the chain, or a falsy Cert if this is the last one. */
+        Cert nextInChain() const {
+            return Cert(CBLCert_CertNextInChain(ref()), adopt);
+        }
+
+        /** Returns the certificate data in DER or PEM format.
+            @param pemEncoded  If true, returns the data in PEM format; otherwise, DER format.
+            @note DER format can only encode a single certificate; if this Cert includes multiple
+                  certificates, use PEM format to preserve them all. */
+        alloc_slice data(bool pemEncoded =false) const {
+            return CBLCert_Data(ref(), pemEncoded);
+        }
+
+        /** Returns the certificate's Subject Name, an X.509 structured string of "KEY=VALUE"
+            pairs separated by commas identifying the cert's owner.
+            @note Rather than parsing this yourself, use \ref subjectNameComponent. */
+        std::string subjectName() const {
+            return internal::asString(CBLCert_SubjectName(ref()));
+        }
+
+        /** Returns a component of the certificate's Subject Name matching the given attribute key,
+            or an empty string if there is no matching component.
+            @param attributeKey  The subject name attribute key to look for, e.g. \ref kCBLCertAttrKeyCommonName. */
+        std::string subjectNameComponent(slice attributeKey) const {
+            return internal::asString(CBLCert_SubjectNameComponent(ref(), attributeKey));
+        }
+
+        /** Returns the time range during which the certificate is valid.
+            @param outCreated  On return, the date/time the cert became valid (was signed).
+            @param outExpires  On return, the date/time at which the certificate expires. */
+        void validTimespan(CBLTimestamp* _cbl_nullable outCreated,
+                            CBLTimestamp* _cbl_nullable outExpires) const {
+            CBLCert_ValidTimespan(ref(), outCreated, outExpires);
+        }
+
+        /** Returns the certificate's public key. */
+        KeyPair publicKey() const {
+            return KeyPair(CBLCert_PublicKey(ref()), KeyPair::adopt);
+        }
+
+    protected:
+        CBL_REFCOUNTED_BOILERPLATE(Cert, RefCounted, CBLCert)
+
+    private:
+        friend class TLSIdentity;
+
+        struct adopt_t {};
+        inline static constexpr adopt_t adopt{};
+
+        Cert(CBLCert* _cbl_nullable cObj, adopt_t) {_ref = (CBLRefCounted*)cObj;}
+    };
+
+    /** Identity information, including an RSA key pair and X.509 certificate chain, used for
+        server or client authentication as well as data encryption/decryption in TLS communication.
+
+        A generated self-signed identity can be persisted using a specified label in the
+        platform's secure key storage:
+        - **Apple (macOS/iOS):** The identity is stored in the Keychain.
+        - **Windows:** The identity is stored in the CNG Key Storage Provider.
+        - **Linux and Android:** Not supported -- Linux has no standard/common secure key
+          storage, and Android doesn't support native C/C++ API access to its keystore. A
+          label must not be given on these platforms.
+
+        Alternatively, \ref KeyPair::createWithExternalKey lets you implement your own
+        cryptographic operations via callbacks, enabling certificate signing and data
+        encryption/decryption using a private key kept in your preferred secure key storage,
+        without ever exposing the private key outside of it.
+
+        See \ref CBLTLSIdentity.h for further platform-specific notes.
+        \note ENTERPRISE EDITION ONLY */
+    class TLSIdentity : protected RefCounted {
+    public:
+        /** Alias for the C \ref CBLKeyUsages bitmask, specifying client and/or server authentication use. */
+        using KeyUsages = CBLKeyUsages;
+
+        /** Returns the certificate chain associated with this identity: the first certificate in
+            the chain. Use \ref Cert::nextInChain to access additional certificates. */
+        Cert certificates() const {
+            return Cert(CBLTLSIdentity_Certificates(ref()));
+        }
+
+        /** Returns the expiration date/time of the first certificate in the chain. */
+        CBLTimestamp expiration() const {
+            return CBLTLSIdentity_Expiration(ref());
+        }
+
+        /** Creates a self-signed TLS identity using the specified certificate attributes.
+            If a label is given, the identity will be persisted in the platform's secure key store
+            (Keychain on Apple platforms, or CNG Key Storage Provider on Windows).
+            @param keyUsages  The key usages for the generated identity.
+            @param attributes  A dictionary containing the certificate attributes. The Common Name
+                   (\ref kCBLCertAttrKeyCommonName) attribute is required.
+            @param validityInMilliseconds  Certificate validity duration in milliseconds.
+            @param label  The label used for persisting the identity in the platform's secure storage,
+                   or `std::nullopt` if it should not be persisted.
+            @note A label is not supported on Linux or Android platforms.
+            @throws cbl::Error  If the identity cannot be created. */
+        static TLSIdentity createIdentity(KeyUsages keyUsages,
+                                           fleece::Dict attributes,
+                                           int64_t validityInMilliseconds,
+                                           std::optional<std::string_view> label =std::nullopt) {
+            slice labelSlice;
+            if ( label ) labelSlice = slice(*label);
+            CBLError error{};
+            CBLTLSIdentity* id = CBLTLSIdentity_CreateIdentity(keyUsages, attributes,
+                                                                validityInMilliseconds, labelSlice, &error);
+            internal::check(id != nullptr, error);
+            return TLSIdentity(id, adopt);
+        }
+
+        /** Creates a self-signed TLS identity using the provided RSA key pair and certificate attributes.
+            @param keyUsages  The key usages for the generated identity.
+            @param keypair  The RSA key pair to be used for generating the TLS identity.
+            @param attributes  A dictionary containing the certificate attributes. The Common Name
+                   (\ref kCBLCertAttrKeyCommonName) attribute is required.
+            @param validityInMilliseconds  Certificate validity duration in milliseconds.
+            @throws cbl::Error  If the identity cannot be created. */
+        static TLSIdentity createIdentity(KeyUsages keyUsages,
+                                           const KeyPair& keypair,
+                                           fleece::Dict attributes,
+                                           int64_t validityInMilliseconds) {
+            CBLError error{};
+            CBLTLSIdentity* id = CBLTLSIdentity_CreateIdentityWithKeyPair(keyUsages, keypair.ref(), attributes,
+                                                                          validityInMilliseconds, &error);
+            internal::check(id != nullptr, error);
+            return TLSIdentity(id, adopt);
+        }
+
+        /** Returns a TLS identity built from an existing RSA key pair and certificate chain.
+            The certificate chain is used as-is; the leaf certificate is not re-signed.
+            @param keypair  The RSA keypair to be associated with the identity.
+            @param cert  The certificate chain.
+            @throws cbl::Error  If the identity cannot be created. */
+        static TLSIdentity identityWithKeyPairAndCerts(const KeyPair& keypair, const Cert& cert) {
+            CBLError error{};
+            CBLTLSIdentity* id = CBLTLSIdentity_IdentityWithKeyPairAndCerts(keypair.ref(), cert.ref(), &error);
+            internal::check(id != nullptr, error);
+            return TLSIdentity(id, adopt);
+        }
+
+#if !defined(__linux__) && !defined(__ANDROID__)
+        /** Deletes the TLS identity associated with the given persistent label from the platform's
+            keystore (Keychain on Apple platforms, or CNG Key Storage Provider on Windows).
+            @param label  The persistent label associated with the identity to be deleted.
+            @return  true if the identity was deleted, or false if no such identity exists.
+            @note Not supported on Linux or Android platforms.
+            @throws cbl::Error  If deletion fails for a reason other than the identity not existing. */
+        static bool deleteIdentityWithLabel(std::string_view label) {
+            CBLError error{};
+            bool deleted = CBLTLSIdentity_DeleteIdentityWithLabel(slice(label), &error);
+            internal::check(deleted || error.code == 0, error);
+            return deleted;
+        }
+
+        /** Retrieves the TLS identity associated with the given persistent label from the platform's
+            keystore (Keychain on Apple platforms, or CNG Key Storage Provider on Windows).
+            @param label  The persistent label associated with the identity.
+            @return  The identity, or a falsy TLSIdentity if no such identity exists.
+            @note Not supported on Linux or Android platforms.
+            @throws cbl::Error  If the lookup fails for a reason other than the identity not existing. */
+        static TLSIdentity identityWithLabel(std::string_view label) {
+            CBLError error{};
+            CBLTLSIdentity* id = CBLTLSIdentity_IdentityWithLabel(slice(label), &error);
+            internal::check(id != nullptr || error.code == 0, error);
+            return TLSIdentity(id, adopt);
+        }
+
+        /** Returns an existing TLS identity associated with the provided certificate chain in the
+            keystore (Keychain on Apple platforms, or CNG Key Storage Provider on Windows). The key
+            pair is looked up by the first certificate in the chain.
+            @param cert  The certificate chain.
+            @note Not supported on Linux or Android platforms.
+            @throws cbl::Error  If the identity cannot be found. */
+        static TLSIdentity identityWithCerts(const Cert& cert) {
+            CBLError error{};
+            CBLTLSIdentity* id = CBLTLSIdentity_IdentityWithCerts(cert.ref(), &error);
+            internal::check(id != nullptr, error);
+            return TLSIdentity(id, adopt);
+        }
+#endif //#if !defined(__linux__) && !defined(__ANDROID__)
+
+#ifdef __OBJC__
+        /** Returns a TLS identity from an existing identity in the keychain, given its SecIdentity object.
+            @param secIdentity  The identity, which must be stored in the keychain.
+            @param certs  Additional certificates (SecCertificateRef) to include in the identity's
+                   certificate chain, if any.
+            @throws cbl::Error  If the identity cannot be created. */
+        static TLSIdentity identityWithSecIdentity(SecIdentityRef secIdentity,
+                                                    NSArray* _cbl_nullable certs =nil) {
+            CBLError error{};
+            CBLTLSIdentity* id = CBLTLSIdentity_IdentityWithSecIdentity(secIdentity, certs, &error);
+            internal::check(id != nullptr, error);
+            return TLSIdentity(id, adopt);
+        }
+#endif //#ifdef __OBJC__
+
+    protected:
+        CBL_REFCOUNTED_BOILERPLATE(TLSIdentity, RefCounted, CBLTLSIdentity)
+
+    private:
+        struct adopt_t {};
+        inline static constexpr adopt_t adopt{};
+
+        TLSIdentity(CBLTLSIdentity* _cbl_nullable cObj, adopt_t) {_ref = (CBLRefCounted*)cObj;}
+    };
+
+}
+
+CBL_ASSUME_NONNULL_END
+
+#endif //#ifdef COUCHBASE_ENTERPRISE

--- a/include/cbl++/TLSIdentity.hh
+++ b/include/cbl++/TLSIdentity.hh
@@ -224,20 +224,19 @@ namespace cbl {
 
         // Shared by the publicKeyData/decrypt trampolines in createWithExternalKey: copies
         // result into output (bounded by outputMaxLen) and sets outputLen.
-static bool copyResult(const std::optional<alloc_slice>& result, void* output, size_t outputMaxLen,
-                       size_t* outputLen) {
-    if ( !outputLen ) return false;
-    if ( !result ) {
-        *outputLen = 0;
-        return false;
-    }
+        static bool copyResult(const std::optional<alloc_slice>& result, void* output, size_t outputMaxLen,
+                               size_t* outputLen) {
+            if ( !outputLen ) return false;
+            if ( !result ) {
+                *outputLen = 0;
+                return false;
+            }
 
-    *outputLen = result->size;
-    if ( result->size > outputMaxLen || (result->size > 0 && !output) ) return false;
+            *outputLen = result->size;
+            if ( result->size > outputMaxLen || (result->size > 0 && !output) ) return false;
 
-    if ( result->size > 0 ) memcpy(output, result->buf, result->size);
-    return true;
-}
+            if ( result->size > 0 ) memcpy(output, result->buf, result->size);
+            return true;
         }
 
         // Invokes fn, catching and logging any exception it throws. Required because the C API

--- a/scripts/coverage_macos.sh
+++ b/scripts/coverage_macos.sh
@@ -84,7 +84,7 @@ core_count=`getconf _NPROCESSORS_ONLN`
 make -j `expr $core_count + 1`
 
 pushd test > /dev/null
-./CBL_C_Tests -r list
+./CBL_C_Tests -r quiet
 popd > /dev/null
 
 mkdir -p report

--- a/test/TLSIdentityTest+Apple.mm
+++ b/test/TLSIdentityTest+Apple.mm
@@ -21,7 +21,6 @@
 #include "TLSIdentityTest.hh"
 #include <optional>
 #include <unordered_map>
-#include <sstream
 
 #ifdef COUCHBASE_ENTERPRISE
 

--- a/test/TLSIdentityTest+Apple.mm
+++ b/test/TLSIdentityTest+Apple.mm
@@ -19,6 +19,7 @@
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
 #include "TLSIdentityTest.hh"
+#include <optional>
 #include <sstream>
 
 #ifdef COUCHBASE_ENTERPRISE
@@ -47,12 +48,50 @@ struct TLSIdentityTest::ExternalKey::Impl {
         CFRelease(_privateKeyRef);
     }
 
+    // Raw-buffer callbacks, used by the C API test (TLSIdentityTest.cc). Each is a thin
+    // wrapper that copies the result of the corresponding C++ API method (below) into the
+    // caller-supplied buffer.
+
     bool publicKeyData(void* output, size_t outputMaxLen, size_t* outputLen) {
+        auto result = publicKeyData();
+        if (!result) return false;
+        *outputLen = result->size;
+        if (*outputLen > outputMaxLen) {
+            CBL_Log(kCBLLogDomainListener, kCBLLogError, "Key size is too big to put in the output");
+            return false;
+        }
+        result->copyTo(output);
+        return true;
+    }
+
+    bool decrypt(fleece::slice input, void* output, size_t outputMaxLen, size_t* outputLen) {
+        auto result = decrypt(input);
+        if (!result) return false;
+        *outputLen = result->size;
+        if (*outputLen > outputMaxLen) {
+            // should never happen
+            CBL_Log(kCBLLogDomainListener, kCBLLogError, "outputLen is too small in callback decrypt");
+            return false;
+        }
+        memcpy(output, result->buf, *outputLen);
+        return true;
+    }
+
+    bool sign(int/*mbedtls_md_type_t*/ mbedDigestAlgorithm, fleece::slice inputData, void* outSignature) {
+        auto result = sign(CBLSignatureDigestAlgorithm(mbedDigestAlgorithm), inputData);
+        if (!result) return false;
+        memcpy(outSignature, result->buf, result->size);
+        return true;
+    }
+
+    // C++ API:
+
+    std::optional<fleece::alloc_slice> publicKeyData() {
         CFErrorRef error;
         CFDataRef data = SecKeyCopyExternalRepresentation(_publicKeyRef, &error);
         if (!data) {
             warnCFError(error, "SecKeyCopyExternalRepresentation");
-            return false;
+            return std::nullopt;
         }
         fleece::slice dataSlice{CFDataGetBytePtr(data), (size_t)CFDataGetLength(data)};
         // Converting it into the DER format LiteCore expects.
@@ -60,25 +99,18 @@ struct TLSIdentityTest::ExternalKey::Impl {
         if (!publicKey) {
             CBL_Log(kCBLLogDomainListener, kCBLLogError, "Error from PublickKeyFromData");
             CFRelease(data);
-            return false;
+            return std::nullopt;
         }
 
         fleece::alloc_slice result = CBLKeyPair_PublicKeyData(publicKey);
-        *outputLen = result.size;
-
-        if (*outputLen <= outputMaxLen) {
-            result.copyTo(output);
-        } else {
-            CBL_Log(kCBLLogDomainListener, kCBLLogError, "Key size is too big to put in the output");
-        }
 
         CFRelease(data);
         CBLKeyPair_Release(publicKey);
 
-        return *outputLen <= outputMaxLen;
+        return result;
     }
 
-    bool decrypt(fleece::slice input, void* output, size_t outputMaxLen, size_t* outputLen) {
+    std::optional<fleece::alloc_slice> decrypt(fleece::slice input) {
         // No exceptions may be thrown from this function!
         @autoreleasepool {
             CBL_Log(kCBLLogDomainListener, kCBLLogInfo, "Decrypting using Keychain private key");
@@ -89,20 +121,13 @@ struct TLSIdentityTest::ExternalKey::Impl {
                                                          (CFDataRef)data, &error) );
             if (!cleartext) {
                 warnCFError(error, "SecKeyCreateDecryptedData");
-                return false;
+                return std::nullopt;
             }
-            *outputLen = cleartext.length;
-            if (*outputLen > outputMaxLen) {
-                // should never happen
-                CBL_Log(kCBLLogDomainListener, kCBLLogError, "outputLen is too small in callback decrypt");
-                return false;
-            }
-            memcpy(output, cleartext.bytes, *outputLen);
-            return true;
+            return std::make_optional<fleece::alloc_slice>(cleartext.bytes, cleartext.length);
         }
     }
 
-    bool sign(int/*mbedtls_md_type_t*/ mbedDigestAlgorithm, fleece::slice inputData, void* outSignature) {
+    std::optional<fleece::alloc_slice> sign(CBLSignatureDigestAlgorithm mbedDigestAlgorithm, fleece::slice inputData) {
         // No exceptions may be thrown from this function!
         CBL_Log(kCBLLogDomainListener, kCBLLogInfo, "Signing using Keychain private key");
         @autoreleasepool {
@@ -115,7 +140,7 @@ struct TLSIdentityTest::ExternalKey::Impl {
                 {10 /*MBEDTLS_MD_SHA384*/, kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384},
                 {11 /*MBEDTLS_MD_SHA512*/, kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512}
             };
-            
+
             SecKeyAlgorithm digestAlgorithm = nullptr;
             if (kDigestAlgorithmMap.contains(mbedDigestAlgorithm)) {
                 digestAlgorithm = kDigestAlgorithmMap.at(mbedDigestAlgorithm);
@@ -123,7 +148,7 @@ struct TLSIdentityTest::ExternalKey::Impl {
 
             if (!digestAlgorithm) {
                 CBL_Log(kCBLLogDomainListener, kCBLLogWarning, "Keychain private key: unsupported mbedTLS digest algorithm %d", mbedDigestAlgorithm);
-                return false;
+                return std::nullopt;
             }
 
             // Create the signature:
@@ -134,11 +159,19 @@ struct TLSIdentityTest::ExternalKey::Impl {
                                                                       (CFDataRef)data, &error));
             if (!sigData) {
                 warnCFError(error, "SecKeyCreateSignature");
-                return false;
+                return std::nullopt;
             }
             assert(sigData.length == _keyLength);
-            memcpy(outSignature, sigData.bytes, _keyLength);
-            return true;
+            if (sigData.length != _keyLength) {
+                // Should be unreachable (see the assert above); this is the release-build
+                // (NDEBUG) safety net, since reading _keyLength bytes from a shorter sigData
+                // would otherwise over-read.
+                CBL_Log(kCBLLogDomainListener, kCBLLogError,
+                        "SecKeyCreateSignature returned %lu bytes, expected %u",
+                        (unsigned long)sigData.length, _keyLength);
+                return std::nullopt;
+            }
+            return std::make_optional<fleece::alloc_slice>(sigData.bytes, _keyLength);
         }
     }
 
@@ -188,6 +221,19 @@ bool TLSIdentityTest::ExternalKey::decrypt(fleece::slice input, void *output, si
 
 bool TLSIdentityTest::ExternalKey::sign(CBLSignatureDigestAlgorithm mbedDigestAlgorithm, fleece::slice inputData, void *outSignature) {
     return _impl->sign(mbedDigestAlgorithm, inputData, outSignature);
+}
+
+// For C++ API
+std::optional<fleece::alloc_slice> TLSIdentityTest::ExternalKey::publicKeyData() {
+    return _impl->publicKeyData();
+}
+
+std::optional<fleece::alloc_slice> TLSIdentityTest::ExternalKey::decrypt(fleece::slice input) {
+    return _impl->decrypt(input);
+}
+
+std::optional<fleece::alloc_slice> TLSIdentityTest::ExternalKey::sign(CBLSignatureDigestAlgorithm mbedDigestAlgorithm, fleece::slice inputData) {
+    return _impl->sign(mbedDigestAlgorithm, inputData);
 }
 
 #endif // #ifdef COUCHBASE_ENTERPRISE

--- a/test/TLSIdentityTest+Apple.mm
+++ b/test/TLSIdentityTest+Apple.mm
@@ -153,7 +153,7 @@ struct TLSIdentityTest::ExternalKey::Impl {
 
             // Create the signature:
             NSData* data = uncopiedNSData(inputData);
-            CFErrorRef error;
+            CFErrorRef error{nullptr};
             NSData* sigData = CFBridgingRelease(SecKeyCreateSignature(_privateKeyRef,
                                                                       digestAlgorithm,
                                                                       (CFDataRef)data, &error));

--- a/test/TLSIdentityTest+Apple.mm
+++ b/test/TLSIdentityTest+Apple.mm
@@ -20,7 +20,8 @@
 #import <Security/Security.h>
 #include "TLSIdentityTest.hh"
 #include <optional>
-#include <sstream>
+#include <unordered_map>
+#include <sstream
 
 #ifdef COUCHBASE_ENTERPRISE
 

--- a/test/TLSIdentityTest+Apple.mm
+++ b/test/TLSIdentityTest+Apple.mm
@@ -97,7 +97,7 @@ struct TLSIdentityTest::ExternalKey::Impl {
         // Converting it into the DER format LiteCore expects.
         CBLKeyPair* publicKey = CBLKeyPair_PublicKeyFromData(dataSlice, nullptr);
         if (!publicKey) {
-            CBL_Log(kCBLLogDomainListener, kCBLLogError, "Error from PublickKeyFromData");
+            CBL_Log(kCBLLogDomainListener, kCBLLogError, "Error from PublicKeyFromData");
             CFRelease(data);
             return std::nullopt;
         }

--- a/test/TLSIdentityTest+Apple.mm
+++ b/test/TLSIdentityTest+Apple.mm
@@ -115,7 +115,7 @@ struct TLSIdentityTest::ExternalKey::Impl {
         @autoreleasepool {
             CBL_Log(kCBLLogDomainListener, kCBLLogInfo, "Decrypting using Keychain private key");
             NSData* data = uncopiedNSData(input);
-            CFErrorRef error;
+            CFErrorRef error{nullptr};
             NSData* cleartext = CFBridgingRelease( SecKeyCreateDecryptedData(_privateKeyRef,
                                                          kSecKeyAlgorithmRSAEncryptionPKCS1,
                                                          (CFDataRef)data, &error) );

--- a/test/TLSIdentityTest+Apple.mm
+++ b/test/TLSIdentityTest+Apple.mm
@@ -87,7 +87,7 @@ struct TLSIdentityTest::ExternalKey::Impl {
     // C++ API:
 
     std::optional<fleece::alloc_slice> publicKeyData() {
-        CFErrorRef error;
+        CFErrorRef error{nullptr};
         CFDataRef data = SecKeyCopyExternalRepresentation(_publicKeyRef, &error);
         if (!data) {
             warnCFError(error, "SecKeyCopyExternalRepresentation");
@@ -192,7 +192,7 @@ TLSIdentityTest::ExternalKey* TLSIdentityTest::ExternalKey::generateRSA(unsigned
         };
 
         SecKeyRef publicKey = NULL, privateKey = NULL;
-        CFErrorRef error;
+        CFErrorRef error{nullptr};
         privateKey = SecKeyCreateRandomKey((CFDictionaryRef)params, &error);
         if (!privateKey) {
             CBL_Log(kCBLLogDomainListener, kCBLLogWarning, "SecKeyCreateRandomKey");

--- a/test/TLSIdentityTest.cc
+++ b/test/TLSIdentityTest.cc
@@ -72,7 +72,7 @@ namespace {
 
 }; // anonymous namespace for external key
 
-TEST_CASE_METHOD(TLSIdentityTest, "Self-Signed Cert Identity", "[TSLIdentity]") {
+TEST_CASE_METHOD(TLSIdentityTest, "Self-Signed Cert Identity", "[TLSIdentity]") {
     CBLError outError{};
 
     CBLKeyPair* keypair = CBLKeyPair_GenerateRSAKeyPair(fleece::nullslice, &outError);
@@ -119,7 +119,7 @@ TEST_CASE_METHOD(TLSIdentityTest, "Self-Signed Cert Identity", "[TSLIdentity]") 
     CBLKeyPair_Release(pkOfCert);
 }
 
-TEST_CASE_METHOD(TLSIdentityTest, "External Keys", "[TSLIdentity]") {
+TEST_CASE_METHOD(TLSIdentityTest, "External Keys", "[TLSIdentity]") {
     CBLError outError{};
 
     TLSIdentityTest::ExternalKey* externalKey = TLSIdentityTest::ExternalKey::generateRSA(2048);
@@ -164,7 +164,7 @@ TEST_CASE_METHOD(TLSIdentityTest, "External Keys", "[TSLIdentity]") {
 #if !defined(__linux__) && !defined(__ANDROID__)
 
 // T0011-1 TestCreateGetDeleteIdentityWithLabel
-TEST_CASE_METHOD(TLSIdentityTest, "Identity With Label", "[TSLIdentity]") {
+TEST_CASE_METHOD(TLSIdentityTest, "Identity With Label", "[TLSIdentity]") {
     CBLError outError{};
 
     // Clean the identity from the system.
@@ -227,7 +227,7 @@ TEST_CASE_METHOD(TLSIdentityTest, "Identity With Label", "[TSLIdentity]") {
 }
 
 // T0011-2 TestUseIdentityCreatedWithLabel
-TEST_CASE_METHOD(URLEndpointListenerTest, "Use Identity Created with Label", "[TSLIdentity]") {
+TEST_CASE_METHOD(URLEndpointListenerTest, "Use Identity Created with Label", "[TLSIdentity]") {
     CBLError outError{};
 
     CBLTLSIdentity* identity = nullptr;
@@ -318,7 +318,7 @@ TEST_CASE_METHOD(URLEndpointListenerTest, "Use Identity Created with Label", "[T
 }
 
 // T0011-3 TestCreateAndUseSelfSignedIdentityWithPrivateKeyData
-TEST_CASE_METHOD(URLEndpointListenerTest, "Self-Signed Identity with Private KeyData", "[TSLIdentity]") {
+TEST_CASE_METHOD(URLEndpointListenerTest, "Self-Signed Identity with Private KeyData", "[TLSIdentity]") {
     CBLError outError{};
 
     // Gets a pre-created RSA private key data in PEM format with a password from file.
@@ -401,7 +401,7 @@ TEST_CASE_METHOD(URLEndpointListenerTest, "Self-Signed Identity with Private Key
 #endif // #if !defined(__linux__) && !defined(__ANDROID__)
 
 // T0011-4 TestCreateAndUseSelfSignedIdentityWithPrivateKeyCallback
-TEST_CASE_METHOD(URLEndpointListenerTest, "Self-Signed Identity with PrivateKey Callback", "[TSLIdentity]") {
+TEST_CASE_METHOD(URLEndpointListenerTest, "Self-Signed Identity with PrivateKey Callback", "[TLSIdentity]") {
     CBLError outError{};
 
     // Creates a KeyPair callback using keychain implementation
@@ -492,7 +492,7 @@ TEST_CASE_METHOD(URLEndpointListenerTest, "Self-Signed Identity with PrivateKey 
 #endif //#ifdef  __APPLE__
 
 // T0011-5 TestCreateAndUseIdentityFromKeyPairAndCerts
-TEST_CASE_METHOD(URLEndpointListenerTest, "Identity from KeyPair and Certs", "[TSLIdentity]") {
+TEST_CASE_METHOD(URLEndpointListenerTest, "Identity from KeyPair and Certs", "[TLSIdentity]") {
     CBLError outError{};
 
     // Create a KeyPair object from a private key loaded from a PEM file.
@@ -586,7 +586,7 @@ namespace {
 } // anonymous namespace
 
 // T0011-6 TestGetCertChain
-TEST_CASE_METHOD(TLSIdentityTest, "Get CertChain", "[TSLIdentity]") {
+TEST_CASE_METHOD(TLSIdentityTest, "Get CertChain", "[TLSIdentity]") {
     CBLError outError{};
 
     // Create a Cert object with the PEM file containing a cert chain.

--- a/test/TLSIdentityTest.hh
+++ b/test/TLSIdentityTest.hh
@@ -19,6 +19,7 @@
 
 #include "CBLTest.hh"
 #include <chrono>
+#include <optional>
 
 #ifdef COUCHBASE_ENTERPRISE
 
@@ -43,6 +44,11 @@ public:
         bool publicKeyData(void* output, size_t outputMaxLen, size_t* outputLen);
         bool decrypt(fleece::slice input, void *output, size_t output_max_len, size_t *output_len);
         bool sign(CBLSignatureDigestAlgorithm mbedDigestAlgorithm, fleece::slice inputData, void *outSignature);
+
+        // For C++ APIs
+        std::optional<fleece::alloc_slice> publicKeyData();
+        std::optional<fleece::alloc_slice> decrypt(fleece::slice input);
+        std::optional<fleece::alloc_slice> sign(CBLSignatureDigestAlgorithm mbedDigestAlgorithm, fleece::slice inputData);
 
     private:
         struct Impl;

--- a/test/TLSIdentityTest_Cpp.cc
+++ b/test/TLSIdentityTest_Cpp.cc
@@ -1,0 +1,318 @@
+//
+// TLSIdentityTest_Cpp.cc
+//
+// Copyright © 2026 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "CBLTest_Cpp.hh"
+#include "TLSIdentityTest.hh"
+#include "URLEndpointListenerTest.hh"     // for the shared readFile() asset helper, and the
+                                          // listener/replicator fixture used below
+#include "fleece/Mutable.hh"
+#include <chrono>
+#include <cmath>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "cbl++/CouchbaseLite.hh"
+#include "cbl++/TLSIdentity.hh"
+
+#ifdef COUCHBASE_ENTERPRISE
+
+using namespace std::chrono;
+using namespace fleece;
+using namespace cbl;
+
+class TLSIdentityTest_Cpp : public CBLTest_Cpp {
+};
+
+TEST_CASE_METHOD(TLSIdentityTest_Cpp, "C++ Self-Signed Cert Identity", "[TLSIdentity]") {
+    // Load a known RSA private key (instead of the private, test-only
+    // CBLKeyPair_GenerateRSAKeyPair API, which has no C++ wrapper) via the public
+    // KeyPair::createWithPrivateKeyData factory.
+    string pem = URLEndpointListenerTest::readFile("private_key_of_self_signed_cert.pem");
+    KeyPair keypair = KeyPair::createWithPrivateKeyData(slice{pem.c_str(), pem.size() + 1});
+
+    MutableDict attributes = MutableDict::newDict();
+    attributes[kCBLCertAttrKeyCommonName] = TLSIdentityTest::CN;
+
+    auto expire = system_clock::now() + TLSIdentityTest::OneYear;
+
+    TLSIdentity identity = TLSIdentity::createIdentity(
+        kCBLKeyUsagesServerAuth, keypair, attributes,
+        duration_cast<milliseconds>(TLSIdentityTest::OneYear).count());
+    CHECK(identity);
+
+    Cert cert = identity.certificates();
+    CHECK(cert);
+    CHECK(!cert.nextInChain());
+
+    // CBLTimestamp is in milliseconds; can differ by up to 60 seconds.
+    CBLTimestamp certExpire  = identity.expiration();
+    CBLTimestamp paramExpire = duration_cast<milliseconds>(expire.time_since_epoch()).count();
+    CHECK(std::abs(certExpire - paramExpire) / 1000 < seconds(61).count());
+
+    CHECK(cert.subjectNameComponent(kCBLCertAttrKeyCommonName) == TLSIdentityTest::CN.asString());
+    CHECK(cert.subjectName() == "CN=" + TLSIdentityTest::CN.asString());
+
+    // The cert's public key should match the input KeyPair's.
+    string pubDigest1 = keypair.publicKeyDigest();
+    KeyPair pkOfCert = cert.publicKey();
+    CHECK(pkOfCert);
+    string pubDigest2 = pkOfCert.publicKeyDigest();
+    CHECK( (!pubDigest1.empty() && pubDigest1 == pubDigest2) );
+}
+
+#ifdef __APPLE__
+
+TEST_CASE_METHOD(TLSIdentityTest_Cpp, "C++ External Keys", "[TLSIdentity]") {
+    constexpr size_t keySizeInBits  = 2048;
+
+    TLSIdentityTest::ExternalKey* externalKey = TLSIdentityTest::ExternalKey::generateRSA(keySizeInBits);
+    REQUIRE(externalKey);
+
+    bool badPublicKeyData = false;
+    bool throwingPublicKeyData = false;
+    SECTION("Successful Callback") {
+        badPublicKeyData = false;
+    }
+    SECTION("Failing Callback") {
+        badPublicKeyData = true;
+    }
+    SECTION("Throwing Callback") {
+        // Regression test for the createWithExternalKey trampolines catching exceptions:
+        // without that, this throw would cross a noexcept boundary in litecore and
+        // std::terminate() the whole test process instead of just failing this operation.
+        throwingPublicKeyData = true;
+    }
+
+    KeyPair::ExternalKeyHolder holder(
+        externalKey,
+        [badPublicKeyData, throwingPublicKeyData](void* ctx) -> std::optional<alloc_slice> {
+            if (throwingPublicKeyData) throw std::runtime_error("publicKeyData boom");
+            if (badPublicKeyData) return std::nullopt;
+            return static_cast<TLSIdentityTest::ExternalKey*>(ctx)->publicKeyData();
+        },
+        [](void* ctx, slice input) -> std::optional<alloc_slice> {
+            return static_cast<TLSIdentityTest::ExternalKey*>(ctx)->decrypt(input);
+        },
+        [](void* ctx, KeyPair::SignatureDigestAlgorithm digestAlgorithm, slice input) -> std::optional<alloc_slice> {
+            return static_cast<TLSIdentityTest::ExternalKey*>(ctx)->sign(digestAlgorithm, input);
+        },
+        [](void* ctx) { delete (TLSIdentityTest::ExternalKey*)ctx; }
+    );
+
+    KeyPair keypair = KeyPair::createWithExternalKey(keySizeInBits, std::move(holder));
+
+    string publicKeyData   = keypair.publicKeyData();
+    string publicKeyDigest = keypair.publicKeyDigest();
+    string privateKeyData  = keypair.privateKeyData();
+
+    if (badPublicKeyData || throwingPublicKeyData) {
+        CHECK(publicKeyData.empty());
+        CHECK(publicKeyDigest.empty());
+    } else {
+        CHECK(!publicKeyData.empty());
+        CHECK(!publicKeyDigest.empty());
+    }
+    // Private key data is not available for external keys.
+    CHECK(privateKeyData.empty());
+}
+
+// Ported from TLSIdentityTest.cc's "Self-Signed Identity with PrivateKey Callback": builds the
+// identity via the C++ API, then bridges into the still-C CBLURLEndpointListener/replicator via
+// KeyPair::ref()/TLSIdentity::ref() -- there's no C++ URLEndpointListener wrapper yet. This is
+// the one deferred test worth porting now (see the comment further down), since it's the only
+// one that actually drives ExternalKeyHolder's decrypt/sign callbacks through a real TLS
+// handshake; the others mostly re-exercise listener/replicator plumbing that's unrelated to
+// this header.
+TEST_CASE_METHOD(URLEndpointListenerTest, "C++ Self-Signed Identity with PrivateKey Callback", "[TLSIdentity]") {
+    constexpr size_t keySizeInBits = 2048;
+
+    // Creates a KeyPair wrapping an Apple Keychain-backed external key (callbacks defined in
+    // TLSIdentityTest+Apple.mm), counting how many times publicKeyData/sign/free are invoked.
+    TLSIdentityTest::ExternalKey* externalKey = TLSIdentityTest::ExternalKey::generateRSA(keySizeInBits);
+    REQUIRE(externalKey);
+
+    int counterPublicKeyData = 0;
+    int counterSign          = 0;
+    int counterFree          = 0;
+
+    KeyPair::ExternalKeyHolder holder(
+        externalKey,
+        [&counterPublicKeyData](void* ctx) -> std::optional<alloc_slice> {
+            counterPublicKeyData++;
+            return static_cast<TLSIdentityTest::ExternalKey*>(ctx)->publicKeyData();
+        },
+        [](void* ctx, slice input) -> std::optional<alloc_slice> {
+            return static_cast<TLSIdentityTest::ExternalKey*>(ctx)->decrypt(input);
+        },
+        [&counterSign](void* ctx, KeyPair::SignatureDigestAlgorithm digestAlgorithm, slice input) -> std::optional<alloc_slice> {
+            counterSign++;
+            return static_cast<TLSIdentityTest::ExternalKey*>(ctx)->sign(digestAlgorithm, input);
+        },
+        [&counterFree](void* ctx) {
+            counterFree++;
+            delete (TLSIdentityTest::ExternalKey*)ctx;
+        });
+
+    KeyPair keypair = KeyPair::createWithExternalKey(keySizeInBits, std::move(holder));
+
+    MutableDict attributes = MutableDict::newDict();
+    attributes[kCBLCertAttrKeyCommonName] = TLSIdentityTest::CN;
+    TLSIdentity identity = TLSIdentity::createIdentity(
+        kCBLKeyUsagesServerAuth, keypair, attributes,
+        duration_cast<milliseconds>(TLSIdentityTest::OneYear).count());
+    CHECK(identity);
+
+    // Initializes a listener with a config using the identity, bridged via TLSIdentity::ref()
+    // since CBLURLEndpointListenerConfiguration is still a plain C API.
+    createNumberedDocsWithPrefix(cy[0], 20, "doc2");
+    createNumberedDocsWithPrefix(cy[1], 20, "doc2");
+    CBLURLEndpointListenerConfiguration listenerConfig {
+        cy.data(),
+        2,
+        0,         // port
+        {},        // networkInterface
+        false      // disableTLS
+    };
+    listenerConfig.tlsIdentity = identity.ref();
+    listenerConfig.authenticator = CBLListenerAuth_CreatePassword([](void* ctx, FLString usr, FLString psw) {
+        return usr == TLSIdentityTest::kUser && psw == TLSIdentityTest::kPassword;
+    }, nullptr);
+    REQUIRE(listenerConfig.authenticator);
+
+    CBLError outError{};
+    CBLURLEndpointListener* listener = CBLURLEndpointListener_Create(&listenerConfig, &outError);
+    CHECK(outError.code == 0);
+    CHECK(listener);
+
+    // Starts the listener.
+    outError.code = 0;
+    bool started = CBLURLEndpointListener_Start(listener, &outError);
+    CHECK(outError.code == 0);
+    CHECK(started);
+
+    // Starts a single shot replicator connecting to the listener.
+    std::vector<CBLCollectionConfiguration> colConfigs;
+    configOneShotReplicator(listener, colConfigs);
+    config.authenticator = CBLAuth_CreatePassword(TLSIdentityTest::kUser, TLSIdentityTest::kPassword);
+    REQUIRE(config.authenticator);
+
+    replicate();
+
+    // Stops the listener.
+    CBLURLEndpointListener_Stop(listener);
+
+    CBLURLEndpointListener_Release(listener);
+    CBLListenerAuth_Free(listenerConfig.authenticator);
+
+    // Release the identity and keypair now (rather than waiting for them to go out of scope)
+    // so the counters below reflect the callbacks having actually fired.
+    identity = nullptr;
+    keypair  = nullptr;
+    CHECK(counterFree == 1);
+    CHECK(counterSign > 0);
+    CHECK(counterPublicKeyData > 0);
+}
+
+#endif //#ifdef __APPLE__
+
+#if !defined(__linux__) && !defined(__ANDROID__)
+
+TEST_CASE_METHOD(TLSIdentityTest_Cpp, "C++ Identity With Label", "[TLSIdentity]") {
+    // Clean up any identity left behind by a previous run.
+    (void) TLSIdentity::deleteIdentityWithLabel(TLSIdentityTest::Label);
+
+    MutableDict attributes = MutableDict::newDict();
+    attributes[kCBLCertAttrKeyCommonName] = TLSIdentityTest::CN;
+    TLSIdentity identity = TLSIdentity::createIdentity(
+        kCBLKeyUsagesServerAuth, attributes,
+        duration_cast<milliseconds>(TLSIdentityTest::OneYear).count(),
+        TLSIdentityTest::Label);
+    CHECK(identity);
+
+    TLSIdentity identity2 = TLSIdentity::identityWithLabel(TLSIdentityTest::Label);
+    CHECK(identity2);
+
+    Cert cert = identity2.certificates();
+    CHECK(cert);
+    string subjectName = cert.subjectName();
+    REQUIRE(subjectName.rfind("CN=", 0) == 0);
+    CHECK(subjectName.substr(3) == TLSIdentityTest::CN.asString());
+
+    CHECK(TLSIdentity::deleteIdentityWithLabel(TLSIdentityTest::Label));
+
+    TLSIdentity identity3 = TLSIdentity::identityWithLabel(TLSIdentityTest::Label);
+    CHECK(!identity3);
+}
+
+#endif //#if !defined(__linux__) && !defined(__ANDROID__)
+
+TEST_CASE_METHOD(TLSIdentityTest_Cpp, "C++ Get CertChain", "[TLSIdentity]") {
+    string pemChain = URLEndpointListenerTest::readFile("cert_chain.pem");
+    Cert cert = Cert::createWithData(slice{pemChain});
+    CHECK(cert);
+
+    // From the Cert object, iterate through the cert chain, verifying the CN and
+    // that each certificate is currently valid. `iter` is reassigned each pass, so
+    // the wrapper's RAII releases the previous certificate automatically.
+    constexpr const char* CNs[] = {
+        "Intermediate3 CA", "Intermediate2 CA", "Intermediate1 CA", "My Root CA"
+    };
+    constexpr int CNCount = sizeof(CNs) / sizeof(CNs[0]);
+
+    CBLTimestamp now = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+    int i = 0;
+    Cert iter = cert;
+    for ( ; iter && i < CNCount; iter = iter.nextInChain(), i++) {
+        CHECK(iter.subjectNameComponent("CN") == CNs[i]);
+        CBLTimestamp created, expires;
+        iter.validTimespan(&created, &expires);
+        CHECK((created < now && now < expires));
+    }
+    CHECK(i == CNCount);
+    CHECK(!iter);
+}
+
+// The following tests from TLSIdentityTest.cc exercise a TLSIdentity together with a
+// CBLURLEndpointListener / replicator. They mostly re-exercise listener/replicator plumbing
+// rather than anything specific to this header, so they're left for whenever
+// include/cbl++/URLEndpointListener.hh gets a C++ wrapper (unlike "Self-Signed Identity with
+// PrivateKey Callback" above, which was worth porting now via KeyPair::ref()/TLSIdentity::ref()
+// since it's the only one that drives ExternalKeyHolder's decrypt/sign callbacks through a real
+// TLS handshake). Revisit once that wrapper exists:
+//   - "Use Identity Created with Label"
+//   - "Self-Signed Identity with Private KeyData"
+//   - "Identity from KeyPair and Certs"
+#if 0
+
+TEST_CASE_METHOD(URLEndpointListenerTest, "C++ Use Identity Created with Label", "[TLSIdentity]") {
+    // TODO: port using cbl::TLSIdentity + cbl::URLEndpointListener once the latter exists.
+}
+
+TEST_CASE_METHOD(URLEndpointListenerTest, "C++ Self-Signed Identity with Private KeyData", "[TLSIdentity]") {
+    // TODO: port using cbl::TLSIdentity + cbl::URLEndpointListener once the latter exists.
+}
+
+TEST_CASE_METHOD(URLEndpointListenerTest, "C++ Identity from KeyPair and Certs", "[TLSIdentity]") {
+    // TODO: port using cbl::TLSIdentity + cbl::URLEndpointListener once the latter exists.
+}
+
+#endif // #if 0
+
+#endif // #ifdef COUCHBASE_ENTERPRISE

--- a/test/cmake/test_source_files.cmake
+++ b/test/cmake/test_source_files.cmake
@@ -37,6 +37,7 @@ function(set_test_source_files)
         ${T_DIR}/ReplicatorPropEncTest_Cpp.cc
         ${T_DIR}/ReplicatorTest.cc
         ${T_DIR}/TLSIdentityTest.cc
+        ${T_DIR}/TLSIdentityTest_Cpp.cc
         ${T_DIR}/URLEndpointListenerTest.cc
         ${T_DIR}/VectorSearchTest.cc
         ${T_DIR}/VectorSearchTest_Cpp.cc


### PR DESCRIPTION
CBL-8264: Unit tests of class TLSIdentity in the C++ API suite, plus Cert and KeyPair

Add TLSIdentity, Cert, and KeyPair to the C++ API (include/cbl++/TLSIdentity.hh), wrapping include/cbl/CBLTLSIdentity.h.

- KeyPair::createWithExternalKey takes a move-only ExternalKeyHolder with std::function-based callbacks (returning std::optional<alloc_slice>) instead of the C API's raw output-buffer shape, with an optional customFree for the caller's opaque key handle.
- Exceptions thrown from those callbacks are caught and logged rather than crossing a noexcept boundary in litecore and crashing the process.
- Full Doxygen coverage, and refactored TLSIdentityTest+Apple.mm to remove duplication between the C and C++ callback shapes.
- Tests cover self-signed identities, label persistence, external keys (including a throwing-callback regression test), and cert chains; also ported the external-key test that drives sign/decrypt through a real TLS handshake via CBLURLEndpointListener.