### PR TITLE
CBL-8784: Don't call the custom conflict resolver when both revisions…

### DIFF
--- a/src/ConflictResolver.cc
+++ b/src/ConflictResolver.cc
@@ -187,6 +187,12 @@ namespace cbl_internal {
         if (localDoc && localDoc->revisionFlags() & kRevDeleted)
             localDoc = nullptr;
 
+        // A conflict between two deletions has nothing to resolve, and there is no document to
+        // hand the resolver. Take the remote (deleted) revision without calling the resolver,
+        // which is what defaultResolve() already ends up doing for this case:
+        if (!localDoc && !remoteDoc)
+            return conflict->resolveConflict(CBLDocument::Resolution::useRemote, nullptr);
+
         // Call the custom resolver (this could take a long time to return)
         SyncLog(Verbose, "Calling custom conflict resolver for doc '%.*s' ...",
                 FMTSLICE(_docID));

--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -726,6 +726,44 @@ TEST_CASE_METHOD(ReplicatorConflictTest, "Custom resolver : merge", "[Replicator
 }
 
 
+TEST_CASE_METHOD(ReplicatorConflictTest, "Custom resolver : both deleted", "[Replicator][Conflict]") {
+    // Deleting the doc on both sides leaves nothing for the resolver to work with, so the
+    // conflict is resolved as the remote deletion and the resolver is never called:
+    docID = "doc1";
+
+    MutableDocument doc(docID);
+    doc["greeting"] = "Howdy!";
+    defaultCollection.saveDocument(doc);
+    defaultCollection.deleteDocument(doc);
+
+    doc = MutableDocument(docID);
+    doc["greeting"] = "Howdy!";
+    otherDBDefaultCol.saveDocument(doc);
+    otherDBDefaultCol.deleteDocument(doc);
+
+    replicatedDocIDs.clear();
+    resolverCalled = false;
+
+    configureCollectionConfigs(config, [](CBLReplicationCollection& colConfig) {
+        colConfig.conflictResolver = [](void *context,
+                                        FLString documentID,
+                                        const CBLDocument *localDocument,
+                                        const CBLDocument *remoteDocument) -> const CBLDocument* {
+            ((ReplicatorConflictTest*)context)->resolverCalled = true;
+            return localDocument;
+        };
+    });
+
+    config.replicatorType = kCBLReplicatorTypePull;
+    resetReplicator();
+    replicate();
+
+    CHECK(asVector(replicatedDocIDs) == vector<string>{docID});
+    CHECK(!resolverCalled);
+    CHECK(!defaultCollection.getDocument(docID));
+}
+
+
 TEST_CASE_METHOD(ReplicatorLocalTest, "Document Replication Listener", "[Replicator]") {
     // No listener:
     MutableDocument doc("foo");

--- a/test/ReplicatorEETest.cc
+++ b/test/ReplicatorEETest.cc
@@ -739,6 +739,12 @@ TEST_CASE_METHOD(ReplicatorConflictTest, "Custom resolver : both deleted", "[Rep
     doc = MutableDocument(docID);
     doc["greeting"] = "Howdy!";
     otherDBDefaultCol.saveDocument(doc);
+    // create a new live version before delete
+    // Without this new version, the two deleted version would be considered
+    // the same and the ensuing Pull replication won't won't receive the remote one
+    // and create conflict on the local DB.
+    doc["greeting"] = "";
+    otherDBDefaultCol.saveDocument(doc);
     otherDBDefaultCol.deleteDocument(doc);
 
     replicatedDocIDs.clear();


### PR DESCRIPTION
… are deleted

When both the local and the remote revision are deletions, resolve the conflict as the remote revision without invoking the client resolver, matching defaultResolve(). Adds a "Custom resolver : both deleted" case to ReplicatorConflictTest.