### PR TITLE
CBL-8720: Don't call the custom conflict resolver when both revisions are deleted

### DIFF
--- a/src/ConflictResolver.cc
+++ b/src/ConflictResolver.cc
@@ -181,6 +181,12 @@ namespace cbl_internal {
         if (localDoc && localDoc->revisionFlags() & kRevDeleted)
             localDoc = nullptr;
 
+        // A conflict between two deletions has nothing to resolve, and there is no document to
+        // hand the resolver. Take the remote (deleted) revision without calling the resolver,
+        // which is what defaultResolve() already ends up doing for this case:
+        if (!localDoc && !remoteDoc)
+            return conflict->resolveConflict(CBLDocument::Resolution::useRemote, nullptr);
+
         // Call the custom resolver (this could take a long time to return)
         SyncLog(Verbose, "Calling custom conflict resolver for doc '%.*s' ...",
                 FMTSLICE(_docID));

--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -599,6 +599,44 @@ TEST_CASE_METHOD(ReplicatorConflictTest, "Custom resolver : merge", "[Replicator
 }
 
 
+TEST_CASE_METHOD(ReplicatorConflictTest, "Custom resolver : both deleted", "[Replicator][Conflict]") {
+    // Deleting the doc on both sides leaves nothing for the resolver to work with, so the
+    // conflict is resolved as the remote deletion and the resolver is never called:
+    docID = "doc1";
+
+    MutableDocument doc(docID);
+    doc["greeting"] = "Howdy!";
+    defaultCollection.saveDocument(doc);
+    defaultCollection.deleteDocument(doc);
+
+    doc = MutableDocument(docID);
+    doc["greeting"] = "Howdy!";
+    otherDBDefaultCol.saveDocument(doc);
+    otherDBDefaultCol.deleteDocument(doc);
+
+    replicatedDocIDs.clear();
+    resolverCalled = false;
+
+    configureCollectionConfigs(config, [](CBLCollectionConfiguration& colConfig) {
+        colConfig.conflictResolver = [](void *context,
+                                        FLString documentID,
+                                        const CBLDocument *localDocument,
+                                        const CBLDocument *remoteDocument) -> const CBLDocument* {
+            ((ReplicatorConflictTest*)context)->resolverCalled = true;
+            return localDocument;
+        };
+    });
+
+    config.replicatorType = kCBLReplicatorTypePull;
+    resetReplicator();
+    replicate();
+
+    CHECK(asVector(replicatedDocIDs) == vector<string>{docID});
+    CHECK(!resolverCalled);
+    CHECK(!defaultCollection.getDocument(docID));
+}
+
+
 TEST_CASE_METHOD(ReplicatorLocalTest, "Document Replication Listener", "[Replicator]") {
     // No listener:
     MutableDocument doc("foo");


### PR DESCRIPTION
When both the local and the remote revision of a document are deletions, `customResolve()`
still called the client conflict resolver, with NULL for both documents. There is nothing to
resolve in that case, and the C++ wrapper crashed on it, since it finds the collection through
the documents it is given.

Resolve the conflict as the remote revision without calling the resolver, which is what
`defaultResolve()` already does, and add a "Custom resolver : both deleted" case to
`ReplicatorConflictTest` — the existing cases only ever delete one side at a time.