### PR TITLE
CBL-8788: Fix use-after-free during replicator conflict resolution

### DIFF
--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -249,7 +249,9 @@ bool CBLDocument::resolveConflict(Resolution resolution, const CBLDocument * _cb
     _fromJSON = nullptr;
 
     // Remote Revision always win so that the resolved revision will not conflict with the remote:
-    slice winner(c4doc->selectedRev().revID), loser(c4doc->revID());
+    // Note: Use alloc_slice to retain the revIDs, as the c4doc's revID storage they point into
+    // may be freed while the document is mutated inside c4doc->resolveConflict():
+    alloc_slice winner(c4doc->selectedRev().revID), loser(c4doc->revID());
 
     // Note: shared lock b/w database and collection
     return _collection->useLocked<bool>([&](C4Collection *c4col) {


### PR DESCRIPTION
`CBLDocument::resolveConflict()` passed raw slices of the C4Document's internal revID storage into `c4doc->resolveConflict()`, which frees that storage when purging the losing branch and then later reads the slices for logging. This issue is subtle because `resolveConflict()` doesn't know that the passed slice is from the internal storage that will be freed. The fix here is to retain the revIDs with `alloc_slice` so the backing memory stays alive across the call.

Note: 
* This issue has been found while debugging a problem found in a test written for CBL-8784. Instead of fixing this in the same PR for CBL-8784, a separate ticket was created for tracking and porting purpose.
* The issue only impacts CBL-C 3.x as the issue is only applicable when using RevTree database.
* The fix doesn't cause any functional changes but just to ensure a lifetime of the passed revID slices.